### PR TITLE
fix(deps): bump shoenig/go-m1cpu to v0.2.1 to avoid SIGSEGV on Apple M5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -300,7 +300,7 @@ require (
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/segmentio/encoding v0.4.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.25.1 // indirect
-	github.com/shoenig/go-m1cpu v0.1.7 // indirect
+	github.com/shoenig/go-m1cpu v0.2.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect
 	github.com/slingdata-io/pocketbase v0.22.136 // indirect

--- a/go.sum
+++ b/go.sum
@@ -935,8 +935,8 @@ github.com/shirou/gopsutil/v3 v3.24.4/go.mod h1:lTd2mdiOspcqLgAnr9/nGi71NkeMpWKd
 github.com/shirou/gopsutil/v4 v4.25.1 h1:QSWkTc+fu9LTAWfkZwZ6j8MSUk4A2LV7rbH0ZqmLjXs=
 github.com/shirou/gopsutil/v4 v4.25.1/go.mod h1:RoUCUpndaJFtT+2zsZzzmhvbfGoDCJ7nFXKJf8GqJbI=
 github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
-github.com/shoenig/go-m1cpu v0.1.7 h1:C76Yd0ObKR82W4vhfjZiCp0HxcSZ8Nqd84v+HZ0qyI0=
-github.com/shoenig/go-m1cpu v0.1.7/go.mod h1:KkDOw6m3ZJQAPHbrzkZki4hnx+pDRR1Lo+ldA56wD5w=
+github.com/shoenig/go-m1cpu v0.2.1 h1:yqRB4fvOge2+FyRXFkXqsyMoqPazv14Yyy+iyccT2E4=
+github.com/shoenig/go-m1cpu v0.2.1/go.mod h1:KkDOw6m3ZJQAPHbrzkZki4hnx+pDRR1Lo+ldA56wD5w=
 github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
 github.com/shoenig/test v1.7.0 h1:eWcHtTXa6QLnBvm0jgEabMRN/uJ4DMV3M8xUGgRkZmk=
 github.com/shoenig/test v1.7.0/go.mod h1:UxJ6u/x2v/TNs/LoLxBNJRV9DiwBBKYxXSyczsBHFoI=


### PR DESCRIPTION
Fixes #736

## Summary

- Bumps the indirect dep `github.com/shoenig/go-m1cpu` from v0.1.7 to v0.2.1.
- v0.1.7 segfaults at package `init()` on Apple M5 because the `pmgr` IORegistry property `voltage-states1-sram` is absent, so `IORegistryEntryCreateCFProperty` returns NULL and the C `getFrequency()` then dereferences NULL via `CFDataGetLength`.
- Upstream v0.2.1 adds `if (typeRef == NULL) return 0;` in `getFrequency`. The public API used by `gopsutil/v3` (`IsAppleSilicon`, `PCoreHz`, `ECoreHz`, etc.) is unchanged, so this is a drop-in version bump.

See #736 for the full crash trace and root-cause analysis.

## Test plan

- [x] Reproduced crash on Apple M5 Max (macOS 26.4.1) with brewed `sling 1.5.15` and a fresh source build of `main`.
- [x] Applied the bump and rebuilt via `bash scripts/build.sh`; `./sling -h` now exits cleanly.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)