### PR TITLE
fixing StarRocks INSERT INTO statement

### DIFF
--- a/core/dbio/database/database_starrocks.go
+++ b/core/dbio/database/database_starrocks.go
@@ -115,7 +115,7 @@ func (conn *StarRocksConn) InsertBatchStream(tableFName string, ds *iop.Datastre
 		}
 
 		sql := g.R(
-			"INSERT {table} ({fields}) VALUES {values} "+noDebugKey,
+			"INSERT INTO {table} ({fields}) VALUES {values} "+noDebugKey,
 			"table", tableFName,
 			"fields", strings.Join(insFields, ", "),
 			"values", strings.Join(valuesSlice, ",\n"),

--- a/core/dbio/database/templates/starrocks.yaml
+++ b/core/dbio/database/templates/starrocks.yaml
@@ -8,7 +8,7 @@ core:
   alter_columns: alter table {table} modify {col_ddl}
   modify_column: '{column} {type}'
   upsert: |
-    INSERT {tgt_table}
+    INSERT INTO {tgt_table}
       ({insert_fields})
     SELECT {src_fields}
     FROM {src_table} src


### PR DESCRIPTION
I tested this on top of your v1.1.4 branch #152. Works.

```
atwong@Albert-CelerData sling-cli % vi core/dbio/database/database_starrocks.go
atwong@Albert-CelerData sling-cli % vi core/dbio/database/templates/starrocks.yaml
atwong@Albert-CelerData sling-cli % bash scripts/build.sh
atwong@Albert-CelerData sling-cli % !mv
mv sling /opt/homebrew/bin
atwong@Albert-CelerData sling-cli % sling run --src-conn POSTGRESLOCAL --src-stream public.staff --tgt-conn STARROCKSLOCAL --tgt-object albert.staff --primary-key staff_id -d
2024-02-09 08:37:26 DBG Sling version: dev (darwin arm64)
2024-02-09 08:37:26 DBG type is db-db
2024-02-09 08:37:26 DBG using source options: {"empty_as_null":true,"null_if":"NULL","datetime_format":"AUTO","max_decimals":-1}
2024-02-09 08:37:26 DBG using target options: {"datetime_format":"auto","max_decimals":-1,"use_bulk":true,"add_new_columns":true,"column_casing":"source"}
2024-02-09 08:37:26 INF connecting to source database (postgres)
2024-02-09 08:37:26 INF connecting to target database (starrocks)
2024-02-09 08:37:26 INF reading from source database
2024-02-09 08:37:26 DBG select * from "public"."staff"
2024-02-09 08:37:26 INF writing to target database [mode: full-refresh]
2024-02-09 08:37:26 DBG drop table if exists `albert`.`staff_tmp`
2024-02-09 08:37:26 DBG table `albert`.`staff_tmp` dropped
2024-02-09 08:37:26 DBG create table if not exists `albert`.`staff_tmp` (`staff_id` integer,
`first_name` string,
`last_name` string,
`address_id` smallint,
`email` string,
`store_id` smallint,
`active` char(5),
`username` string,
`password` string,
`last_update` datetime,
`picture` varbinary) primary key(`staff_id`) distributed by hash(`staff_id`)
2024-02-09 08:37:26 INF streaming data
2024-02-09 08:37:26 DBG WARN: Using INSERT mode which is meant for small datasets. Please set the `fe_url` for loading large datasets via Stream Load mode. See https://docs.slingdata.io/connections/database-connections/starrocks
2024-02-09 08:37:26 DBG select count(*) cnt from `albert`.`staff_tmp`
2024-02-09 08:37:26 DBG comparing checksums []string{"staff_id", "first_name", "last_name", "address_id", "email", "store_id", "active", "username", "password", "last_update", "picture"} vs []string{"staff_id", "first_name", "last_name", "address_id", "email", "store_id", "active", "username", "password", "last_update", "picture"}: []string{"staff_id", "first_name", "last_name", "address_id", "email", "store_id", "active", "username", "password", "last_update", "picture"}
fixing StarRocks INSERT INTO statement
2024-02-09 08:37:26 DBG select sum(abs(`staff_id`)) as `staff_id`, sum(length(`first_name`)) as `first_name`, sum(length(`last_name`)) as `last_name`, sum(abs(`address_id`)) as `address_id`, sum(length(`email`)) as `email`, sum(abs(`store_id`)) as `store_id`, sum(`active`) as `active`, sum(length(`username`)) as `username`, sum(length(`password`)) as `password`, sum(cast((UNIX_TIMESTAMP(`last_update`) * 1000000) as UNSIGNED)) as `last_update`, sum(length(`picture`)) as `picture` from `albert`.`staff_tmp`
2024-02-09 08:37:26 DBG Error 1064: Vectorized engine does not support the operator, cast from VARBINARY to VARCHAR failed, maybe use switch function backend [id=10004] [host=127.0.0.1]
2024-02-09 08:37:26 DBG drop table if exists `albert`.`staff`
2024-02-09 08:37:26 DBG table `albert`.`staff` dropped
2024-02-09 08:37:26 INF dropped table `albert`.`staff`
2024-02-09 08:37:26 DBG create table if not exists `albert`.`staff` (`staff_id` integer,
`first_name` string,
`last_name` string,
`address_id` smallint,
`email` string,
`store_id` smallint,
`active` char(5),
`username` string,
`password` string,
`last_update` datetime,
`picture` varbinary) primary key(`staff_id`) distributed by hash(`staff_id`)
2024-02-09 08:37:26 INF created table `albert`.`staff`
2024-02-09 08:37:26 DBG insert into `albert`.`staff` (`staff_id`, `first_name`, `last_name`, `address_id`, `email`, `store_id`, `active`, `username`, `password`, `last_update`, `picture`) select `staff_id`, `first_name`, `last_name`, `address_id`, `email`, `store_id`, `active`, `username`, `password`, `last_update`, `picture` from `albert`.`staff_tmp`
2024-02-09 08:37:27 DBG inserted rows into `albert`.`staff` from temp table `albert`.`staff_tmp`
2024-02-09 08:37:27 INF inserted 2 rows into `albert`.`staff` in 1 secs [2 r/s]
2024-02-09 08:37:27 DBG connection was closed, reconnecting
2024-02-09 08:37:27 DBG drop table if exists `albert`.`staff_tmp`
2024-02-09 08:37:27 DBG table `albert`.`staff_tmp` dropped
2024-02-09 08:37:27 INF execution succeeded
```