### PR TITLE
Update types_general_to_native.tsv

### DIFF
--- a/core/dbio/templates/types_general_to_native.tsv
+++ b/core/dbio/templates/types_general_to_native.tsv
@@ -1,6 +1,6 @@
 general_type	oracle	postgres	mysql	mariadb	sqlserver	azuresql	azuredwh	redshift	snowflake	sqlite	bigquery	clickhouse	duckdb	motherduck	starrocks	trino
 bigint	number(19)	bigint	bigint	bigint	bigint	bigint	bigint	bigint	bigint	bigint	int64	Nullable(Int64)	bigint	bigint	bigint	bigint
-binary	varbinary()	bytes	varbinary	varbinary	varbinary	varbinary	varbinary	varchar(65535)	binary	blob	bytes	Nullable(String)	binary	binary	varbinary	varbinary
+binary	varbinary()	bytea	varbinary	varbinary	varbinary	varbinary	varbinary	varchar(65535)	binary	blob	bytes	Nullable(String)	binary	binary	varbinary	varbinary
 bool	varchar(5)	bool	char(5)	char(5)	varchar(5)	varchar(5)	varchar(5)	bool	boolean	boolean	bool	Nullable(String)	bool	bool	char(5)	boolean
 date	date	date	date	date	date	date	date	date	date	text	date	Nullable(Date)	date	date	date	date
 datetime	timestamp(9)	timestamp	datetime(6)	datetime(6)	datetime2	datetime2	datetime2	timestamp	timestamp	text	timestamp	Nullable(DateTime64(6))	datetime	datetime	datetime	timestamp


### PR DESCRIPTION
Fix Postgres binary type mapping.

Currently an attempt to replicate one PG database to another fails when binary fields exist:
```
2024-04-03 19:46:52 INF execution failed

fatal:
~ execution failed
--- task_run.go:99 func1 ---
~ Could not WriteToDb
--- task_run.go:522 runDbToDb ---
~ could not create temp table "public"."*_tmp"
--- task_run_write.go:218 WriteToDb ---
~ Error creating table "public"."*_tmp"
--- task_func.go:74 createTableIfNotExists ---
~ Could not execute SQL
--- database.go:1091 ExecMulti ---

--- task_run.go:99 func1 ---
--- task_run.go:522 runDbToDb ---
--- task_run_write.go:218 WriteToDb ---
--- task_func.go:74 createTableIfNotExists ---
--- database.go:1089 ExecMulti ---
~ Error executing query
--- database.go:1128 ExecMultiContext ---
~ Error executing [tx: false] create table if not exists "public"."*_tmp" ("id" bigint,
"issuer_ca_id" integer,
"certificate" bytes)
--- database.go:1115 ExecContext ---
pq: type "bytes" does not exist
```