### PR TITLE
use DUCKDB_PATH to override path to duckdb binary

### DIFF
--- a/core/dbio/database/database_duckdb.go
+++ b/core/dbio/database/database_duckdb.go
@@ -132,6 +132,14 @@ func EnsureBinDuckDB(version string) (binPath string, err error) {
 		}
 	}
 
+	// use specified path to duckdb binary
+	if envPath := os.Getenv("DUCKDB_PATH"); envPath != "" {
+		if !g.PathExists(envPath) {
+			return "", g.Error("duckdb binary not found")
+		}
+		return envPath, nil
+	}
+
 	if useTempFile := os.Getenv("DUCKDB_USE_TMP_FILE"); useTempFile != "" {
 		DuckDbUseTempFile = cast.ToBool(useTempFile)
 	} else if g.In(version, "0.8.0", "0.8.1") {


### PR DESCRIPTION
This way, users are not forced to download a binary from GitHub into their home dir. With `DUCKDB_PATH`, it's now possible to use the binary from the preferred package manager, e.g.: Homebrew:

    export DUCKDB_PATH=/opt/homebrew/bin/duckdb
    sling run --src-stream file://./postgres.csv --tgt-conn DUCKDB --tgt-object clusters