### PR TITLE
Fix BigQuery Location Mismatch during export

### DIFF
--- a/core/dbio/database/database_bigquery.go
+++ b/core/dbio/database/database_bigquery.go
@@ -931,9 +931,7 @@ func (conn *BigQueryConn) CopyToGCS(table Table, gcsURI string) error {
 
 	extractor := client.DatasetInProject(conn.ProjectID, table.Schema).Table(table.Name).ExtractorTo(gcsRef)
 	extractor.DisableHeader = false
-	// You can choose to run the task in a specific location for more complex data locality scenarios.
-	// Ex: In this example, source dataset and GCS bucket are in the US.
-	extractor.Location = "US"
+	extractor.Location = conn.Location
 
 	job, err := extractor.Run(conn.Context().Ctx)
 	if err != nil {


### PR DESCRIPTION
Remove hard coded location and instead respect the location passed from the connection object.

Without this change, BigQuery extract can sometimes fail with a 404:

```
~ Could not Copy to GS
--- database_bigquery.go:866 func1 ---
~ Error in extractor.Execute
--- database_bigquery.go:940 CopyToGCS ---
googleapi: Error 404: Not found: Dataset project:dataset_name, notFound
```

This is because the app may be looking in the wrong place for the dataset