### PR TITLE
Handle PK column casing in upsert

### DIFF
--- a/core/sling/task_run_write.go
+++ b/core/sling/task_run_write.go
@@ -659,9 +659,15 @@ func truncateTable(t *TaskExecution, tgtConn database.Connection, tableName stri
 }
 
 func performUpsert(tgtConn database.Connection, tableTmp, targetTable database.Table, cfg *Config) error {
+	tgtPrimaryKey := cfg.Source.PrimaryKey()
+	if cc := cfg.Target.Options.ColumnCasing; cc != nil && *cc != SourceColumnCasing {
+		for i, pk := range tgtPrimaryKey {
+			tgtPrimaryKey[i] = applyColumnCasing(pk, *cc == SnakeColumnCasing, tgtConn.GetType())
+		}
+	}
 	g.Debug("Performing upsert from temporary table %s to target table %s with primary keys %v",
-		tableTmp.FullName(), targetTable.FullName(), cfg.Source.PrimaryKey())
-	rowAffCnt, err := tgtConn.Upsert(tableTmp.FullName(), targetTable.FullName(), cfg.Source.PrimaryKey())
+		tableTmp.FullName(), targetTable.FullName(), tgtPrimaryKey)
+	rowAffCnt, err := tgtConn.Upsert(tableTmp.FullName(), targetTable.FullName(), tgtPrimaryKey)
 	if err != nil {
 		err = g.Error(err, "Could not perform upsert from temp")
 		return err


### PR DESCRIPTION
Copy over the column casing handling from update key to primary key in upsert code. Might not be the best spot for it.