### PR TITLE
Fix Linux binary install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,10 @@ sling -h
 
 #### Binary on Linux
 
-```powershell
+```bash
 curl -LO 'https://github.com/slingdata-io/sling-cli/releases/latest/download/sling_linux_amd64.tar.gz' \
-  && tar xf sling_linux_amd64.tar.gz \
-  && rm -f sling_linux_amd64.tar.gz \
-  && chmod +x sling
+  && tar xzf sling_linux_amd64.tar.gz \
+  && rm -f sling_linux_amd64.tar.gz
 
 # You're good to go!
 sling -h


### PR DESCRIPTION
- GNU tar needs `-z` as the archive is gzip compressed
- no need to use chmod (tar preserves the executable bit)
- define code block as bash