### PR TITLE
Feature/support quote customized

### DIFF
--- a/cmd/sling/tests/files/test7.csv
+++ b/cmd/sling/tests/files/test7.csv
@@ -1,0 +1,4 @@
+col1|header|col3
+data1|'data with single quote \' inside'|data3
+'data with pipe | inside'|data2|data3
+'data with backslash \\ inside'|'data with \"escaped\" double quotes'|data3

--- a/cmd/sling/tests/files/test8.csv
+++ b/cmd/sling/tests/files/test8.csv
@@ -1,0 +1,4 @@
+col1|header|col3
+data1|$data with single quote \' inside$|data3
+$data with pipe | inside$|data2|data3
+$data with backslash \\ inside$|$data with \"escaped\" double quotes$|data3

--- a/cmd/sling/tests/suite.cli.tsv
+++ b/cmd/sling/tests/suite.cli.tsv
@@ -51,4 +51,5 @@ n	test_name	rows	bytes	streams	fails	output_contains	command
 50	Run sling with task configuration	24					sling run -c cmd/sling/tests/task.yaml
 51	Run sling with Parquet source	1018					sling run --src-stream 'file://cmd/sling/tests/files/parquet' --stdout > /dev/null
 52	Run sling with empty input	0				execution succeeded	echo '' | sling run --stdout
-53  Run sling with CSV source and custom options	4					./sling run --src-conn LOCAL --src-stream file://cmd/sling/tests/files/test7.csv --src-options '{ delimiter: "|", quote: "'"'"'", escape: "\\" }' --stdout > /dev/null
+53  Run sling with CSV source and custom single quote	4					./sling run --src-conn LOCAL --src-stream file://cmd/sling/tests/files/test7.csv --src-options '{ delimiter: "|", quote: "'"'"'", escape: "\\" }' --stdout > /dev/null
+54  Run sling with CSV source and custom quote($)	4					./sling run --src-conn LOCAL --src-stream file://cmd/sling/tests/files/test8.csv --src-options '{ delimiter: "|", quote: "$", escape: "\\" }' --stdout > /dev/null

--- a/cmd/sling/tests/suite.cli.tsv
+++ b/cmd/sling/tests/suite.cli.tsv
@@ -51,5 +51,5 @@ n	test_name	rows	bytes	streams	fails	output_contains	command
 50	Run sling with task configuration	24					sling run -c cmd/sling/tests/task.yaml
 51	Run sling with Parquet source	1018					sling run --src-stream 'file://cmd/sling/tests/files/parquet' --stdout > /dev/null
 52	Run sling with empty input	0				execution succeeded	echo '' | sling run --stdout
-53  Run sling with CSV source and custom single quote	4					./sling run --src-conn LOCAL --src-stream file://cmd/sling/tests/files/test7.csv --src-options '{ delimiter: "|", quote: "'"'"'", escape: "\\" }' --stdout > /dev/null
-54  Run sling with CSV source and custom quote($)	4					./sling run --src-conn LOCAL --src-stream file://cmd/sling/tests/files/test8.csv --src-options '{ delimiter: "|", quote: "$", escape: "\\" }' --stdout > /dev/null
+53	Run sling with CSV source and single quote	3					"sling run --src-conn LOCAL --src-stream file://cmd/sling/tests/files/test7.csv --src-options '{ delimiter: ""|"", quote: ""'\''"", escape: ""\\"" }' --stdout > /dev/null"
+54	Run sling with CSV source and $symbol quote	3					"sling run --src-conn LOCAL --src-stream file://cmd/sling/tests/files/test8.csv --src-options '{ delimiter: ""|"", quote: ""$"", escape: ""\\"" }' --stdout > /dev/null"

--- a/cmd/sling/tests/suite.cli.tsv
+++ b/cmd/sling/tests/suite.cli.tsv
@@ -51,3 +51,4 @@ n	test_name	rows	bytes	streams	fails	output_contains	command
 50	Run sling with task configuration	24					sling run -c cmd/sling/tests/task.yaml
 51	Run sling with Parquet source	1018					sling run --src-stream 'file://cmd/sling/tests/files/parquet' --stdout > /dev/null
 52	Run sling with empty input	0				execution succeeded	echo '' | sling run --stdout
+53  Run sling with CSV source and custom options	4					./sling run --src-conn LOCAL --src-stream file://cmd/sling/tests/files/test7.csv --src-options '{ delimiter: "|", quote: "'"'"'", escape: "\\" }' --stdout > /dev/null

--- a/core/dbio/database/database_clickhouse.go
+++ b/core/dbio/database/database_clickhouse.go
@@ -111,7 +111,7 @@ func (conn *ClickhouseConn) BulkImportStream(tableFName string, ds *iop.Datastre
 
 	table, err := ParseTableName(tableFName, conn.GetType())
 	if err != nil {
-		err = g.Error(err, "could not get  table name for imoprt")
+		err = g.Error(err, "could not get table name for import")
 		return
 	}
 

--- a/core/dbio/database/database_duckdb.go
+++ b/core/dbio/database/database_duckdb.go
@@ -186,6 +186,7 @@ func (conn *DuckDbConn) importViaTempCSVs(tableFName string, df *iop.Dataflow) (
 		config.Header = true
 		config.Delimiter = ","
 		config.Escape = `"`
+		config.Quote = `"`
 		config.NullAs = `\N`
 
 		timestampZLayout := conn.Type.GetTemplateValue("variable.timestampz_layout")

--- a/core/dbio/database/database_duckdb_unix.go
+++ b/core/dbio/database/database_duckdb_unix.go
@@ -54,6 +54,7 @@ func (conn *DuckDbConn) importViaNamedPipe(tableFName string, df *iop.Dataflow) 
 		config.Header = true
 		config.Delimiter = ","
 		config.Escape = `"`
+		config.Quote = `"`
 		config.NullAs = `\N`
 		config.DatetimeFormat = conn.Type.GetTemplateValue("variable.timestampz_layout")
 

--- a/core/dbio/database/database_postgres.go
+++ b/core/dbio/database/database_postgres.go
@@ -128,7 +128,7 @@ func (conn *PostgresConn) BulkImportStream(tableFName string, ds *iop.Datastream
 
 	table, err := ParseTableName(tableFName, conn.GetType())
 	if err != nil {
-		err = g.Error(err, "could not get  table name for imoprt")
+		err = g.Error(err, "could not get table name for import")
 		return
 	}
 

--- a/core/dbio/database/database_proton.go
+++ b/core/dbio/database/database_proton.go
@@ -104,7 +104,7 @@ func (conn *ProtonConn) BulkImportStream(tableFName string, ds *iop.Datastream) 
 
 	table, err := ParseTableName(tableFName, conn.GetType())
 	if err != nil {
-		err = g.Error(err, "could not get  table name for imoprt")
+		err = g.Error(err, "could not get table name for import")
 		return
 	}
 

--- a/core/dbio/database/database_sqlite.go
+++ b/core/dbio/database/database_sqlite.go
@@ -114,7 +114,7 @@ func (conn *SQLiteConn) BulkImportStream(tableFName string, ds *iop.Datastream) 
 
 	table, err := ParseTableName(tableFName, conn.GetType())
 	if err != nil {
-		err = g.Error(err, "could not get table name for imoprt")
+		err = g.Error(err, "could not get table name for import")
 		return
 	}
 

--- a/core/dbio/iop/csv.go
+++ b/core/dbio/iop/csv.go
@@ -26,6 +26,7 @@ type CSV struct {
 	NoHeader        bool
 	Delimiter       rune
 	Escape          string
+	Quote           string
 	FieldsPerRecord int
 	Columns         []Column
 	File            *os.File
@@ -263,6 +264,11 @@ func (c *CSV) getReader() (r csv.CsvReaderLike, err error) {
 		options := csv.CsvOptions{}
 		options.Delimiter = byte(c.Delimiter)
 		options.Escape = []byte(c.Escape)[0]
+
+		if c.Quote != "" {
+			options.Quote = []byte(c.Quote)[0]
+		}
+
 		return csv.NewCsv(options).NewReader(reader4), nil
 	}
 

--- a/core/dbio/iop/csv_duckdb.go
+++ b/core/dbio/iop/csv_duckdb.go
@@ -33,6 +33,10 @@ func NewCsvReaderDuckDb(uri string, sc *StreamConfig, props ...string) (*CsvDuck
 		sc.Escape = `"`
 	}
 
+	if sc.Quote == "" {
+		sc.Quote = `"`
+	}
+
 	if sc.NullIf == "" {
 		sc.NullIf = `\N`
 	}
@@ -66,7 +70,7 @@ func (r *CsvDuckDb) Close() error {
 func (r *CsvDuckDb) MakeQuery(fsc FileStreamConfig) string {
 	quote := r.Duck.GetProp("quote_char")
 	if quote == "" {
-		quote = `"`
+		quote = r.sc.Quote
 	}
 
 	sql := r.Duck.MakeScanQuery(dbio.FileTypeCsv, r.URI, fsc)

--- a/core/dbio/iop/datastream.go
+++ b/core/dbio/iop/datastream.go
@@ -1114,6 +1114,7 @@ func (ds *Datastream) ConsumeCsvReaderChl(readerChn chan *ReaderReady) (err erro
 		NoHeader:        !ds.config.Header,
 		FieldsPerRecord: ds.config.FieldsPerRec,
 		Escape:          ds.config.Escape,
+		Quote:           ds.config.Quote,
 		Delimiter:       rune(0),
 		NoDebug:         ds.NoDebug,
 	}
@@ -1297,6 +1298,7 @@ func (ds *Datastream) ConsumeCsvReader(reader io.Reader) (err error) {
 		NoHeader:        !ds.config.Header,
 		FieldsPerRecord: ds.config.FieldsPerRec,
 		Escape:          ds.config.Escape,
+		Quote:           ds.config.Quote,
 		Delimiter:       rune(0),
 		NoDebug:         ds.NoDebug,
 	}

--- a/core/dbio/iop/stream_processor.go
+++ b/core/dbio/iop/stream_processor.go
@@ -54,6 +54,7 @@ type StreamConfig struct {
 	SkipBlankLines    bool                   `json:"skip_blank_lines"`
 	Delimiter         string                 `json:"delimiter"`
 	Escape            string                 `json:"escape"`
+	Quote             string                 `json:"quote"`
 	FileMaxRows       int64                  `json:"file_max_rows"`
 	BatchLimit        int64                  `json:"batch_limit"`
 	MaxDecimals       int                    `json:"max_decimals"`
@@ -262,6 +263,10 @@ func (sp *StreamProcessor) SetConfig(configMap map[string]string) {
 
 	if configMap["escape"] != "" {
 		sp.Config.Escape = configMap["escape"]
+	}
+
+	if configMap["quote"] != "" {
+		sp.Config.Quote = configMap["quote"]
 	}
 
 	if configMap["file_max_rows"] != "" {

--- a/core/sling/config.go
+++ b/core/sling/config.go
@@ -1276,6 +1276,7 @@ type SourceOptions struct {
 	SkipBlankLines *bool               `json:"skip_blank_lines,omitempty" yaml:"skip_blank_lines,omitempty"`
 	Delimiter      string              `json:"delimiter,omitempty" yaml:"delimiter,omitempty"`
 	Escape         string              `json:"escape,omitempty" yaml:"escape,omitempty"`
+	Quote          string              `json:"quote,omitempty" yaml:"quote,omitempty"`
 	MaxDecimals    *int                `json:"max_decimals,omitempty" yaml:"max_decimals,omitempty"`
 	JmesPath       *string             `json:"jmespath,omitempty" yaml:"jmespath,omitempty"`
 	Sheet          *string             `json:"sheet,omitempty" yaml:"sheet,omitempty"`
@@ -1423,6 +1424,9 @@ func (o *SourceOptions) SetDefaults(sourceOptions SourceOptions) {
 	}
 	if o.Escape == "" {
 		o.Escape = sourceOptions.Escape
+	}
+	if o.Quote == "" {
+		o.Quote = sourceOptions.Quote
 	}
 	if o.MaxDecimals == nil {
 		o.MaxDecimals = sourceOptions.MaxDecimals


### PR DESCRIPTION
fix #389 
now we can pass a new option to choose which quote symbol we use. usually the standard CSV prefer double quote, but single quote or other symbol in some specific case applied.

below is test output explain:
./sling run --src-conn LOCAL --src-stream file://cmd/sling/tests/files/test7.csv --src-options '{ delimiter: "|", quote: '\''', escape: "\\" }' --stdout

<details> 
<summary> single quote </summary>

csv source
```
col1|header|col3
data1|'data with single quote \' inside'|data3
'data with pipe | inside'|data2|data3
'data with backslash \\ inside'|'data with \"escaped\" double quotes'|data3
```

sling std output
```
6:42AM INF writing to target stream (stdout)
col1,header,col3
data1,data with single quote ' inside,data3
data with pipe | inside,data2,data3
data with backslash \\ inside,"data with \""escaped\"" double quotes",data3
6:42AM INF wrote 3 rows to stdout in 0 secs [530 r/s]
```

</details>

./sling run --src-conn LOCAL --src-stream file://cmd/sling/tests/files/test8.csv --src-options '{ delimiter: "|", quote: "$", escape: "\\" }' --stdout

<details>
<summary> quote use $ symol </summary>

csv source
```
col1|header|col3
data1|$data with single quote \' inside$|data3
$data with pipe | inside$|data2|data3
$data with backslash \\ inside$|$data with \"escaped\" double quotes$|data3
```

sling std output 
```
6:42AM INF writing to target stream (stdout)
col1,header,col3
data1,data with single quote \' inside,data3
data with pipe | inside,data2,data3
data with backslash \\ inside,"data with \""escaped\"" double quotes",data3
6:42AM INF wrote 3 rows to stdout in 0 secs [541 r/s]
```

</details>

