### PR TITLE
fix: add provider param to duckdb secret

### DIFF
--- a/core/dbio/database/database_duckdb.go
+++ b/core/dbio/database/database_duckdb.go
@@ -414,7 +414,14 @@ func MakeDuckDbSecretProps(conn Connection, secretType iop.DuckDbSecretType) (se
 			"url_style":            "URL_STYLE",
 			"assume_role_arn":      "ASSUME_ROLE_ARN",
 			"chain":                "CHAIN",
+			"provider":             "PROVIDER",
 		})
+		// If user supplied CHAIN but no PROVIDER, default to credential_chain
+        if _, hasChain := secretProps["CHAIN"]; hasChain {
+            if _, hasProv := secretProps["PROVIDER"]; !hasProv {
+                secretProps["PROVIDER"] = "credential_chain"
+            }
+        }
 	case iop.DuckDbSecretTypeAzure:
 		fillSecretProps(map[string]string{
 			"azure_connection_string": "CONNECTION_STRING",


### PR DESCRIPTION
Add provider parameter to the duckdb secret constructor.

When chain is provided without a provider duckdb discards the value of chain and defaults the value of provider to config.

To handle when chain is supplied without PROVIDER the value of PROVIDER defaults to credential_chain.

fixes #623 