### PR TITLE
fix: handle quoted replication paths

### DIFF
--- a/core/sling/replication.go
+++ b/core/sling/replication.go
@@ -1886,10 +1886,44 @@ func cleanMergePrefixes(cols any) any {
 	return cleaned
 }
 
+func normalizeReplicationConfigPathArg(cfgPath string) string {
+	cfgPath = strings.TrimSpace(cfgPath)
+	if cfgPath == "" {
+		return cfgPath
+	}
+
+	if _, err := os.Stat(cfgPath); err == nil {
+		return cfgPath
+	}
+
+	if len(cfgPath) < 2 {
+		return cfgPath
+	}
+
+	quote := cfgPath[0]
+	if (quote != '"' && quote != '\'') || cfgPath[len(cfgPath)-1] != quote {
+		return cfgPath
+	}
+
+	unquotedPath := cfgPath[1 : len(cfgPath)-1]
+	if unquotedPath == "" {
+		return cfgPath
+	}
+
+	return unquotedPath
+}
+
 func LoadReplicationConfigFromFile(cfgPath string) (config ReplicationConfig, err error) {
+	originalCfgPath := strings.TrimSpace(cfgPath)
+	cfgPath = normalizeReplicationConfigPathArg(cfgPath)
+
 	cfgFile, err := os.Open(cfgPath)
 	if err != nil {
-		err = g.Error(err, "Unable to open replication path: "+cfgPath)
+		if originalCfgPath != cfgPath {
+			err = g.Error(err, "Unable to open replication path: %s (from %s)", cfgPath, originalCfgPath)
+		} else {
+			err = g.Error(err, "Unable to open replication path: "+cfgPath)
+		}
 		return
 	}
 

--- a/core/sling/replication_test.go
+++ b/core/sling/replication_test.go
@@ -1,6 +1,8 @@
 package sling
 
 import (
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -35,6 +37,64 @@ streams:
 	assert.NoError(t, err)
 
 	g.PP(replication)
+}
+
+func TestLoadReplicationConfigFromFileQuotedPath(t *testing.T) {
+	t.Setenv("SLING_REPLICATION_TASKS", "")
+
+	cfgPath := filepath.Join(t.TempDir(), "replication.yaml")
+	cfgBody := strings.TrimSpace(`
+source: local
+target: local
+streams:
+  test_stream:
+`) + "\n"
+	assert.NoError(t, os.WriteFile(cfgPath, []byte(cfgBody), 0644))
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "normal", path: cfgPath},
+		{name: "double quoted", path: `"` + cfgPath + `"`},
+		{name: "single quoted", path: `'` + cfgPath + `'`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := LoadReplicationConfigFromFile(tt.path)
+			if assert.NoError(t, err) {
+				assert.Equal(t, cfgPath, config.Env["SLING_CONFIG_PATH"])
+			}
+		})
+	}
+}
+
+func TestLoadReplicationConfigFromFileQuotedPathErrors(t *testing.T) {
+	t.Setenv("SLING_REPLICATION_TASKS", "")
+
+	cfgPath := filepath.Join(t.TempDir(), "replication.yaml")
+	cfgBody := strings.TrimSpace(`
+source: local
+target: local
+streams:
+  test_stream:
+`) + "\n"
+	assert.NoError(t, os.WriteFile(cfgPath, []byte(cfgBody), 0644))
+
+	mismatched := `"` + cfgPath + `'`
+	_, err := LoadReplicationConfigFromFile(mismatched)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), mismatched)
+	}
+
+	missingPath := filepath.Join(t.TempDir(), "missing.yaml")
+	quotedMissing := `"` + missingPath + `"`
+	_, err = LoadReplicationConfigFromFile(quotedMissing)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), missingPath)
+		assert.Contains(t, err.Error(), quotedMissing)
+	}
 }
 
 func TestReplicationWildcards(t *testing.T) {


### PR DESCRIPTION
Fixes #744.

## Summary
- Normalizes replication config file path arguments that arrive with preserved surrounding quotes.
- Keeps normal path handling unchanged.
- Adds regression coverage for quoted replication paths.

## Testing
- gofmt core/sling/replication.go core/sling/replication_test.go
- git diff --check
- go test -modfile=/private/tmp/sling-cli-test.mod ./core/sling -run 'TestLoadReplicationConfigFromFileQuotedPath'
- go test ./core/sling, go test ./cmd/sling, and go test ./... were blocked locally because this checkout is missing the go.mod replacement path ../g.