### PR TITLE
fix: Sling not respecting private_key property

### DIFF
--- a/core/dbio/database/database_snowflake.go
+++ b/core/dbio/database/database_snowflake.go
@@ -48,8 +48,11 @@ func (conn *SnowflakeConn) Init() error {
 		conn.SetProp("schema", s)
 	}
 
-	if strings.EqualFold(conn.GetProp("authenticator"), "snowflake_jwt") && conn.GetProp("private_key_path") == "" {
-		return g.Error("did not provide property `private_key_path` with authenticator=snowflake_jwt. See https://docs.slingdata.io/connections/database-connections/snowflake")
+	if strings.EqualFold(conn.GetProp("authenticator"), "snowflake_jwt") &&
+		(conn.GetProp("private_key_path") == "" && conn.GetProp("private_key") == "") {
+		return g.Error(
+			"did not provide property `private_key_path` or `private_key` with authenticator=snowflake_jwt. See https://docs.slingdata.io/connections/database-connections/snowflake",
+		)
 	}
 
 	if m := conn.GetProp("copy_method"); m != "" {
@@ -98,7 +101,6 @@ func (conn *SnowflakeConn) Init() error {
 	conn.BaseConn.instance = &instance
 
 	return conn.BaseConn.Init()
-
 }
 
 func (conn *SnowflakeConn) ConnString() string {


### PR DESCRIPTION
When attempting to connect to snowflake using the snowflake_jwt authenticator snowflake returns an error that the `private_key_path` property is not set.

This changes it so that it will only error if both `private_key` and `private_key_path` are not set.

This way existing users will not be effected by this change, and new users are able to use the `private_key` property instead.

Resolves: https://github.com/slingdata-io/sling-cli/issues/552