### PR TITLE
Add sling conns row-count command

### DIFF
--- a/cmd/sling/sling_cli.go
+++ b/cmd/sling/sling_cli.go
@@ -272,6 +272,24 @@ var cliConns = &g.CliSC{
 			},
 		},
 		{
+			Name:        "row-count",
+			Description: "determines the row count of a connection's table",
+			PosFlags: []g.Flag{
+				{
+					Name:        "name",
+					ShortName:   "",
+					Type:        "string",
+					Description: "The name of the connection to query",
+				},
+				{
+					Name:        "table",
+					ShortName:   "",
+					Type:        "string",
+					Description: "The name of the table to query",
+				},
+			},
+		},
+		{
 			Name:        "exec",
 			Description: "execute a SQL query on a Database connection",
 			PosFlags: []g.Flag{

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -65,6 +65,7 @@ SLING_ROW_CNT=1 sling conns exec postgres "select data_type from information_sch
 
 sling conns test POSTGRES
 sling conns exec POSTGRES 'select count(1) from public.my_table'
+SLING_ROW_CNT=18 sling conns row-count 'public.my_table'
 sling conns discover POSTGRES
 sling conns discover POSTGRES -s 'public.*'
 sling conns discover local


### PR DESCRIPTION
## Summary

Adds a new `sling conns row-count [connection] [table]` command which can be used to quickly view the row count for a particular table in a connection.

```bash
./sling conns row-count SNOWFLAKE "public.metrics"
+--------+
|  COUNT |
+--------+
| 129504 |
+--------+
```

```bash
SLING_OUTPUT=json ./sling conns row-count SNOWFLAKE "public.metrics"
{"count":129504}
```

For the Dagster sling integration, we would find this functionality useful for attaching row count metadata after a sync completes successfully. Outside of this use-case, I would expect this command to be useful to sanity check total row counts after manually syncing via the CLI.

## Test Plan

Command respects `SLING_ROW_CNT` - added a new line to the test script.