### PR TITLE
create row for every sample

### DIFF
--- a/core/dbio/database/database_prometheus.go
+++ b/core/dbio/database/database_prometheus.go
@@ -305,30 +305,33 @@ func (conn *PrometheusConn) StreamRowsContext(ctx context.Context, query string,
 				fieldMap = data.Columns.FieldMap(true)
 			}
 
-			row := make([]any, len(data.Columns))
-			for k, v := range metricMap {
-				row[index(k)] = v
-			}
-
 			for _, value := range sample.Values {
-				row[index("timestamp")] = value.Timestamp.Time()
-				row[index("value")] = cast.ToFloat64(value.Value)
+				row := make([]any, len(data.Columns))
+				for k, v := range metricMap {
+					row[index(k)] = v
+				}
+				row[index("timestamp")] = value.Timestamp.Unix()
+				row[index("value")] = value.Value
+				data.Append(row)
 			}
 
 			for _, value := range sample.Histograms {
-				row[index("timestamp")] = value.Timestamp.Time()
-				row[index("count")] = cast.ToFloat64(value.Histogram.Count)
-				row[index("sum")] = cast.ToFloat64(value.Histogram.Sum)
-
 				for _, bucket := range value.Histogram.Buckets {
+					row := make([]any, len(data.Columns))
+					for k, v := range metricMap {
+						row[index(k)] = v
+					}
+					row[index("timestamp")] = value.Timestamp.Unix()
+					row[index("count")] = cast.ToFloat64(value.Histogram.Count)
+					row[index("sum")] = cast.ToFloat64(value.Histogram.Sum)
 					row[index("bucket_boundaries")] = cast.ToInt(bucket.Boundaries)
 					row[index("bucket_count")] = cast.ToFloat64(bucket.Count)
 					row[index("bucket_lower")] = cast.ToFloat64(bucket.Lower)
 					row[index("bucket_upper")] = cast.ToFloat64(bucket.Upper)
+					data.Append(row)
 				}
 			}
 
-			data.Append(row)
 			if Limit > 0 && len(data.Rows) >= Limit {
 				break
 			}
@@ -402,7 +405,7 @@ func (conn *PrometheusConn) StreamRowsContext(ctx context.Context, query string,
 			}
 
 			if sample.Histogram != nil {
-				row[index("timestamp")] = sample.Timestamp.Time()
+				row[index("timestamp")] = sample.Timestamp.Unix()
 				row[index("count")] = cast.ToFloat64(sample.Histogram.Count)
 				row[index("sum")] = cast.ToFloat64(sample.Histogram.Sum)
 
@@ -413,7 +416,7 @@ func (conn *PrometheusConn) StreamRowsContext(ctx context.Context, query string,
 					row[index("bucket_upper")] = cast.ToFloat64(bucket.Upper)
 				}
 			} else {
-				row[index("timestamp")] = sample.Timestamp.Time()
+				row[index("timestamp")] = sample.Timestamp.Unix()
 				row[index("value")] = cast.ToFloat64(sample.Value)
 			}
 


### PR DESCRIPTION
When setting a range and step what will result in multiple samples for that range, only one row is being created and its fields overwritten for every sample.

This pr moves the creation of the row within the loop that pulls the sample data as well as appending after each row is filled in.

Lastly uses of `sample.Timestamp.Time()` are replaced with `sample.Timestamp.Unix()` since that is more closer to the output from the api. Might be worth hooking into slings datetime formatting options, but im not yet familiar enough with sling-cli to know how to do that.