### PR TITLE
fix(iceberg): map time/timez/uuid to native Arrow types in ColumnsToArrowSchema (#751)

### DIFF
--- a/core/dbio/iop/arrow.go
+++ b/core/dbio/iop/arrow.go
@@ -584,6 +584,12 @@ func ColumnsToArrowSchema(columns Columns) *arrow.Schema {
 			default:
 				arrowType = arrow.FixedWidthTypes.Timestamp_us // iceberg does not support nano, micro as default
 			}
+		case TimeType, TimezType:
+			// Iceberg Time (microsecond precision), matching iopTypeToIcebergPrimitiveType
+			arrowType = arrow.FixedWidthTypes.Time64us
+		case UUIDType:
+			// Iceberg UUID via the arrow.uuid extension, matching iopTypeToIcebergPrimitiveType
+			arrowType = extensions.NewUUIDType()
 		case StringType, TextType, JsonType:
 			arrowType = arrow.BinaryTypes.String
 		case BinaryType:
@@ -600,6 +606,21 @@ func ColumnsToArrowSchema(columns Columns) *arrow.Schema {
 	}
 
 	return arrow.NewSchema(fields, nil)
+}
+
+// parseTimeOfDayE parses a value into time.Time, also handling bare time-of-day
+// strings (e.g. "08:30:00") that cast.ToTimeE rejects for lacking a date
+func parseTimeOfDayE(val interface{}) (time.Time, error) {
+	if t, err := cast.ToTimeE(val); err == nil {
+		return t, nil
+	}
+	s := strings.TrimSpace(cast.ToString(val))
+	for _, layout := range []string{"15:04:05.9999999", "15:04:05.999999", "15:04:05", "15:04"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, g.Error("could not parse time-of-day value: %v", val)
 }
 
 func AppendToBuilder(builder array.Builder, col *Column, val interface{}) {
@@ -863,7 +884,7 @@ func AppendToBuilder(builder array.Builder, col *Column, val interface{}) {
 			}
 		}
 	case *array.Time32Builder:
-		tVal, _ := cast.ToTimeE(val)
+		tVal, _ := parseTimeOfDayE(val)
 		// Time32 can be seconds or milliseconds since midnight
 		dt := b.Type().(*arrow.Time32Type)
 		if dt.Unit == arrow.Second {
@@ -874,7 +895,7 @@ func AppendToBuilder(builder array.Builder, col *Column, val interface{}) {
 			b.Append(arrow.Time32(millis))
 		}
 	case *array.Time64Builder:
-		tVal, _ := cast.ToTimeE(val)
+		tVal, _ := parseTimeOfDayE(val)
 		// Time64 can be microseconds or nanoseconds since midnight
 		dt := b.Type().(*arrow.Time64Type)
 		if dt.Unit == arrow.Microsecond {

--- a/core/dbio/iop/arrow_test.go
+++ b/core/dbio/iop/arrow_test.go
@@ -6,6 +6,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/extensions"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 )
@@ -185,4 +189,60 @@ func TestArrowReaderWithSelectedColumns(t *testing.T) {
 	}
 
 	assert.Equal(t, len(testData), rowCount)
+}
+
+// ColumnsToArrowSchema must map time/timez/uuid to their native Arrow types so the
+// schema matches iopTypeToIcebergPrimitiveType. Previously they fell through to
+// String, causing "cannot promote string to time/uuid" when appending to Iceberg.
+func TestColumnsToArrowSchemaTimeUUID(t *testing.T) {
+	columns := Columns{
+		{Name: "t", Type: TimeType, Position: 1},
+		{Name: "tz", Type: TimezType, Position: 2},
+		{Name: "u", Type: UUIDType, Position: 3},
+	}
+
+	schema := ColumnsToArrowSchema(columns)
+
+	assert.IsType(t, &arrow.Time64Type{}, schema.Field(0).Type)
+	assert.IsType(t, &arrow.Time64Type{}, schema.Field(1).Type)
+	_, isUUID := schema.Field(2).Type.(*extensions.UUIDType)
+	assert.True(t, isUUID, "uuid column should map to the arrow.uuid extension type, got %T", schema.Field(2).Type)
+}
+
+// AppendToBuilder must fill a Time64 builder from a bare time-of-day string (as
+// emitted by SQL `time` columns). Previously cast.ToTimeE rejected these and the
+// value silently zeroed to 00:00:00.
+func TestAppendToBuilderTimeOfDay(t *testing.T) {
+	col := &Column{Name: "t", Type: TimeType}
+	builder := array.NewTime64Builder(memory.NewGoAllocator(), &arrow.Time64Type{Unit: arrow.Microsecond})
+	defer builder.Release()
+
+	AppendToBuilder(builder, col, "08:30:00.0000000")
+	AppendToBuilder(builder, col, "08:30:00")
+	AppendToBuilder(builder, col, nil)
+
+	arr := builder.NewTime64Array()
+	defer arr.Release()
+
+	wantMicros := arrow.Time64(int64((8*3600 + 30*60) * 1e6))
+	assert.Equal(t, wantMicros, arr.Value(0), "fractional time-of-day not parsed")
+	assert.Equal(t, wantMicros, arr.Value(1), "plain time-of-day not parsed")
+	assert.True(t, arr.IsNull(2), "nil should append null")
+}
+
+func TestParseTimeOfDayE(t *testing.T) {
+	for _, s := range []string{"08:30:00.0000000", "08:30:00", "08:30"} {
+		tVal, err := parseTimeOfDayE(s)
+		assert.NoError(t, err, "input %q", s)
+		assert.Equal(t, 8, tVal.Hour())
+		assert.Equal(t, 30, tVal.Minute())
+	}
+
+	// full datetime still works (delegates to cast.ToTimeE)
+	tVal, err := parseTimeOfDayE("2023-01-02 15:04:05")
+	assert.NoError(t, err)
+	assert.Equal(t, 15, tVal.Hour())
+
+	_, err = parseTimeOfDayE("not a time")
+	assert.Error(t, err)
 }

--- a/core/dbio/iop/arrow_test.go
+++ b/core/dbio/iop/arrow_test.go
@@ -246,3 +246,24 @@ func TestParseTimeOfDayE(t *testing.T) {
 	_, err = parseTimeOfDayE("not a time")
 	assert.Error(t, err)
 }
+
+// AppendToBuilder must round-trip a canonical UUID string into the arrow.uuid
+// extension builder. With the schema fix, uuid columns now map to UUIDBuilder
+// instead of String, so this value path is exercised end-to-end.
+func TestAppendToBuilderUUID(t *testing.T) {
+	col := &Column{Name: "u", Type: UUIDType}
+	builder := extensions.NewUUIDBuilder(memory.NewGoAllocator())
+	defer builder.Release()
+
+	AppendToBuilder(builder, col, "B86D9F47-F5E1-44A1-9576-1AEF61206EB1") // uppercase
+	AppendToBuilder(builder, col, "b86d9f47-f5e1-44a1-9576-1aef61206eb1") // lowercase
+	AppendToBuilder(builder, col, nil)
+
+	arr := builder.NewArray().(*extensions.UUIDArray)
+	defer arr.Release()
+
+	want := "b86d9f47-f5e1-44a1-9576-1aef61206eb1"
+	assert.Equal(t, want, arr.ValueStr(0), "uppercase uuid should normalize and round-trip")
+	assert.Equal(t, want, arr.ValueStr(1), "lowercase uuid should round-trip")
+	assert.True(t, arr.IsNull(2), "nil should append null")
+}


### PR DESCRIPTION
Fixes #751.

## Problem

Writing to an Iceberg target fails for any `time`, `timez`, or `uuid` column:

```
error encountered during schema visitor: cannot resolve type: cannot promote string to time
```

(`...to uuid` for UUID columns.)

## Root cause

Sling builds the Iceberg schema with two functions that disagree:

- **Table creation** — `IcebergConn.iopTypeToIcebergPrimitiveType` maps `TimeType`/`TimezType` → Iceberg `Time` and `UUIDType` → Iceberg `UUID` (native).
- **Data append** — `BulkImportStream` builds the Arrow record via `ColumnsToArrowSchema`, which had **no cases** for `TimeType`/`TimezType`/`UUIDType`, so they fell through to `String`.

`tx.AppendTable` then reconciles the incoming Arrow `string` against the table's declared native `time`/`uuid` type and `iceberg-go` refuses to promote.

A second, related bug: even with the schema fixed, `Time32Builder`/`Time64Builder` in `AppendToBuilder` use `cast.ToTimeE`, which rejects bare time-of-day strings (e.g. `"08:30:00"` — no date) and silently zeroes the value to `00:00:00`.

## Fix

- `ColumnsToArrowSchema`: add `TimeType, TimezType` → `arrow.FixedWidthTypes.Time64us` and `UUIDType` → `extensions.NewUUIDType()` (the `arrow.uuid` extension `iceberg-go` recognizes), matching `iopTypeToIcebergPrimitiveType`.
- Add `parseTimeOfDayE`, which falls back to time-of-day layouts when `cast.ToTimeE` fails; use it in the `Time32Builder`/`Time64Builder` cases.

## Note on `parse_ms_uuid` (why UUID needs only the schema fix)

This PR does **not** touch UUID value handling, which already works:

1. The SQL Server reader scans `uniqueidentifier` as raw 16 mixed-endian bytes (`microsoft/go-mssqldb`'s `UniqueIdentifier [16]byte`).
2. `BaseConn.setTransforms` auto-registers the **`parse_ms_uuid`** transform for any `uniqueidentifier` column, which byte-swaps those bytes into a canonical UUID string (`transformsNS.ParseMsUUID`).
3. `AppendToBuilder`'s existing `*extensions.UUIDBuilder` case parses that canonical string into the 16-byte Arrow UUID.

Step 3 was simply never reached for the Iceberg target, because `ColumnsToArrowSchema` typed the column as `String` (not `UUIDType` → `UUIDBuilder`). Once the schema maps it to the `arrow.uuid` extension, the existing transform + builder chain handles the value end-to-end. No reader/transform changes needed.

(One testing caveat from this: `parse_ms_uuid`, like all transforms, is gated to official releases — a locally-built binary will skip it and leave UUIDs as raw bytes. `time` is unaffected because its fix lives in the Arrow builder, not a transform.)

## Tests

- `TestColumnsToArrowSchemaTimeUUID` — schema maps the three types to native Arrow types, not String.
- `TestAppendToBuilderTimeOfDay` — a `Time64` builder gets the correct microseconds from `"08:30:00"` / `"08:30:00.0000000"`, and nil → null.
- `TestParseTimeOfDayE` — parse layouts, datetime delegation, error case.

## Verification

Reproduced the original failure on v1.4.26, confirmed the patched build no longer crashes, and verified a SQL Server `time` column round-trips (`08:30:00`) through Iceberg → Postgres, using a `sql` catalog on Postgres with a MinIO warehouse. UUID end-to-end value verification requires an official build per the transform-gating note above; the schema mapping and `time` value path are fully verified here.
