### PR TITLE
fix: prevent deadlock in Prometheus chunked streaming

### DIFF
--- a/core/dbio/database/database_prometheus.go
+++ b/core/dbio/database/database_prometheus.go
@@ -767,6 +767,9 @@ func (conn *PrometheusConn) StreamRowsChunked(queryContext *g.Context, query str
 	}
 	ds.SetConfig(props)
 
+	// Start the bytes-written processor to prevent blocking on bwRows channel
+	ds.StartBwProcessor()
+
 	// Process in chunks
 	go func() {
 		defer ds.Close()

--- a/core/dbio/iop/datastream.go
+++ b/core/dbio/iop/datastream.go
@@ -261,6 +261,13 @@ func (ds *Datastream) processBwRows() {
 	}
 }
 
+// StartBwProcessor starts the bytes-written processor goroutine.
+// This should be called when creating a datastream that pushes rows
+// directly without calling Start() (e.g., chunked streaming).
+func (ds *Datastream) StartBwProcessor() {
+	go ds.processBwRows()
+}
+
 // SetReady sets the ds.ready
 func (ds *Datastream) SetReady() {
 	if !ds.Ready {


### PR DESCRIPTION
When streaming data from Prometheus with large time ranges (> 1 hour), the StreamRowsChunked function would stall after ~100 rows. This was caused by the bwRows channel (buffer size 100) filling up because processBwRows goroutine was never started.

The issue occurred because StreamRowsChunked creates a datastream with NewDatastreamContext() and pushes rows directly, bypassing Start() which normally starts the processBwRows goroutine.

Changes:
- Add StartBwProcessor() public method to Datastream to start the bytes-written processor independently
- Call StartBwProcessor() in StreamRowsChunked before pushing rows

This ensures the bwRows channel is drained, preventing the producer from blocking when the buffer fills up.

Related: #668 