### PR TITLE
V1.5.20

### DIFF
--- a/cmd/sling/resource/llm_API_SPEC.md
+++ b/cmd/sling/resource/llm_API_SPEC.md
@@ -345,6 +345,8 @@ endpoints:
 
 **Lifecycle**: Declare → Write (via processors) → Read (via iterate) → Auto-cleanup. Queues are temporary JSONL files. Producers run before consumers (auto-ordered). Cannot write after reading starts.
 
+**Consumption** (`iterate.consume`): By default (`deferred`) a consumer waits for the producer to finish before reading. Set `consume: immediate` to tail the queue live — the consumer starts as soon as the producer appends records (runs concurrently with `SLING_THREADS`). With `immediate`, the producer and its consumers form a fail-fast group: if any member fails, the rest of that group is terminated (a failed consumer stops its producer; a failed producer stops its consumers). Unrelated streams are unaffected. Use `immediate` when you want early failure and pipelined throughput; keep the default `deferred` when a consumer needs the complete queue (e.g. dedupe/aggregate across all items).
+
 **Usage Tips**: Use descriptive names, keep items small (IDs/strings), let Sling determine execution order.
 
 ### Direct Queue-to-Records
@@ -659,6 +661,10 @@ iterate:
   over: "queue.product_ids"
   # Name of the state variable to store the current item in each iteration. Must start with 'state.'.
   into: "state.current_product_id"
+  # Optional (queue iteration only): when to consume the queue.
+  #   deferred (default) — wait for the producer to finish, then read from the start.
+  #   immediate — tail the queue live as the producer appends; enables fail-fast.
+  consume: deferred
   # Optional: Number of iterations to run concurrently (default: 10).
   concurrency: 5
   # Optional: Condition to evaluate before starting iteration.

--- a/cmd/sling/sling_cli.go
+++ b/cmd/sling/sling_cli.go
@@ -579,9 +579,16 @@ func cliInit(done chan struct{}) int {
 		flaggy.AttachSubcommand(cli.Sc, 1)
 	}
 
-	// patch 'sling mcp' into 'sling serve mcp' for backwards compatibility
-	if len(os.Args) >= 2 && os.Args[1] == "mcp" {
+	// patch subcommands for backwards compatibility
+	switch {
+	// 'sling mcp' into 'sling serve mcp'
+	case len(os.Args) >= 2 && os.Args[1] == "mcp":
 		os.Args = append([]string{os.Args[0], "serve"}, os.Args[1:]...)
+	// 'sling agent' into 'sling runner'
+	case len(os.Args) == 2 && os.Args[1] == "agent":
+		os.Args = []string{os.Args[0], "runner"}
+	case len(os.Args) > 2 && os.Args[1] == "agent":
+		os.Args = append([]string{os.Args[0], "runner"}, os.Args[2:]...)
 	}
 
 	flaggy.ShowHelpOnUnexpectedDisable()

--- a/core/dbio/api/api.go
+++ b/core/dbio/api/api.go
@@ -335,8 +335,20 @@ func (ac *APIConnection) ReadDataflow(endpointName string, sCfg APIStreamConfig)
 	// dataflow so the caller (task_run_read.go) treats it as a no-record stream.
 	if endpoint.QueueOnly {
 		if _, err = ds.Collect(0); err != nil {
+			// on failure, don't mark queues done — consumers stop via context cancel
 			return nil, g.Error(err, "queue_only endpoint failed during drain")
 		}
+
+		// mark produced queues done (only after success) to unblock eager consumers
+		for _, queueName := range endpoint.ProducerQueueNames() {
+			if q, ok := ac.GetQueue(queueName); ok {
+				q.Flush()
+				if err = q.MarkDone(); err != nil {
+					return nil, g.Error(err, "could not mark queue done: %s", queueName)
+				}
+			}
+		}
+
 		if err = endpoint.teardown(); err != nil {
 			return nil, g.Error(err, "could not teardown queue_only endpoint")
 		}

--- a/core/dbio/api/api_suite.yaml
+++ b/core/dbio/api/api_suite.yaml
@@ -1153,3 +1153,54 @@
     echoed_filter: "2026-05-01"
   expected_next_state: {}
 
+# id: 25 - `sync` variables must be available during the endpoint `setup`
+# sequence, not only during the main request. On an incremental re-run the prior
+# watermark is restored into endpoint.syncMap (seeded here via `sync_state`); a
+# setup request referencing {sync.last_updated} must send the resolved value.
+# The /echo handler reflects the payload so we assert what setup actually sent.
+- id: 25
+  name: test_setup_sequence_sync_var_unavailable
+  mock_response:
+    items:
+      - id: 1
+        name: "Item One"
+  sync_state:
+    last_updated: "2026-05-01T00:00:00Z"
+  spec:
+    name: setup_sync_api
+    description: "Test that sync variables are available during the setup sequence"
+    authentication:
+      type: none
+    endpoints:
+      test_endpoint:
+        sync: [last_updated]
+        setup:
+          - request:
+              url: "/echo"
+              method: POST
+              payload:
+                watermark: "{sync.last_updated}"
+            response:
+              processors:
+                - expression: "response.json.received.watermark"
+                  output: "state.echoed_watermark"
+                  aggregation: last
+        request:
+          url: "/items"
+          method: GET
+          headers:
+            X-Watermark: "{sync.last_updated}"
+        response:
+          processors:
+            - expression: record.name
+              output: state.last_updated
+              aggregation: maximum
+          records:
+            jmespath: items
+  expected_records:
+    - id: "1"
+      name: "Item One"
+  expected_state:
+    echoed_watermark: "2026-05-01T00:00:00Z"
+  expected_next_state: {}
+

--- a/core/dbio/api/api_suite.yaml
+++ b/core/dbio/api/api_suite.yaml
@@ -1102,3 +1102,54 @@
       updated_at: "2025-01-13"
   expected_state: {}
 
+# Reproduces: state templates that call a function with a quoted format
+# argument (e.g. date_format(..., "%Y-%m-%d")) are NOT rendered before the
+# endpoint `setup` sequence runs. A setup request payload referencing such a
+# state var ships the raw template string to the server instead of the resolved
+# value. The main request path renders state via renderInitial(); the setup
+# path does not. This test asserts the value the setup request actually sent.
+- id: 24
+  name: test_setup_state_render_date_format
+  mock_response:
+    users:
+      - id: 1
+        name: "John Doe"
+  spec:
+    name: setup_state_render_api
+    description: "Test that state function templates render before setup runs"
+    authentication:
+      type: none
+    endpoints:
+      test_endpoint:
+        description: "Main endpoint whose setup references a date_format() state var"
+        state:
+          # deterministic (no now()) so the expected value is stable, but
+          # exercises the exact failing pattern: function + quoted "%"-format arg
+          date_filter: '{date_format(date_parse("2026-05-01"), "%Y-%m-%d")}'
+        setup:
+          - request:
+              url: "/echo"
+              method: POST
+              payload:
+                filter: "{state.date_filter}"
+            response:
+              processors:
+                - expression: "response.json.received.filter"
+                  output: "state.echoed_filter"
+                  aggregation: last
+        request:
+          url: "/users"
+          method: GET
+        response:
+          records:
+            jmespath: users
+  expected_records:
+    - id: "1"
+      name: "John Doe"
+  # With the bug, echoed_filter is the raw '{date_format(date_parse("2026-05-01"), "%Y-%m-%d")}'.
+  # After the fix, the setup request sends (and echoes back) the resolved date.
+  expected_state:
+    date_filter: "2026-05-01"
+    echoed_filter: "2026-05-01"
+  expected_next_state: {}
+

--- a/core/dbio/api/api_suite.yaml
+++ b/core/dbio/api/api_suite.yaml
@@ -988,7 +988,9 @@
   expected_state: {}
 
 # id: 21 - records.select with exclusion globs drops matching columns while
-# keeping everything else in source order via implicit `*`.
+# keeping everything else via implicit `*`. The remaining columns emit
+# ALPHABETICALLY (the API source field order is not preserved) — so
+# {id,name,email} minus internal_* comes out [email, id, name].
 - id: 21
   name: select_exclude_glob_drops_matching_columns
   mock_response_raw: |
@@ -1008,7 +1010,7 @@
             jmespath: "@"
             select:
               - "-internal_*"
-  expected_columns: [id, name, email]
+  expected_columns: [email, id, name]
   expected_records:
     - id: "1"
       name: Alice
@@ -1051,10 +1053,10 @@
       email: bob@example.com
   expected_state: {}
 
-# id: 23 - records.select reorder: front-pins `id` and `name`, `*` expands
-# to the remaining source columns in place, and `created_at`/`updated_at`
-# pin to the back. This is the column-reorder regression guard —
-# firstObjectKeysInOrder recovers the source order from raw bytes.
+# id: 23 - records.select reorder: front-pins `id` and `name`, the `*`
+# remainder fills the middle ALPHABETICALLY (the API source field order is not
+# preserved), and `created_at`/`updated_at` pin to the back. Explicit pins hold
+# their list position; only the `*` remainder is alphabetized.
 - id: 23
   name: select_reorder_front_star_back_pins
   mock_response_raw: |
@@ -1078,25 +1080,24 @@
               - "*"
               - created_at
               - updated_at
-  # Source order of the first record is: extra_b, created_at, extra_a, name,
-  # id, updated_at, email. With select [id, name, *, created_at, updated_at]:
-  # `id` and `name` pin to the front; `*` expands to remaining source columns
-  # in source order minus pins → extra_b, extra_a, email; `created_at` and
-  # `updated_at` pin to the back.
-  expected_columns: [id, name, extra_b, extra_a, email, created_at, updated_at]
+  # With select [id, name, *, created_at, updated_at]: `id` and `name` pin to
+  # the front; the `*` remainder (the columns not otherwise named: extra_a,
+  # extra_b, email) fills the middle ALPHABETICALLY → email, extra_a, extra_b;
+  # `created_at` and `updated_at` pin to the back.
+  expected_columns: [id, name, email, extra_a, extra_b, created_at, updated_at]
   expected_records:
     - id: "1"
       name: Alice
-      extra_b: B1
-      extra_a: A1
       email: alice@example.com
+      extra_a: A1
+      extra_b: B1
       created_at: "2025-01-10"
       updated_at: "2025-01-11"
     - id: "2"
       name: Bob
-      extra_b: B2
-      extra_a: A2
       email: bob@example.com
+      extra_a: A2
+      extra_b: B2
       created_at: "2025-01-12"
       updated_at: "2025-01-13"
   expected_state: {}

--- a/core/dbio/api/api_test.go
+++ b/core/dbio/api/api_test.go
@@ -713,6 +713,7 @@ func TestHTTPCallAndResponseExtraction(t *testing.T) {
 
 		MockResponse      any              `yaml:"mock_response"`     // can be map or string (for CSV)
 		MockResponseRaw   string           `yaml:"mock_response_raw"` // pre-serialized JSON; preserves key order
+		SyncState         map[string]any   `yaml:"sync_state"`        // pre-seeded sync values (simulates a prior incremental run's watermark via PutSyncedState)
 		ExpectedRecords   []map[string]any `yaml:"expected_records"`
 		ExpectedColumns   []string         `yaml:"expected_columns"` // exact column list & order
 		ExpectedState     map[string]any   `yaml:"expected_state"`
@@ -913,6 +914,14 @@ func TestHTTPCallAndResponseExtraction(t *testing.T) {
 			} else {
 				// For other auth types, bypass authentication for testing
 				ac.State.Auth.Authenticated = true
+			}
+
+			// Seed sync values the same way a real incremental re-run does:
+			// the prior run's watermark is restored via PutSyncedState before
+			// reading, populating endpoint.syncMap so {sync.X} resolves.
+			if len(tc.SyncState) > 0 {
+				err = ac.PutSyncedState("test_endpoint", tc.SyncState)
+				assert.NoError(t, err)
 			}
 
 			// Execute the API call and get dataflow

--- a/core/dbio/api/api_test.go
+++ b/core/dbio/api/api_test.go
@@ -811,6 +811,14 @@ func TestHTTPCallAndResponseExtraction(t *testing.T) {
 					} else {
 						json.NewEncoder(w).Encode(mockMap)
 					}
+				case "/echo":
+					// Reflect the request payload back so a setup processor can
+					// capture exactly what the server received. Used to assert that
+					// {state.X} templates were rendered before the request was built.
+					body, _ := io.ReadAll(r.Body)
+					var reqBody map[string]any
+					_ = g.JSONUnmarshal(body, &reqBody)
+					json.NewEncoder(w).Encode(map[string]any{"received": reqBody})
 				default:
 					// Return the main mock response for other endpoints
 					json.NewEncoder(w).Encode(mockMap)

--- a/core/dbio/api/auth.go
+++ b/core/dbio/api/auth.go
@@ -460,9 +460,9 @@ func (a *AuthenticatorOAuth2) Authenticate(ctx context.Context, state *APIStateA
 		g.Warn("Stored refresh token invalid, falling back to authentication")
 	}
 
-	// if agent mode and not client_credentials, use frontend to auth.
+	// if agent/runner mode and not client_credentials, use frontend to auth.
 	// client_credentials doesn't need browser
-	if env.IsAgentMode && a.Flow != OAuthFlowClientCredentials {
+	if env.IsRunnerMode && a.Flow != OAuthFlowClientCredentials {
 		if storedTok != nil {
 			return g.Error("Stored refresh token is invalid. Need to re-authenticate. Please use the 'Connections' panel in the Platform UI.")
 		}

--- a/core/dbio/api/spec.go
+++ b/core/dbio/api/spec.go
@@ -604,6 +604,42 @@ func (eps Endpoints) HasUpstreams(endpointName string) (upstreams []string) {
 	return upstreams
 }
 
+// IteratesOverQueue reports whether the endpoint iterates over a queue.
+func (ep *Endpoint) IteratesOverQueue() bool {
+	return ep.QueueIterName() != ""
+}
+
+// QueueIterName returns the queue name iterated over (e.g. "order_ids"), or "".
+func (ep *Endpoint) QueueIterName() string {
+	if over, ok := ep.Iterate.Over.(string); ok {
+		if strings.HasPrefix(over, "queue.") {
+			return strings.TrimPrefix(over, "queue.")
+		}
+	}
+	return ""
+}
+
+// ConsumesQueueImmediately reports whether the endpoint tails a queue live,
+// rather than deferring until the producer finishes (the default).
+func (ep *Endpoint) ConsumesQueueImmediately() bool {
+	return ep.IteratesOverQueue() && ep.Iterate.Consume == ConsumeImmediate
+}
+
+// ProducerQueueNames returns the queues this endpoint produces to (processor outputs).
+func (ep *Endpoint) ProducerQueueNames() (names []string) {
+	seen := map[string]bool{}
+	for _, processor := range ep.Response.Processors {
+		if strings.HasPrefix(processor.Output, "queue.") {
+			name := strings.TrimPrefix(processor.Output, "queue.")
+			if name != "" && !seen[name] {
+				seen[name] = true
+				names = append(names, name)
+			}
+		}
+	}
+	return names
+}
+
 func (eps Endpoints) Sort() {
 	// First sort alphabetically
 	sort.Slice(eps, func(i, j int) bool {
@@ -993,11 +1029,22 @@ func (iter *Iteration) renderInitial() (err error) {
 	return nil
 }
 
+// Consume controls how an endpoint that iterates over a queue consumes it.
+type Consume string
+
+const (
+	// ConsumeImmediate tails the queue live as the producer appends (fail-fast).
+	ConsumeImmediate Consume = "immediate"
+	// ConsumeDeferred waits for the producer to finish, then reads from the start (default).
+	ConsumeDeferred Consume = "deferred"
+)
+
 // Iterate is for configuring looping values for requests
 type Iterate struct {
-	Over        any    `yaml:"over" json:"over,omitempty"` // expression
-	Into        string `yaml:"into" json:"into,omitempty"` // state variable
-	Concurrency int    `yaml:"concurrency" json:"concurrency,omitempty"`
+	Over        any         `yaml:"over" json:"over,omitempty"` // expression
+	Into        string      `yaml:"into" json:"into,omitempty"` // state variable
+	Consume     Consume     `yaml:"consume" json:"consume,omitempty"` // for queues: deferred (default) or immediate
+	Concurrency int         `yaml:"concurrency" json:"concurrency,omitempty"`
 	iterations  chan *Iteration
 }
 

--- a/core/dbio/api/spec.go
+++ b/core/dbio/api/spec.go
@@ -360,7 +360,7 @@ type Endpoint struct {
 
 type jsonStream interface {
 	SetOrderedKeys(keys []string) // to maintain column order
-	Flatten() int                // flatten depth, to select flattened field names
+	Flatten() int                 // flatten depth, to select flattened field names
 }
 
 func (ep *Endpoint) SetStateVal(key string, val any) {
@@ -793,6 +793,11 @@ func (ep *Endpoint) setup() (err error) {
 	}
 	ep.context.Unlock()
 
+	// render state templates before the sequence runs
+	if err := baseEndpoint.renderSequenceState(); err != nil {
+		return g.Error(err, "could not render setup state")
+	}
+
 	if err := runSequence(ep.Setup, baseEndpoint); err != nil {
 		return g.Error(err, "endpoint setup failed")
 	}
@@ -845,6 +850,11 @@ func (ep *Endpoint) teardown() (err error) {
 		maps.Copy(baseEndpoint.State, ep.State)
 	}
 	ep.context.Unlock()
+
+	// render state templates before the sequence runs
+	if err := baseEndpoint.renderSequenceState(); err != nil {
+		return g.Error(err, "could not render teardown state")
+	}
 
 	if err := runSequence(ep.Teardown, baseEndpoint); err != nil {
 		return g.Error(err, "endpoint teardown failed")

--- a/core/dbio/api/spec.go
+++ b/core/dbio/api/spec.go
@@ -834,10 +834,14 @@ func (ep *Endpoint) setup() (err error) {
 	array, _ := jmespath.Search("setup", ep.originalMap)
 	baseEndpoint.context.Map.Set("sequence_array", array)
 
-	// copy over state from endpoint with proper locking
+	// copy over state and sync values from endpoint with proper locking
 	ep.context.Lock()
 	if ep.State != nil {
 		maps.Copy(baseEndpoint.State, ep.State)
+	}
+	if ep.syncMap != nil {
+		baseEndpoint.syncMap = make(StateMap)
+		maps.Copy(baseEndpoint.syncMap, ep.syncMap)
 	}
 	ep.context.Unlock()
 
@@ -892,10 +896,14 @@ func (ep *Endpoint) teardown() (err error) {
 		}
 	}
 
-	// copy over state from endpoint with proper locking
+	// copy over state and sync values from endpoint with proper locking
 	ep.context.Lock()
 	if ep.State != nil {
 		maps.Copy(baseEndpoint.State, ep.State)
+	}
+	if ep.syncMap != nil {
+		baseEndpoint.syncMap = make(StateMap)
+		maps.Copy(baseEndpoint.syncMap, ep.syncMap)
 	}
 	ep.context.Unlock()
 

--- a/core/dbio/api/spec.go
+++ b/core/dbio/api/spec.go
@@ -952,6 +952,41 @@ func (iter *Iteration) DetermineStateRenderOrder() (order []string, err error) {
 	return
 }
 
+func (iter *Iteration) renderInitial() (err error) {
+	// set iteration value
+	if iter.field != "" {
+		iter.SetStateVal(iter.field, iter.value)
+	}
+
+	// determine order render
+	order, err := iter.DetermineStateRenderOrder()
+	if err != nil {
+		return g.Error(err, "could not determine render order")
+	}
+
+	// render initial state with proper synchronization
+	for _, k := range order {
+		iter.context.Lock()
+		expr := cast.ToString(iter.state[k])
+		iter.context.Unlock()
+
+		if iter.hasBrackets(expr) {
+			val, err := iter.renderAny(iter.state[k])
+			if err != nil {
+				if strings.Contains(err.Error(), `"require" - input required`) {
+					return g.Error("state variable input was required but not provided: %s = %s", k, expr)
+				}
+				return g.Error(err, "could not render state var (%s) => %s", k, expr)
+			}
+			iter.context.Lock()
+			iter.state[k] = val
+			iter.context.Unlock()
+		}
+	}
+
+	return nil
+}
+
 // Iterate is for configuring looping values for requests
 type Iterate struct {
 	Over        any    `yaml:"over" json:"over,omitempty"` // expression

--- a/core/dbio/api/spec.go
+++ b/core/dbio/api/spec.go
@@ -360,6 +360,7 @@ type Endpoint struct {
 
 type jsonStream interface {
 	SetOrderedKeys(keys []string) // to maintain column order
+	Flatten() int                // flatten depth, to select flattened field names
 }
 
 func (ep *Endpoint) SetStateVal(key string, val any) {

--- a/core/dbio/api/spec.go
+++ b/core/dbio/api/spec.go
@@ -882,6 +882,12 @@ func (ep *Endpoint) teardown() (err error) {
 	return nil
 }
 
+func (iter *Iteration) SetStateVal(key string, val any) {
+	iter.context.Lock()
+	iter.state[key] = val
+	iter.context.Unlock()
+}
+
 func (iter *Iteration) DetermineStateRenderOrder() (order []string, err error) {
 	iter.context.Lock()
 	remaining := lo.Keys(iter.state)

--- a/core/dbio/api/spec.go
+++ b/core/dbio/api/spec.go
@@ -525,6 +525,18 @@ func (ep *Endpoint) Evaluate(expr string, state map[string]interface{}) (result 
 	return ep.eval.Evaluate(expr, state, iop.GlobalFunctionMap)
 }
 
+// renderSequenceState renders the endpoint's state templates in-place, the same
+// way the main request path does via renderInitial().
+func (ep *Endpoint) renderSequenceState() error {
+	iter := &Iteration{
+		id:       g.F("seq.%s", ep.Name),
+		endpoint: ep,
+		state:    ep.State,
+		context:  g.NewContext(ep.context.Ctx),
+	}
+	return iter.renderInitial()
+}
+
 // Names returns names in alphabetical order
 func (eps Endpoints) Names() (names []string) {
 	for _, e := range eps {

--- a/core/dbio/database/database.go
+++ b/core/dbio/database/database.go
@@ -2573,6 +2573,10 @@ func (conn *BaseConn) GenerateDDL(table Table, data iop.Dataset, temporary bool)
 
 		columnDDL := conn.Template().Quote(col.Name) + " " + nativeType
 
+		// explicit DDL declared via the columns: modifier DSL applies at CREATE
+		// time regardless of schema-migration
+		colExplicit := col.IsDDLExplicit() && !temporary
+
 		// Add schema migration attributes when enabled and not temporary
 		if sm.IsEnabled() && !temporary {
 			// Auto-increment (before NOT NULL)
@@ -2581,11 +2585,6 @@ func (conn *BaseConn) GenerateDDL(table Table, data iop.Dataset, temporary bool)
 				if autoIncSyntax != "" {
 					columnDDL += " " + autoIncSyntax
 				}
-			}
-
-			// NOT NULL for non-nullable columns
-			if sm.HasNullableEnabled() && !col.IsNullable() {
-				columnDDL += " NOT NULL"
 			}
 
 			// DEFAULT value (skip for auto-increment columns)
@@ -2600,13 +2599,33 @@ func (conn *BaseConn) GenerateDDL(table Table, data iop.Dataset, temporary bool)
 			}
 		}
 
+		// NOT NULL for non-nullable columns (schema-migration nullable gate OR explicit modifier).
+		dialectNoNotNull := g.In(conn.Self().GetType(), dbio.TypeDbClickhouse, dbio.TypeDbProton)
+		if !temporary && !col.IsNullable() && !dialectNoNotNull && (sm.HasNullableEnabled() || colExplicit) {
+			columnDDL += " NOT NULL"
+		}
+
+		// UNIQUE column constraint (explicit modifier, or schema-migration unique gate)
+		if !temporary && col.HasUniqueConstraint() && (colExplicit || sm.HasUniqueEnabled()) {
+			columnDDL += " UNIQUE"
+		}
+
 		columnsDDL = append(columnsDDL, columnDDL)
 	}
 
 	// Add PRIMARY KEY constraint for columns marked as primary key (when not temporary)
 	if !temporary {
 		var pkCols []string
-		if sm.HasPrimaryKeyEnabled() || sm.HasForeignKeyEnabled() {
+		// explicit PK via columns: DSL applies regardless of schema-migration
+		hasExplicitPK := false
+		for _, col := range columns {
+			if col.IsPrimaryKey() && col.IsDDLExplicit() {
+				hasExplicitPK = true
+				break
+			}
+		}
+
+		if sm.HasPrimaryKeyEnabled() || sm.HasForeignKeyEnabled() || hasExplicitPK {
 			isMySQLLike := conn.Self().GetType().IsMySQLLike()
 			for _, col := range columns {
 				if col.IsPrimaryKey() {

--- a/core/dbio/database/database.go
+++ b/core/dbio/database/database.go
@@ -77,6 +77,7 @@ type Connection interface {
 	CreateTable(tableName string, cols iop.Columns, tableDDL string) (err error)
 	CreateTemporaryTable(tableName string, cols iop.Columns) (err error)
 	CurrentDatabase() (string, error)
+	CurrentSchema() (string, error)
 	Db() *sqlx.DB
 	DbX() *DbX
 	DropTable(...string) error
@@ -1456,6 +1457,11 @@ func (conn *BaseConn) CurrentDatabase() (dbName string, err error) {
 	}
 
 	return
+}
+
+// CurrentSchema returns the name of the current schema
+func (conn *BaseConn) CurrentSchema() (schemaName string, err error) {
+	return conn.GetProp("schema"), nil
 }
 
 // GetDatabases returns databases for given connection

--- a/core/dbio/database/database_bigquery.go
+++ b/core/dbio/database/database_bigquery.go
@@ -298,6 +298,9 @@ func (conn *BigQueryConn) GenerateDDL(table Table, data iop.Dataset, temporary b
 	}
 	sql = strings.ReplaceAll(sql, "{cluster_by}", clusterBy)
 
+	// column descriptions (no general CREATE INDEX in BigQuery)
+	sql = appendColumnComments(strings.TrimSpace(sql), conn, table, data, temporary)
+
 	return strings.TrimSpace(sql), nil
 }
 

--- a/core/dbio/database/database_bigquery.go
+++ b/core/dbio/database/database_bigquery.go
@@ -612,6 +612,7 @@ func (conn *BigQueryConn) importStreamConfig(columns iop.Columns) (config iop.St
 		fileFormat = dbio.FileTypeCsv
 	}
 	config.Format = fileFormat
+	config.BinaryAsHex = fileFormat == dbio.FileTypeCsv
 
 	// set max decimal for only numeric
 	{

--- a/core/dbio/database/database_clickhouse.go
+++ b/core/dbio/database/database_clickhouse.go
@@ -343,7 +343,82 @@ func (conn *ClickhouseConn) GenerateDDL(table Table, data iop.Dataset, temporary
 	}
 	ddl = strings.ReplaceAll(ddl, "{partition_by}", partitionBy)
 
+	// ClickHouse data-skipping indexes are declared inline in CREATE TABLE as
+	// `INDEX <name> <expr> TYPE <type> GRANULARITY <n>` clauses within the
+	// column list, not as separate CREATE INDEX statements.
+	if !temporary {
+		table.Dialect = conn.GetType()
+		ddl = conn.injectInlineIndexes(ddl, &table, data.Columns)
+	}
+
 	return strings.TrimSpace(ddl), nil
+}
+
+// injectInlineIndexes appends ClickHouse INDEX clauses into the CREATE TABLE
+// column list. ClickHouse requires a TYPE and GRANULARITY for each index; when
+// the user omits TYPE we default to minmax with granularity 1.
+func (conn *ClickhouseConn) injectInlineIndexes(ddl string, table *Table, columns iop.Columns) string {
+	indexes := table.Indexes(columns)
+	if len(indexes) == 0 {
+		return ddl
+	}
+
+	clauses := []string{}
+	for _, ti := range indexes {
+		def := ti.Def
+		if len(def.Columns) == 0 && def.Expression == "" {
+			continue
+		}
+
+		// warn for unsupported attributes (where/include/unique are no-ops)
+		if def.Where != "" {
+			g.Warn("index %q: clickhouse does not support partial-index 'where'; clause ignored", def.Name)
+		}
+		if len(def.Include) > 0 {
+			g.Warn("index %q: clickhouse does not support covering-index 'include'; clause ignored", def.Name)
+		}
+		if def.Unique {
+			g.Warn("index %q: clickhouse data-skipping indexes are not unique; 'unique' ignored", def.Name)
+		}
+
+		// expression: prefer Expression, else the (comma-joined) column list
+		expr := def.Expression
+		if expr == "" {
+			parts := []string{}
+			for _, c := range def.Columns {
+				if isIndexExpression(c.Name) {
+					parts = append(parts, c.Name)
+				} else {
+					parts = append(parts, conn.Self().Quote(c.Name))
+				}
+			}
+			expr = strings.Join(parts, ", ")
+			if len(parts) > 1 {
+				expr = "(" + expr + ")"
+			}
+		}
+
+		idxType := def.Type
+		if idxType == "" {
+			idxType = "minmax"
+		}
+
+		clauses = append(clauses, g.F("INDEX %s %s TYPE %s GRANULARITY 1", conn.Self().Quote(def.Name), expr, idxType))
+	}
+
+	if len(clauses) == 0 {
+		return ddl
+	}
+
+	// inject before the closing paren of the column list: find ") engine="
+	marker := ") engine="
+	idx := strings.Index(strings.ToLower(ddl), marker)
+	if idx < 0 {
+		g.Warn("could not inject clickhouse inline indexes (unexpected DDL shape)")
+		return ddl
+	}
+	injection := ",\n  " + strings.Join(clauses, ",\n  ")
+	return ddl[:idx] + injection + ddl[idx:]
 }
 
 // BulkImportStream inserts a stream into a table
@@ -659,8 +734,12 @@ func processClickhouseInsertRow(columns iop.Columns, row []any) []any {
 func (conn *ClickhouseConn) GetNativeType(col iop.Column) (nativeType string, err error) {
 	nativeType, err = conn.BaseConn.GetNativeType(col)
 
-	// remove Nullable if part of pk
-	if col.IsKeyType(iop.PrimaryKey) && strings.HasPrefix(nativeType, "Nullable(") {
+	// ClickHouse has no separate NOT NULL clause; non-nullability is expressed by
+	// the absence of the Nullable(T) wrapper. Strip it when the column is part of
+	// the primary key, or explicitly declared not_null via the columns: DSL.
+	// This directly addresses the Discord report (not_null -> Nullable(UUID)).
+	notNull := col.IsKeyType(iop.PrimaryKey) || (col.IsDDLExplicit() && !col.IsNullable())
+	if notNull && strings.HasPrefix(nativeType, "Nullable(") {
 		nativeType = strings.TrimPrefix(nativeType, "Nullable(")
 		nativeType = strings.TrimSuffix(nativeType, ")")
 	}

--- a/core/dbio/database/database_d1.go
+++ b/core/dbio/database/database_d1.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -61,10 +62,24 @@ func (conn *D1Conn) makeRequest(ctx context.Context, method, route string, body 
 		URL = g.F("%s/%s/d1/database/%s/%s", urlBase, conn.AccountID, conn.UUID, route)
 	}
 
+	// buffer body for potential retries (readers are single-use)
+	var bodyBytes []byte
+	if body != nil {
+		bodyBytes, err = io.ReadAll(body)
+		if err != nil {
+			return nil, g.Error(err, "could not read request body for %s @ %s", method, URL)
+		}
+	}
+
 retry:
 	tries++
 	g.Trace("request #%d for %s @ %s", tries, method, URL)
-	req, err := http.NewRequestWithContext(ctx, method, URL, body)
+
+	var reqBody io.Reader
+	if bodyBytes != nil {
+		reqBody = bytes.NewReader(bodyBytes)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, URL, reqBody)
 	if err != nil {
 		return nil, g.Error(err, "could not make request for %s @ %s", method, URL)
 	}
@@ -79,16 +94,24 @@ retry:
 		return
 	}
 
-	// retry logic
+	// retry logic for transient server errors / rate limits
 	if (resp.StatusCode >= 502 || resp.StatusCode == 429) && tries <= 4 {
 		delay := tries * 5
 		g.Debug("d1 request failed %d: %s. Retrying in %d seconds.", resp.StatusCode, resp.Status, delay)
+		// drain and close body before retry to avoid leaks
+		if resp.Body != nil {
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}
 		time.Sleep(time.Duration(delay * int(time.Second)))
 		goto retry
 	}
 
 	if resp.StatusCode >= 400 || resp.StatusCode < 200 {
 		respBytes, _ := io.ReadAll(resp.Body)
+		if resp.Body != nil {
+			resp.Body.Close()
+		}
 		err = g.Error("Unexpected Response %d: %s (%s) => %s", resp.StatusCode, resp.Status, URL, string(respBytes))
 		return
 	}
@@ -152,6 +175,9 @@ func (conn *D1Conn) GetDatabases() (data iop.Dataset, err error) {
 	}
 
 	respBytes, err := io.ReadAll(resp.Body)
+	if resp.Body != nil {
+		resp.Body.Close()
+	}
 	if err != nil {
 		return data, g.Error(err, "could not read from request body")
 	}
@@ -179,7 +205,7 @@ type d1ExecResponse struct {
 	Result  []struct {
 		Meta struct {
 			ServedBy    string  `json:"served_by"`
-			Duration    float64 `json:"uuid"`
+			Duration    float64 `json:"duration"`
 			Changes     int64   `json:"changes"`
 			LastRowID   any     `json:"last_row_id"`
 			ChangedDB   bool    `json:"changed_db"`
@@ -236,6 +262,9 @@ func (conn *D1Conn) ExecContext(ctx context.Context, q string, args ...interface
 	}
 
 	respBytes, err := io.ReadAll(resp.Body)
+	if resp.Body != nil {
+		resp.Body.Close()
+	}
 	if err != nil {
 		return nil, g.Error(err, "could not read from request body")
 	}
@@ -285,10 +314,14 @@ func (conn *D1Conn) StreamRowsContext(ctx context.Context, query string, options
 	// g.Warn(string(respBytes))
 	// return nil, g.Error("stopping")
 
-	decoder := json.NewDecoder(resp.Body)
+	respBody := resp.Body
+	decoder := json.NewDecoder(respBody)
 
 	// Read opening object
 	if t, err := decoder.Token(); err != nil || t != json.Delim('{') {
+		if respBody != nil {
+			respBody.Close()
+		}
 		return nil, g.Error(err, "invalid JSON structure: expected opening brace")
 	}
 
@@ -350,8 +383,6 @@ func (conn *D1Conn) StreamRowsContext(ctx context.Context, query string, options
 						t, err = decoder.Token()
 						if err != nil || cast.ToString(t) != "rows" {
 							return nil, g.Error(err, "invalid JSON structure: expected rows array inside results")
-						} else if cast.ToString(t) != "rows" {
-							return nil, g.Error("invalid JSON structure: expected rows array inside results")
 						}
 
 						// Read opening bracket of rows array
@@ -405,6 +436,9 @@ func (conn *D1Conn) StreamRowsContext(ctx context.Context, query string, options
 
 	nextFunc, err := makeNextFunc()
 	if err != nil {
+		if respBody != nil {
+			respBody.Close()
+		}
 		return ds, err
 	}
 
@@ -412,10 +446,16 @@ func (conn *D1Conn) StreamRowsContext(ctx context.Context, query string, options
 	ds.NoDebug = strings.Contains(query, noDebugKey)
 	ds.SetMetadata(conn.GetProp("METADATA"))
 	ds.SetConfig(conn.Props())
+	if respBody != nil {
+		ds.Defer(func() { respBody.Close() })
+	}
 
 	err = ds.Start()
 	if err != nil {
 		queryContext.Cancel()
+		if respBody != nil {
+			respBody.Close()
+		}
 		return ds, g.Error(err, "could start datastream")
 	}
 

--- a/core/dbio/database/database_databricks.go
+++ b/core/dbio/database/database_databricks.go
@@ -680,6 +680,9 @@ func (conn *DatabricksConn) GenerateDDL(table Table, data iop.Dataset, temporary
 		sql += clusterBy
 	}
 
+	// column comments (Delta has no secondary CREATE INDEX)
+	sql = appendColumnComments(strings.TrimSpace(sql), conn, table, data, temporary)
+
 	return strings.TrimSpace(sql) + ";", nil
 }
 

--- a/core/dbio/database/database_duckdb.go
+++ b/core/dbio/database/database_duckdb.go
@@ -78,6 +78,24 @@ func (conn *DuckDbConn) DuckDb() *iop.DuckDb {
 	return conn.duck
 }
 
+// GenerateDDL builds the CREATE TABLE plus post-CREATE indexes and column
+// comments (covers DuckDB and MotherDuck).
+func (conn *DuckDbConn) GenerateDDL(table Table, data iop.Dataset, temporary bool) (string, error) {
+	ddl, err := conn.BaseConn.GenerateDDL(table, data, temporary)
+	if err != nil {
+		return ddl, g.Error(err)
+	}
+
+	ddl, err = table.AddPrimaryKeyToDDL(ddl, data.Columns)
+	if err != nil {
+		return ddl, g.Error(err)
+	}
+
+	ddl = appendIndexesAndComments(strings.TrimSpace(ddl), conn, table, data, temporary)
+
+	return strings.TrimSpace(ddl), nil
+}
+
 func (conn *DuckDbConn) dbPath() (string, error) {
 	dbPathU, err := net.NewURL(conn.GetURL())
 	if err != nil {

--- a/core/dbio/database/database_mysql.go
+++ b/core/dbio/database/database_mysql.go
@@ -542,6 +542,7 @@ func (conn *MySQLConn) LoadDataLocal(tableFName string, ds *iop.Datastream) (cou
 	cfg := iop.LoaderStreamConfig(true)
 	cfg.BoolAsInt = true
 	cfg.EscapeBackslash = true
+	cfg.BinaryAsHex = true
 
 	// Each batch in the datastream needs its own LOAD DATA LOCAL INFILE execution,
 	// because the reader handler is consumed once per Exec. Without a per-batch loop,
@@ -549,10 +550,36 @@ func (conn *MySQLConn) LoadDataLocal(tableFName string, ds *iop.Datastream) (cou
 	// is silently dropped.
 	defer mysql.DeregisterReaderHandler(handlerName)
 
+	// binary columns are hex-encoded in the CSV (BinaryAsHex), so read them
+	// into positional @vars and decode via UNHEX on load
+	columnsSpec := ""
+	hasBinary := false
+	for _, col := range ds.Columns {
+		if col.IsBinary() {
+			hasBinary = true
+			break
+		}
+	}
+	if hasBinary {
+		fields := make([]string, len(ds.Columns))
+		sets := []string{}
+		for i, col := range ds.Columns {
+			if col.IsBinary() {
+				varName := g.F("@v%d", i)
+				fields[i] = varName
+				sets = append(sets, g.F("%s = UNHEX(%s)", conn.Quote(col.Name), varName))
+			} else {
+				fields[i] = conn.Quote(col.Name)
+			}
+		}
+		columnsSpec = g.F("\n(%s)\nSET %s", strings.Join(fields, ", "), strings.Join(sets, ", "))
+	}
+
 	tmpl := conn.GetTemplateValue("core.load_data_local_reader")
 	loadQuery := g.R(tmpl,
 		"handler_name", handlerName,
 		"table", tableFName,
+		"columns_spec", columnsSpec,
 	)
 	g.Trace("LoadDataLocal query: %s", loadQuery)
 

--- a/core/dbio/database/database_mysql.go
+++ b/core/dbio/database/database_mysql.go
@@ -388,8 +388,17 @@ func (conn *MySQLConn) GenerateDDL(table Table, data iop.Dataset, temporary bool
 		return ddl, g.Error(err)
 	}
 
-	for _, index := range table.Indexes(data.Columns) {
-		ddl = ddl + ";\n" + index.CreateDDL()
+	// indexes & comments only on the final table (see note in postgres GenerateDDL)
+	if !temporary {
+		for _, index := range table.Indexes(data.Columns) {
+			if idxDDL := index.CreateDDL(); idxDDL != "" {
+				ddl = ddl + ";\n" + idxDDL
+			}
+		}
+
+		for _, stmt := range table.ColumnCommentsDDL(conn, data.Columns) {
+			ddl = ddl + ";\n" + stmt
+		}
 	}
 
 	return ddl, nil

--- a/core/dbio/database/database_oracle.go
+++ b/core/dbio/database/database_oracle.go
@@ -219,12 +219,19 @@ func (conn *OracleConn) GenerateDDL(table Table, data iop.Dataset, temporary boo
 		return ddl, g.Error(err)
 	}
 
-	for _, index := range table.Indexes(data.Columns) {
-		ddl = strings.ReplaceAll(
-			ddl,
-			"EXCEPTION",
-			g.F("EXECUTE IMMEDIATE '%s';\nEXCEPTION", index.CreateDDL()),
-		)
+	// indexes only on the final table (see note in postgres GenerateDDL)
+	if !temporary {
+		for _, index := range table.Indexes(data.Columns) {
+			idxDDL := index.CreateDDL()
+			if idxDDL == "" {
+				continue
+			}
+			ddl = strings.ReplaceAll(
+				ddl,
+				"EXCEPTION",
+				g.F("EXECUTE IMMEDIATE '%s';\nEXCEPTION", idxDDL),
+			)
+		}
 	}
 
 	return ddl, nil

--- a/core/dbio/database/database_oracle.go
+++ b/core/dbio/database/database_oracle.go
@@ -447,6 +447,23 @@ retry:
 	return ds.Count, err
 }
 
+// CurrentSchema returns the name of the current schema
+func (conn *OracleConn) CurrentSchema() (schemaName string, err error) {
+	if schemaName = conn.GetProp("schema"); schemaName != "" {
+		return schemaName, nil
+	}
+
+	data, err := conn.Query("SELECT SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA') FROM dual")
+	if err != nil {
+		return schemaName, g.Error(err)
+	}
+
+	schemaName = cast.ToString(data.Rows[0][0])
+	conn.SetProp("schema", schemaName)
+
+	return schemaName, nil
+}
+
 func (conn *OracleConn) getColumnsString(ds *iop.Datastream, tgtColumns ...iop.Columns) string {
 	// build lookup of target column length by name (from GetColumns/metadata)
 	tgtLength := map[string]int{}

--- a/core/dbio/database/database_postgres.go
+++ b/core/dbio/database/database_postgres.go
@@ -338,8 +338,16 @@ func (conn *PostgresConn) GenerateDDL(table Table, data iop.Dataset, temporary b
 	}
 	ddl = strings.ReplaceAll(ddl, "{partition_by}", partitionBy)
 
-	for _, index := range table.Indexes(data.Columns) {
-		ddl = ddl + ";\n" + index.CreateDDL()
+	if !temporary {
+		for _, index := range table.Indexes(data.Columns) {
+			if idxDDL := index.CreateDDL(); idxDDL != "" {
+				ddl = ddl + ";\n" + idxDDL
+			}
+		}
+
+		for _, stmt := range table.ColumnCommentsDDL(conn, data.Columns) {
+			ddl = ddl + ";\n" + stmt
+		}
 	}
 
 	return strings.TrimSpace(ddl), nil

--- a/core/dbio/database/database_redshift.go
+++ b/core/dbio/database/database_redshift.go
@@ -82,6 +82,9 @@ func (conn *RedshiftConn) GenerateDDL(table Table, data iop.Dataset, temporary b
 	}
 	sql = strings.ReplaceAll(sql, "{sort_key}", sortKey)
 
+	// column comments (Redshift has no secondary indexes)
+	sql = appendColumnComments(strings.TrimSpace(sql), conn, table, data, temporary)
+
 	return strings.TrimSpace(sql), nil
 }
 

--- a/core/dbio/database/database_snowflake.go
+++ b/core/dbio/database/database_snowflake.go
@@ -163,15 +163,22 @@ func (conn *SnowflakeConn) Connect(timeOut ...int) error {
 	return err
 }
 
-func getEncodedPrivateKey(pemStr, passphrase string) (epk string, err error) {
-	block, _ := pem.Decode([]byte(pemStr))
-	if block == nil {
-		return "", g.Error("invalid private key data: no PEM block found or missing file")
+func getEncodedPrivateKey(keyStr, passphrase string) (epk string, err error) {
+	keyStr = strings.TrimSpace(keyStr)
+
+	// Normalize the input into raw DER (PKCS#8) bytes.
+	var derBytes []byte
+	if block, _ := pem.Decode([]byte(keyStr)); block != nil {
+		derBytes = block.Bytes
+	} else if b := decodeBase64Any(keyStr); len(b) > 0 {
+		derBytes = b
+	} else {
+		derBytes = []byte(keyStr)
 	}
 
-	key, err := pkcs8.ParsePKCS8PrivateKey(block.Bytes, []byte(passphrase))
+	key, err := pkcs8.ParsePKCS8PrivateKey(derBytes, []byte(passphrase))
 	if err != nil {
-		return "", g.Error(err, "could not parse key")
+		return "", g.Error(err, "could not parse private key (expected PEM, base64-encoded DER, or raw DER PKCS#8)")
 	}
 
 	privKeyPem, err := pkcs8.MarshalPrivateKey(key, nil, nil)
@@ -180,6 +187,22 @@ func getEncodedPrivateKey(pemStr, passphrase string) (epk string, err error) {
 	}
 
 	return base64.URLEncoding.EncodeToString(privKeyPem), nil
+}
+
+// decodeBase64Any attempts to base64-decode s using the standard and URL
+// alphabets, with and without padding.
+func decodeBase64Any(s string) []byte {
+	for _, enc := range []*base64.Encoding{
+		base64.StdEncoding,
+		base64.RawStdEncoding,
+		base64.URLEncoding,
+		base64.RawURLEncoding,
+	} {
+		if b, err := enc.DecodeString(s); err == nil && len(b) > 0 {
+			return b
+		}
+	}
+	return nil
 }
 
 func (conn *SnowflakeConn) getOrCreateStage(schema string) string {

--- a/core/dbio/database/database_snowflake.go
+++ b/core/dbio/database/database_snowflake.go
@@ -234,6 +234,9 @@ func (conn *SnowflakeConn) GenerateDDL(table Table, data iop.Dataset, temporary 
 	}
 	sql = strings.ReplaceAll(sql, "{cluster_by}", clusterBy)
 
+	// column comments (Snowflake has no secondary indexes)
+	sql = appendIndexesAndComments(strings.TrimSpace(sql), conn, table, data, temporary)
+
 	return strings.TrimSpace(sql), nil
 }
 

--- a/core/dbio/database/database_snowflake.go
+++ b/core/dbio/database/database_snowflake.go
@@ -819,10 +819,12 @@ func (conn *SnowflakeConn) CopyViaStage(table Table, df *iop.Dataflow) (count ui
 		switch fileFormat {
 		case dbio.FileTypeCsv:
 			config.Header = true
+			config.BinaryAsHex = true
 			config.Delimiter = ","
 			_, err = fs.WriteDataflowReady(df, folderPath, fileReadyChn, config)
 		case dbio.FileTypeParquet:
 			if env.UseDuckDbCompute() {
+				config.BinaryAsHex = true
 				_, err = filesys.WriteDataflowReadyViaDuckDB(fs, df, folderPath, fileReadyChn, config)
 			} else {
 				_, err = fs.WriteDataflowReady(df, folderPath, fileReadyChn, config)

--- a/core/dbio/database/database_sqlite.go
+++ b/core/dbio/database/database_sqlite.go
@@ -68,9 +68,16 @@ func (conn *SQLiteConn) GenerateDDL(table Table, data iop.Dataset, temporary boo
 		return ddl, g.Error(err)
 	}
 
-	for _, index := range table.Indexes(data.Columns) {
-		indexDDL := strings.ReplaceAll(index.CreateDDL(), table.FDQN(), table.NameQ()) // doesn't like FDQN
-		ddl = ddl + ";\n" + indexDDL
+	// indexes only on the final table (see note in postgres GenerateDDL)
+	if !temporary {
+		for _, index := range table.Indexes(data.Columns) {
+			idxDDL := index.CreateDDL()
+			if idxDDL == "" {
+				continue
+			}
+			indexDDL := strings.ReplaceAll(idxDDL, table.FDQN(), table.NameQ()) // doesn't like FDQN
+			ddl = ddl + ";\n" + indexDDL
+		}
 	}
 
 	return ddl, nil

--- a/core/dbio/database/database_sqlserver.go
+++ b/core/dbio/database/database_sqlserver.go
@@ -503,8 +503,16 @@ func (conn *MsSQLServerConn) GenerateDDL(table Table, data iop.Dataset, temporar
 		return ddl, g.Error(err)
 	}
 
-	for _, index := range table.Indexes(data.Columns) {
-		ddl = ddl + ";\n" + index.CreateDDL()
+	if !temporary {
+		for _, index := range table.Indexes(data.Columns) {
+			if idxDDL := index.CreateDDL(); idxDDL != "" {
+				ddl = ddl + ";\n" + idxDDL
+			}
+		}
+
+		for _, stmt := range table.ColumnCommentsDDL(conn, data.Columns) {
+			ddl = ddl + ";\n" + stmt
+		}
 	}
 
 	return ddl, nil

--- a/core/dbio/database/database_sqlserver.go
+++ b/core/dbio/database/database_sqlserver.go
@@ -638,6 +638,7 @@ func (conn *MsSQLServerConn) BcpImportFileParrallel(tableFName string, ds *iop.D
 	}
 
 	var boolCols []int
+	hasBinaryCol := false
 	insColMap := insCols.Map()
 	for i, col := range ds.Columns {
 		insCol := g.PtrVal(insColMap[col.Name])
@@ -648,7 +649,14 @@ func (conn *MsSQLServerConn) BcpImportFileParrallel(tableFName string, ds *iop.D
 			if insCol.IsBool() || insCol.IsInteger() {
 				boolCols = append(boolCols, i)
 			}
+		case insCol.IsBinary():
+			hasBinaryCol = true
 		}
+	}
+
+	// hex-encode binary columns; bcp -w decodes the hex text into varbinary on load
+	if hasBinaryCol {
+		ds.Sp.Config.BinaryAsHex = true
 	}
 
 	// transformation to correctly post process quotes, newlines, and delimiter afterwards
@@ -810,6 +818,28 @@ func (conn *MsSQLServerConn) BcpImportFileParrallel(tableFName string, ds *iop.D
 	}
 
 	return ds.Count, ds.Err()
+}
+
+// processSQLServerInsertRow ensures binary column values are bound as []byte
+// so the driver sends them as varbinary instead of nvarchar
+func processSQLServerInsertRow(columns iop.Columns, row []any) []any {
+	for i := range row {
+		if i >= len(columns) || !columns[i].IsBinary() {
+			continue
+		}
+		switch v := row[i].(type) {
+		case nil:
+			// typed nil so the driver declares varbinary, not nvarchar(1)
+			row[i] = []byte(nil)
+		case []byte:
+			// already bytes
+		case string:
+			row[i] = []byte(v)
+		default:
+			row[i] = []byte(cast.ToString(v))
+		}
+	}
+	return row
 }
 
 func (conn *MsSQLServerConn) bcpPath() string {

--- a/core/dbio/database/database_starrocks.go
+++ b/core/dbio/database/database_starrocks.go
@@ -415,6 +415,9 @@ func (conn *StarRocksConn) GenerateDDL(table Table, data iop.Dataset, temporary 
 	}
 	ddl = strings.ReplaceAll(ddl, "{distribution}", distribution)
 
+	// inline column comments (StarRocks' post-CREATE ALTER ... COMMENT is async)
+	ddl = conn.injectInlineColumnComments(ddl, data.Columns, "`", temporary)
+
 	return ddl, nil
 }
 
@@ -660,4 +663,94 @@ func (conn *StarRocksConn) GetDatabases() (data iop.Dataset, err error) {
 	data1.Columns[0].Name = "name" // rename
 
 	return data1, nil
+}
+
+// injectInlineColumnComments adds an inline COMMENT '<desc>' to each described
+// column definition, for dialects whose post-CREATE comment path is async/stale
+func (conn *StarRocksConn) injectInlineColumnComments(ddl string, columns iop.Columns, quoteChar string, temporary bool) string {
+	if temporary {
+		return ddl
+	}
+
+	// build lookup of described columns (escaped)
+	comments := map[string]string{}
+	for _, col := range columns {
+		if !col.IsDDLExplicit() {
+			continue
+		}
+		description := col.Metadata[iop.ColMetaDescription.String()]
+		if description == "" {
+			description = col.Description
+		}
+		if description == "" {
+			continue
+		}
+		comments[col.Name] = strings.ReplaceAll(description, "'", "''")
+	}
+	if len(comments) == 0 {
+		return ddl
+	}
+
+	createIdx := strings.Index(strings.ToUpper(ddl), "CREATE TABLE")
+	if createIdx == -1 {
+		return ddl
+	}
+	openParen := strings.Index(ddl[createIdx:], "(")
+	if openParen == -1 {
+		return ddl
+	}
+	openParen += createIdx
+
+	// find the matching closing paren of the column list (balanced)
+	depth := 0
+	closeParen := -1
+	for i := openParen; i < len(ddl); i++ {
+		switch ddl[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				closeParen = i
+			}
+		}
+		if closeParen != -1 {
+			break
+		}
+	}
+	if closeParen == -1 {
+		return ddl
+	}
+
+	body := ddl[openParen+1 : closeParen]
+
+	// split body on top-level commas (parens-aware)
+	var entries []string
+	d, start := 0, 0
+	for i := 0; i < len(body); i++ {
+		switch body[i] {
+		case '(':
+			d++
+		case ')':
+			d--
+		case ',':
+			if d == 0 {
+				entries = append(entries, body[start:i])
+				start = i + 1
+			}
+		}
+	}
+	entries = append(entries, body[start:])
+
+	for idx, entry := range entries {
+		trimmed := strings.TrimSpace(entry)
+		for name, desc := range comments {
+			if strings.HasPrefix(trimmed, quoteChar+name+quoteChar) {
+				entries[idx] = strings.TrimRight(entry, " \t") + g.F(" COMMENT '%s'", desc)
+				break
+			}
+		}
+	}
+
+	return ddl[:openParen+1] + strings.Join(entries, ",") + ddl[closeParen:]
 }

--- a/core/dbio/database/schemata.go
+++ b/core/dbio/database/schemata.go
@@ -1220,21 +1220,19 @@ func (t *Table) ColumnCommentsDDL(conn Connection, columns iop.Columns) (stmts [
 	return stmts
 }
 
+var createTableRegex = regexp.MustCompile(`(?i)create\s+(?:temp\s+|temporary\s+)?table`)
+
 func (t *Table) AddPrimaryKeyToDDL(ddl string, columns iop.Columns) (string, error) {
 
 	if pkCols := columns.GetKeys(iop.PrimaryKey); len(pkCols) > 0 {
 		ddl = strings.TrimSpace(ddl)
 
-		// Find the closing parenthesis of the column definitions
-		// We need to find the first balanced closing paren that matches the opening
-		// paren of the CREATE TABLE column list, not just the last paren in the DDL
-		// This handles cases like: CREATE TABLE t (col1 int) WITH (data_compression=page)
-
-		// Find "CREATE TABLE" pattern to locate start of statement
-		createTableIdx := strings.Index(strings.ToUpper(ddl), "CREATE TABLE")
-		if createTableIdx == -1 {
+		// anchor on the CREATE [TEMP|TEMPORARY] TABLE keyword to start the column-list search
+		loc := createTableRegex.FindStringIndex(ddl)
+		if loc == nil {
 			return ddl, g.Error("could not find CREATE TABLE in DDL")
 		}
+		createTableIdx := loc[0]
 
 		// Find the opening paren after CREATE TABLE (this is the column list)
 		openParen := strings.Index(ddl[createTableIdx:], "(")

--- a/core/dbio/database/schemata.go
+++ b/core/dbio/database/schemata.go
@@ -137,6 +137,11 @@ func (t *Table) SetKeys(sourcePKCols []string, updateCol string, tableKeys Table
 
 	if tkMap := tableKeys; tkMap != nil {
 		for tableKey, keys := range tkMap {
+			if tableKey == iop.IndexKey {
+				// index DDL is driven by ParseIndexes (which supports composite)
+				eG.Capture(t.Columns.SetKeys(tableKey, tableKeys.IndexColumnNames()...))
+				continue
+			}
 			eG.Capture(t.Columns.SetKeys(tableKey, keys...))
 		}
 	}
@@ -524,8 +529,6 @@ func (t *Table) Select(Opts ...SelectOptions) (sql string) {
 
 	return
 }
-
-type TableKeys map[iop.KeyType][]string
 
 // Database represents a schemata database
 type Database struct {
@@ -1168,6 +1171,55 @@ func GetSchemataAll(conn Connection) (schemata Schemata, err error) {
 }
 
 // AddPrimaryKeyToDDL adds a primary key to the table
+// ColumnCommentsDDL returns COMMENT/description statements for columns that
+// carry an explicit description (set via the `description(...)` column modifier).
+// These are applied post-CREATE so that descriptions render on fresh tables even
+// when schema-migration is disabled. Returns an empty slice when the dialect has
+// no add_column_comment template or no explicit descriptions exist.
+func (t *Table) ColumnCommentsDDL(conn Connection, columns iop.Columns) (stmts []string) {
+	addCommentTemplate := conn.Template().Core["add_column_comment"]
+	if addCommentTemplate == "" {
+		return nil
+	}
+
+	for _, col := range columns {
+		// only apply for columns that explicitly declared a description via the modifier DSL
+		if !col.IsDDLExplicit() {
+			continue
+		}
+		description := col.Metadata[iop.ColMetaDescription.String()]
+		if description == "" {
+			description = col.Description
+		}
+		if description == "" {
+			continue
+		}
+
+		// Escape single quotes
+		escapedDesc := strings.ReplaceAll(description, "'", "''")
+
+		// For MySQL/MariaDB the template needs the full column type definition
+		colType := col.DbType
+		if g.In(conn.GetType(), dbio.TypeDbMySQL, dbio.TypeDbMariaDB) {
+			if nativeType, err := conn.Self().GetNativeType(col); err == nil {
+				colType = nativeType
+			}
+		}
+
+		stmt := g.R(
+			addCommentTemplate,
+			"table", t.FullName(),
+			"schema", t.Schema,
+			"table_name", t.Name,
+			"column", col.Name,
+			"comment", "'"+escapedDesc+"'",
+			"type", colType,
+		)
+		stmts = append(stmts, stmt)
+	}
+	return stmts
+}
+
 func (t *Table) AddPrimaryKeyToDDL(ddl string, columns iop.Columns) (string, error) {
 
 	if pkCols := columns.GetKeys(iop.PrimaryKey); len(pkCols) > 0 {
@@ -1228,102 +1280,6 @@ func (t *Table) AddPrimaryKeyToDDL(ddl string, columns iop.Columns) (string, err
 	}
 
 	return ddl, nil
-}
-
-type TableIndex struct {
-	Name    string
-	Columns iop.Columns
-	Unique  bool
-	Table   *Table
-}
-
-func (ti *TableIndex) CreateDDL() string {
-	dialect := ti.Table.Dialect
-	quotedNames := dialect.QuoteNames(ti.Columns.Names()...)
-
-	if ti.Unique {
-		return g.R(
-			dialect.GetTemplateValue("core.create_unique_index"),
-			"index", dialect.Quote(ti.Name),
-			"table", ti.Table.FDQN(),
-			"cols", strings.Join(quotedNames, ", "),
-		)
-	}
-
-	return g.R(
-		dialect.GetTemplateValue("core.create_index"),
-		"index", dialect.Quote(ti.Name),
-		"table", ti.Table.FDQN(),
-		"cols", strings.Join(quotedNames, ", "),
-	)
-}
-
-func (ti *TableIndex) DropDDL() string {
-	dialect := ti.Table.Dialect
-
-	return g.R(
-		dialect.GetTemplateValue("core.drop_index"),
-		"index", dialect.Quote(ti.Name),
-		"name", ti.Name,
-		"table", ti.Table.FDQN(),
-		"schema", ti.Table.SchemaQ(),
-	)
-}
-
-func (t *Table) Indexes(columns iop.Columns) (indexes []TableIndex) {
-
-	// TODO: composite column indexes not yet supported
-	// if indexSet := columns.GetKeys(iop.IndexKey); len(indexSet) > 0 {
-
-	// 	// create index name from the first 6 chars of each column name
-	// 	indexNameParts := []string{strings.ToLower(t.Name)}
-	// 	for _, col := range indexSet.Names() {
-	// 		if len(col) < 6 {
-	// 			indexNameParts = append(indexNameParts, col)
-	// 		} else {
-	// 			indexNameParts = append(indexNameParts, col[:6])
-	// 		}
-	// 	}
-
-	// 	index := TableIndex{
-	// 		Name:    strings.Join(indexNameParts, "_"),
-	// 		Columns: indexSet,
-	// 		Unique:  false,
-	// 		Table:   t,
-	// 	}
-
-	// 	indexes = append(indexes, index)
-	// }
-
-	// normal index
-	for _, col := range columns.GetKeys(iop.IndexKey) {
-
-		indexNameParts := []string{strings.ToLower(t.Name), strings.ToLower(col.Name)}
-		index := TableIndex{
-			Name:    strings.Join(indexNameParts, "_"),
-			Columns: iop.Columns{col},
-			Unique:  false,
-			Table:   t,
-		}
-
-		indexes = append(indexes, index)
-	}
-
-	// unique index
-	for _, col := range columns.GetKeys(iop.UniqueKey) {
-
-		indexNameParts := []string{strings.ToLower(t.Name), strings.ToLower(col.Name)}
-		index := TableIndex{
-			Name:    strings.Join(indexNameParts, "_"),
-			Columns: iop.Columns{col},
-			Unique:  true,
-			Table:   t,
-		}
-
-		indexes = append(indexes, index)
-	}
-
-	return
 }
 
 // getColumnTypes recovers from ColumnTypes panics
@@ -1590,6 +1546,7 @@ type SchemaMigrator interface {
 	HasAutoIncrementEnabled() bool
 	HasNullableEnabled() bool
 	HasDefaultValueEnabled() bool
+	HasUniqueEnabled() bool
 	IsEnabled() bool
 }
 
@@ -1633,6 +1590,10 @@ func (d *dummySchemaMigrator) HasNullableEnabled() bool {
 }
 
 func (d *dummySchemaMigrator) HasDefaultValueEnabled() bool {
+	return false
+}
+
+func (d *dummySchemaMigrator) HasUniqueEnabled() bool {
 	return false
 }
 

--- a/core/dbio/database/schemata.go
+++ b/core/dbio/database/schemata.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"regexp"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"sync"
 	"unicode"
@@ -316,10 +317,43 @@ func (t *Table) Select(Opts ...SelectOptions) (sql string) {
 	whereClause := lo.Ternary(opts.Where != "", g.F(" where (%s)", opts.Where), "")
 	whereAnd := lo.Ternary(opts.Where != "", g.F(" and (%s)", opts.Where), "")
 
+	shouldQuote := func(f string) bool {
+		f = strings.TrimSpace(f)
+
+		switch {
+		case strings.Contains(f, "(") || strings.EqualFold(f, "null"):
+			return false
+		case strings.EqualFold(f, "false") || strings.EqualFold(f, "true"):
+			return false
+		case strings.Contains(f, "'"):
+			// string literal (e.g. 'N/A' as status)
+			return false
+		case strings.HasPrefix(f, GetQualifierQuote(t.Dialect)):
+			// already quoted identifier
+			return false
+		case g.In(strings.ToLower(f),
+			"current_date", "current_timestamp", "current_time", "now",
+			"current_user", "session_user", "localtime", "localtimestamp", "default"):
+			// bare keyword expressions (no parens)
+			return false
+		case strings.HasPrefix(strings.ToLower(f), "case "):
+			// CASE ... END expression
+			return false
+		case strings.Contains(f, "::"):
+			// cast shorthand (e.g. 0::int)
+			return false
+		}
+		// check if number
+		if _, parseNumErr := strconv.ParseFloat(f, 64); parseNumErr == nil {
+			return false
+		}
+		return true
+	}
+
 	fields = lo.Map(fields, func(f string, i int) string {
 		q := GetQualifierQuote(t.Dialect)
 		f = strings.TrimSpace(f)
-		if f == "*" || strings.Contains(f, "(") {
+		if f == "*" || !shouldQuote(f) {
 			return f
 		}
 
@@ -329,6 +363,11 @@ func (t *Table) Select(Opts ...SelectOptions) (sql string) {
 			// Generate: "original_col" AS "alias_name"
 			origQuoted := q + strings.ReplaceAll(original, q, "") + q
 			aliasQuoted := q + strings.ReplaceAll(alias, q, "") + q
+
+			if !shouldQuote(original) {
+				return original + " as " + aliasQuoted
+			}
+
 			return origQuoted + " as " + aliasQuoted
 		}
 		return q + strings.ReplaceAll(f, q, "") + q

--- a/core/dbio/database/schemata_keys.go
+++ b/core/dbio/database/schemata_keys.go
@@ -1,0 +1,601 @@
+package database
+
+import (
+	"strings"
+
+	"github.com/flarco/g"
+	"github.com/slingdata-io/sling-cli/core/dbio"
+	"github.com/slingdata-io/sling-cli/core/dbio/iop"
+	"github.com/spf13/cast"
+)
+
+type TableKeys map[iop.KeyType][]string
+
+// indexEntryPrefix marks an index entry whose original YAML/JSON value was a
+// composite list or a complex map (rather than a plain column name). The
+// original value is JSON-encoded after the prefix so it survives the
+// []string-typed TableKeys map and can be decoded by ParseIndexes.
+const indexEntryPrefix = "\x00idx:"
+
+// UnmarshalJSON allows the `index` key to accept rich entry shapes (bare column
+// names, composite lists, named simple maps, named complex maps) while keeping
+// every other key as a plain []string. Complex index entries are JSON-encoded
+// behind indexEntryPrefix so the map stays []string-typed for all existing code.
+func (tk *TableKeys) UnmarshalJSON(data []byte) error {
+	raw := map[iop.KeyType]any{}
+	if err := g.JSONUnmarshal(data, &raw); err != nil {
+		return g.Error(err, "could not unmarshal table_keys")
+	}
+
+	out := TableKeys{}
+	for kt, val := range raw {
+		if kt == iop.IndexKey {
+			entries, ok := val.([]any)
+			if !ok {
+				// allow a single non-list value
+				entries = []any{val}
+			}
+			encoded := []string{}
+			for _, entry := range entries {
+				switch e := entry.(type) {
+				case string:
+					encoded = append(encoded, e)
+				default:
+					// composite list or complex map -> encode behind prefix
+					encoded = append(encoded, indexEntryPrefix+g.Marshal(e))
+				}
+			}
+			out[kt] = encoded
+			continue
+		}
+
+		// all other keys: plain []string
+		switch v := val.(type) {
+		case []any:
+			strs := []string{}
+			for _, item := range v {
+				strs = append(strs, cast.ToString(item))
+			}
+			out[kt] = strs
+		case nil:
+			out[kt] = []string{}
+		default:
+			out[kt] = []string{cast.ToString(v)}
+		}
+	}
+
+	*tk = out
+	return nil
+}
+
+// UnmarshalYAML delegates to UnmarshalJSON by round-tripping through JSON, so
+// the rich `index` entry shapes are handled identically on the YAML config path.
+func (tk *TableKeys) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var raw map[string]any
+	if err := unmarshal(&raw); err != nil {
+		return g.Error(err, "could not unmarshal table_keys (yaml)")
+	}
+	// normalize any map[interface{}]interface{} from yaml.v2 to JSON-friendly maps
+	return tk.UnmarshalJSON([]byte(g.Marshal(raw)))
+}
+
+// IndexColumnNames returns the plain column-name index entries (used for
+// key-metadata validation), skipping any complex/encoded entries.
+func (tk TableKeys) IndexColumnNames() (names []string) {
+	for _, entry := range tk[iop.IndexKey] {
+		if !strings.HasPrefix(entry, indexEntryPrefix) {
+			names = append(names, entry)
+		}
+	}
+	return
+}
+
+// isIndexExpression returns true when the entry is not a plain identifier and
+// should be treated as a raw SQL expression (no column-name validation).
+func isIndexExpression(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r == '_' || r == '$' || (r >= '0' && r <= '9') || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+			continue
+		}
+		return true // contains '(', '|', whitespace, etc. -> expression
+	}
+	return false
+}
+
+// indexColumnEntry turns a single column/expression token into an IndexColumn.
+// Plain identifiers are validated against knownColumns (unless empty); anything
+// else is passed through verbatim as an expression.
+func indexColumnEntry(token string, knownColumns iop.Columns) (col iop.IndexColumn, isExpr bool, err error) {
+	token = strings.TrimSpace(token)
+	if isIndexExpression(token) {
+		return iop.IndexColumn{Name: token}, true, nil
+	}
+	if len(knownColumns) > 0 {
+		if c := knownColumns.GetColumn(token); c == nil {
+			return col, false, g.Error("index references unknown column %q\navailable: %s", token, g.Marshal(knownColumns.Names()))
+		}
+	}
+	return iop.IndexColumn{Name: token}, false, nil
+}
+
+// ParseIndexes normalizes the table_keys.index entries (in all accepted shapes)
+// into []iop.IndexDef. tableName is used for auto-naming; knownColumns (when
+// provided) validates plain-identifier column references. Expression entries
+// (containing non-identifier characters) bypass validation.
+func (tk TableKeys) ParseIndexes(tableName string, knownColumns iop.Columns, maxLength int) (defs []iop.IndexDef, err error) {
+	for _, entry := range tk[iop.IndexKey] {
+		var raw any
+		if strings.HasPrefix(entry, indexEntryPrefix) {
+			if err = g.Unmarshal(strings.TrimPrefix(entry, indexEntryPrefix), &raw); err != nil {
+				return nil, g.Error(err, "could not decode index entry")
+			}
+		} else {
+			raw = entry
+		}
+
+		def, err := parseIndexEntry(raw, tableName, knownColumns, maxLength)
+		if err != nil {
+			return nil, err
+		}
+		defs = append(defs, def)
+	}
+	return defs, nil
+}
+
+// parseIndexEntry parses one normalized index entry value into an IndexDef.
+func parseIndexEntry(raw any, tableName string, knownColumns iop.Columns, maxLength int) (def iop.IndexDef, err error) {
+	switch v := raw.(type) {
+	case string:
+		// 1. anonymous single-column (or expression)
+		ic, _, err := indexColumnEntry(v, knownColumns)
+		if err != nil {
+			return def, err
+		}
+		def.Columns = []iop.IndexColumn{ic}
+
+	case []any:
+		// 2./3. anonymous composite (strings and/or expressions)
+		for _, item := range v {
+			ic, _, err := indexColumnEntry(cast.ToString(item), knownColumns)
+			if err != nil {
+				return def, err
+			}
+			def.Columns = append(def.Columns, ic)
+		}
+
+	case map[string]any:
+		// 4./5./6. named entry (single key)
+		if len(v) != 1 {
+			return def, g.Error("named index entry must have exactly one key (the index name), got %d", len(v))
+		}
+		for name, body := range v {
+			def.Name = name
+			switch b := body.(type) {
+			case []any:
+				// named simple: value is a column list
+				for _, item := range b {
+					ic, _, err := indexColumnEntry(cast.ToString(item), knownColumns)
+					if err != nil {
+						return def, err
+					}
+					def.Columns = append(def.Columns, ic)
+				}
+			case map[string]any:
+				// named complex
+				if err := applyComplexIndexBody(&def, b, knownColumns); err != nil {
+					return def, err
+				}
+			default:
+				return def, g.Error("named index %q has unsupported value type %T", name, body)
+			}
+		}
+
+	default:
+		return def, g.Error("unsupported index entry type %T", raw)
+	}
+
+	if def.Name == "" {
+		parts := def.ColumnNames()
+		if def.Expression != "" {
+			parts = []string{def.Expression}
+		}
+		def.Name = iop.MakeIndexName(tableName, parts, maxLength)
+	}
+
+	return def, nil
+}
+
+// applyComplexIndexBody fills an IndexDef from the complex-form map body.
+func applyComplexIndexBody(def *iop.IndexDef, body map[string]any, knownColumns iop.Columns) error {
+	for k, val := range body {
+		switch strings.ToLower(k) {
+		case "columns":
+			items, ok := val.([]any)
+			if !ok {
+				return g.Error("index %q: columns must be a list", def.Name)
+			}
+			for _, item := range items {
+				switch c := item.(type) {
+				case string:
+					ic, _, err := indexColumnEntry(c, knownColumns)
+					if err != nil {
+						return err
+					}
+					def.Columns = append(def.Columns, ic)
+				case map[string]any:
+					// { name: created_at, sort: desc }
+					ic := iop.IndexColumn{
+						Name: cast.ToString(c["name"]),
+						Sort: strings.ToLower(cast.ToString(c["sort"])),
+					}
+					if ic.Sort != "" && ic.Sort != "asc" && ic.Sort != "desc" {
+						return g.Error("index %q: invalid sort %q (expected asc/desc)", def.Name, ic.Sort)
+					}
+					// validate plain identifier names only
+					if !isIndexExpression(ic.Name) && len(knownColumns) > 0 {
+						if col := knownColumns.GetColumn(ic.Name); col == nil {
+							return g.Error("index %q references unknown column %q", def.Name, ic.Name)
+						}
+					}
+					def.Columns = append(def.Columns, ic)
+				default:
+					return g.Error("index %q: unsupported column entry type %T", def.Name, item)
+				}
+			}
+		case "expression":
+			def.Expression = cast.ToString(val)
+		case "where":
+			def.Where = cast.ToString(val)
+		case "unique":
+			def.Unique = cast.ToBool(val)
+		case "type", "using":
+			def.Type = strings.ToLower(cast.ToString(val))
+		case "include":
+			items, ok := val.([]any)
+			if !ok {
+				return g.Error("index %q: include must be a list", def.Name)
+			}
+			for _, item := range items {
+				def.Include = append(def.Include, cast.ToString(item))
+			}
+		default:
+			return g.Error("index %q: unknown key %q", def.Name, k)
+		}
+	}
+
+	if def.Expression != "" && len(def.Columns) > 0 {
+		return g.Error("index %q: 'columns' and 'expression' are mutually exclusive", def.Name)
+	}
+	if def.Expression == "" && len(def.Columns) == 0 {
+		return g.Error("index %q: must declare either 'columns' or 'expression'", def.Name)
+	}
+
+	return nil
+}
+
+type TableIndex struct {
+	Def   iop.IndexDef
+	Table *Table
+
+	// Deprecated convenience accessors retained for back-compat with callers
+	// that constructed TableIndex directly; prefer Def.
+	Name    string
+	Columns iop.Columns
+	Unique  bool
+}
+
+// indexDef returns the effective IndexDef for this TableIndex, normalizing the
+// legacy Name/Columns/Unique fields into Def when Def is empty.
+func (ti *TableIndex) indexDef() iop.IndexDef {
+	def := ti.Def
+	if def.Name == "" && ti.Name != "" {
+		def.Name = ti.Name
+	}
+	if len(def.Columns) == 0 && len(ti.Columns) > 0 {
+		for _, c := range ti.Columns {
+			def.Columns = append(def.Columns, iop.IndexColumn{Name: c.Name})
+		}
+	}
+	if !def.Unique && ti.Unique {
+		def.Unique = true
+	}
+	return def
+}
+
+// CreateDDL renders the CREATE INDEX statement for the dialect, honoring the
+// §3.1 capability matrix: unsupported attributes are dropped with a one-time
+// warning, and a closed-set `type` violation returns empty (the caller has
+// already validated; this method warns and renders best-effort).
+func (ti *TableIndex) CreateDDL() string {
+	dialect := ti.Table.Dialect
+	def := ti.indexDef()
+
+	// validate + warn for dropped attributes
+	warnings, err := validateIndexForDialect(def, dialect)
+	for _, w := range warnings {
+		g.Warn(w)
+	}
+	if err != nil {
+		g.Warn(err.Error())
+		return ""
+	}
+
+	cap := indexCapabilityFor(dialect)
+	if cap.noIndexes {
+		return "" // engine has no index concept; warning already emitted
+	}
+
+	cols := renderIndexColumns(def, dialect)
+
+	// build the optional tokens for create_index_full
+	uniqueTok := ""
+	if def.Unique && cap.supportsUnique {
+		uniqueTok = "unique"
+	}
+
+	usingTok := ""
+	if def.Type != "" && cap.supportsType {
+		// SQL Server maps clustered/nonclustered to a keyword before INDEX, not USING
+		if dialect == dbio.TypeDbSQLServer {
+			uniqueTok = strings.TrimSpace(uniqueTok + " " + strings.ToUpper(def.Type))
+		} else if dialect == dbio.TypeDbOracle && strings.EqualFold(def.Type, "bitmap") {
+			uniqueTok = strings.TrimSpace(uniqueTok + " bitmap")
+		} else if dialect == dbio.TypeDbBigQuery && strings.EqualFold(def.Type, "search") {
+			uniqueTok = strings.TrimSpace(uniqueTok + " search")
+		} else {
+			usingTok = "using " + def.Type
+		}
+	}
+
+	includeTok := ""
+	if len(def.Include) > 0 && cap.supportsInclude {
+		includeTok = g.F("include (%s)", strings.Join(dialect.QuoteNames(def.Include...), ", "))
+	}
+
+	whereTok := ""
+	if def.Where != "" && cap.supportsWhere {
+		whereTok = "where " + def.Where
+	}
+
+	// prefer the richer template when the dialect (or base) defines it
+	tmpl := dialect.GetTemplateValue("core.create_index_full")
+	if tmpl != "" {
+		ddl := g.R(
+			tmpl,
+			"unique", uniqueTok,
+			"index", dialect.Quote(def.Name),
+			"table", ti.Table.FDQN(),
+			"using", usingTok,
+			"cols", cols,
+			"include", includeTok,
+			"where", whereTok,
+		)
+		return collapseSpaces(ddl)
+	}
+
+	// legacy fallback (no extras)
+	key := "core.create_index"
+	if def.Unique {
+		key = "core.create_unique_index"
+	}
+	return g.R(
+		dialect.GetTemplateValue(key),
+		"index", dialect.Quote(def.Name),
+		"table", ti.Table.FDQN(),
+		"cols", cols,
+	)
+}
+
+// collapseSpaces removes the extra whitespace left by empty interpolation tokens.
+func collapseSpaces(s string) string {
+	for strings.Contains(s, "  ") {
+		s = strings.ReplaceAll(s, "  ", " ")
+	}
+	s = strings.ReplaceAll(s, " (", " (")
+	return strings.TrimSpace(s)
+}
+
+func (ti *TableIndex) DropDDL() string {
+	dialect := ti.Table.Dialect
+	def := ti.indexDef()
+
+	return g.R(
+		dialect.GetTemplateValue("core.drop_index"),
+		"index", dialect.Quote(def.Name),
+		"name", def.Name,
+		"table", ti.Table.FDQN(),
+		"schema", ti.Table.SchemaQ(),
+	)
+}
+
+// Indexes collects all index definitions for the table from both sources:
+//   - inline column modifiers (columns: ... index(...)) on the given columns
+//   - target_options.table_keys.index (t.Keys[iop.IndexKey])
+//   - legacy single-column index/unique keys marked on columns
+//
+// Definitions are deduped by name (table_keys wins over inline on conflict).
+func (t *Table) Indexes(columns iop.Columns) (indexes []TableIndex) {
+	maxLength := cast.ToInt(t.Dialect.GetTemplateValue("variable.max_column_length"))
+
+	seen := map[string]bool{}
+	add := func(def iop.IndexDef) {
+		key := strings.ToLower(def.Name)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		indexes = append(indexes, TableIndex{Def: def, Table: t})
+	}
+
+	// 1. table_keys.index (rich forms)
+	if len(t.Keys[iop.IndexKey]) > 0 {
+		defs, err := t.Keys.ParseIndexes(t.Name, columns, maxLength)
+		if err != nil {
+			g.Warn("could not parse table_keys.index: %s", err.Error())
+		}
+		for _, def := range defs {
+			add(def)
+		}
+	}
+
+	// 2. inline column-modifier indexes
+	if inlineDefs, err := columns.CollectInlineIndexes(t.Name, maxLength); err != nil {
+		g.Warn("could not collect inline column indexes: %s", err.Error())
+	} else {
+		for _, def := range inlineDefs {
+			add(def)
+		}
+	}
+
+	// 3. legacy unique-key columns -> single-column unique indexes
+	for _, col := range columns.GetKeys(iop.UniqueKey) {
+		add(iop.IndexDef{
+			Name:    iop.MakeIndexName(t.Name, []string{col.Name}, maxLength),
+			Columns: []iop.IndexColumn{{Name: col.Name}},
+			Unique:  true,
+		})
+	}
+
+	return
+}
+
+// indexCapability describes, per engine, which index attributes are rendered,
+// silently dropped (with a warning), or rejected. It is the single Go-side
+// source of truth for the §3.1 coverage matrix; the actual statement placement
+// of `type` lives in each engine's template (create_index_full).
+type indexCapability struct {
+	// noIndexes: engine has no secondary index concept; the whole index is a
+	// no-op (accepted + one-time warning, never an error).
+	noIndexes bool
+
+	supportsWhere   bool // partial index predicate
+	supportsInclude bool // covering-index columns
+	supportsUnique  bool // UNIQUE keyword
+
+	// supportsType: engine accepts a `type`/`using` clause. When typeClosedSet
+	// is non-nil, an unknown value is a hard error; otherwise the value is
+	// passed through to the engine verbatim.
+	supportsType  bool
+	typeClosedSet []string // closed set of recognized type values (lowercased)
+}
+
+// indexCapabilities encodes the §3.1 matrix. Engines absent from this map use
+// indexCapDefault (basic CREATE INDEX, no extras).
+var indexCapabilities = map[dbio.Type]indexCapability{
+	dbio.TypeDbPostgres: {supportsWhere: true, supportsInclude: true, supportsUnique: true, supportsType: true},
+	dbio.TypeDbRedshift: {noIndexes: true},
+	dbio.TypeDbMySQL:    {supportsUnique: true, supportsType: true, typeClosedSet: []string{"btree", "hash"}},
+	dbio.TypeDbMariaDB:  {supportsUnique: true, supportsType: true, typeClosedSet: []string{"btree", "hash"}},
+	dbio.TypeDbSQLServer: {
+		supportsWhere: true, supportsInclude: true, supportsUnique: true,
+		supportsType: true, typeClosedSet: []string{"clustered", "nonclustered"},
+	},
+	dbio.TypeDbClickhouse: {supportsType: true}, // handled inline in create_table
+	dbio.TypeDbProton:     {supportsType: true},
+	dbio.TypeDbSnowflake:  {noIndexes: true},
+	dbio.TypeDbBigQuery:   {supportsType: true, typeClosedSet: []string{"search"}},
+	dbio.TypeDbDuckDb:     {supportsUnique: true},
+	dbio.TypeDbMotherDuck: {supportsUnique: true},
+	dbio.TypeDbOracle:     {supportsUnique: true, supportsType: true, typeClosedSet: []string{"bitmap"}},
+	dbio.TypeDbSQLite:     {supportsWhere: true, supportsUnique: true},
+}
+
+var indexCapDefault = indexCapability{supportsUnique: true}
+
+func indexCapabilityFor(dialect dbio.Type) indexCapability {
+	if cap, ok := indexCapabilities[dialect]; ok {
+		return cap
+	}
+	return indexCapDefault
+}
+
+// validateIndexForDialect checks the IndexDef's attributes against the engine
+// capabilities. It returns a (possibly empty) list of one-line warnings for
+// dropped attributes, and a hard error only for a closed-set `type` violation.
+func validateIndexForDialect(def iop.IndexDef, dialect dbio.Type) (warnings []string, err error) {
+	cap := indexCapabilityFor(dialect)
+
+	if cap.noIndexes {
+		warnings = append(warnings, g.F("index %q: %s has no secondary indexes; index is ignored", def.Name, dialect))
+		return warnings, nil
+	}
+
+	if def.Where != "" && !cap.supportsWhere {
+		warnings = append(warnings, g.F("index %q: %s does not support partial-index 'where'; clause ignored", def.Name, dialect))
+	}
+	if len(def.Include) > 0 && !cap.supportsInclude {
+		warnings = append(warnings, g.F("index %q: %s does not support covering-index 'include'; clause ignored", def.Name, dialect))
+	}
+	if def.Unique && !cap.supportsUnique {
+		warnings = append(warnings, g.F("index %q: %s does not support unique indexes; treated as non-unique", def.Name, dialect))
+	}
+	if def.Type != "" {
+		if !cap.supportsType {
+			warnings = append(warnings, g.F("index %q: %s does not support index 'type'; clause ignored", def.Name, dialect))
+		} else if len(cap.typeClosedSet) > 0 && !g.In(strings.ToLower(def.Type), cap.typeClosedSet...) {
+			return warnings, g.Error("index %q: %s does not support index type %q (allowed: %s)", def.Name, dialect, def.Type, strings.Join(cap.typeClosedSet, ", "))
+		}
+	}
+
+	return warnings, nil
+}
+
+// renderIndexColumns produces the quoted, sorted column/expression list for an
+// index. Plain identifiers are quoted; expressions and explicit sort orders are
+// passed through. For an expression index (no Columns), the raw expression is
+// returned verbatim.
+func renderIndexColumns(def iop.IndexDef, dialect dbio.Type) string {
+	if len(def.Columns) == 0 && def.Expression != "" {
+		return def.Expression
+	}
+	parts := []string{}
+	for _, c := range def.Columns {
+		name := c.Name
+		// quote plain identifiers only; leave expressions untouched
+		if !isIndexExpression(name) {
+			name = dialect.Quote(name)
+		}
+		if c.Sort != "" {
+			name += " " + strings.ToUpper(c.Sort)
+		}
+		parts = append(parts, name)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// appendIndexesAndComments appends CREATE INDEX and column-comment statements to
+// a CREATE TABLE ddl (";\n"-joined). CreateDDL/ColumnCommentsDDL return "" when
+// the dialect lacks the capability. Skipped for temporary tables.
+func appendIndexesAndComments(ddl string, conn Connection, table Table, data iop.Dataset, temporary bool) string {
+	if temporary {
+		return ddl
+	}
+
+	for _, index := range table.Indexes(data.Columns) {
+		if idxDDL := index.CreateDDL(); idxDDL != "" {
+			ddl = ddl + ";\n" + idxDDL
+		}
+	}
+
+	for _, stmt := range table.ColumnCommentsDDL(conn, data.Columns) {
+		ddl = ddl + ";\n" + stmt
+	}
+
+	return ddl
+}
+
+// appendColumnComments appends only column-comment statements (";\n"-joined) to a
+// CREATE TABLE ddl, for dialects that support descriptions but not CREATE INDEX.
+func appendColumnComments(ddl string, conn Connection, table Table, data iop.Dataset, temporary bool) string {
+	if temporary {
+		return ddl
+	}
+	for _, stmt := range table.ColumnCommentsDDL(conn, data.Columns) {
+		ddl = ddl + ";\n" + stmt
+	}
+	return ddl
+}

--- a/core/dbio/database/schemata_keys.go
+++ b/core/dbio/database/schemata_keys.go
@@ -115,9 +115,12 @@ func indexColumnEntry(token string, knownColumns iop.Columns) (col iop.IndexColu
 		return iop.IndexColumn{Name: token}, true, nil
 	}
 	if len(knownColumns) > 0 {
-		if c := knownColumns.GetColumn(token); c == nil {
+		c := knownColumns.GetColumn(token)
+		if c == nil {
 			return col, false, g.Error("index references unknown column %q\navailable: %s", token, g.Marshal(knownColumns.Names()))
 		}
+		// use the resolved column's actual casing (e.g. Oracle folds to upper)
+		token = c.Name
 	}
 	return iop.IndexColumn{Name: token}, false, nil
 }
@@ -306,10 +309,8 @@ func (ti *TableIndex) indexDef() iop.IndexDef {
 	return def
 }
 
-// CreateDDL renders the CREATE INDEX statement for the dialect, honoring the
-// §3.1 capability matrix: unsupported attributes are dropped with a one-time
-// warning, and a closed-set `type` violation returns empty (the caller has
-// already validated; this method warns and renders best-effort).
+// CreateDDL renders the CREATE INDEX statement for the dialect; unsupported
+// attributes are dropped with a warning, a closed-set type violation returns "".
 func (ti *TableIndex) CreateDDL() string {
 	dialect := ti.Table.Dialect
 	def := ti.indexDef()
@@ -464,27 +465,21 @@ func (t *Table) Indexes(columns iop.Columns) (indexes []TableIndex) {
 }
 
 // indexCapability describes, per engine, which index attributes are rendered,
-// silently dropped (with a warning), or rejected. It is the single Go-side
-// source of truth for the §3.1 coverage matrix; the actual statement placement
-// of `type` lives in each engine's template (create_index_full).
+// dropped (with a warning), or rejected.
 type indexCapability struct {
-	// noIndexes: engine has no secondary index concept; the whole index is a
-	// no-op (accepted + one-time warning, never an error).
-	noIndexes bool
+	noIndexes bool // no standalone CREATE INDEX; the whole index is a no-op
 
 	supportsWhere   bool // partial index predicate
 	supportsInclude bool // covering-index columns
 	supportsUnique  bool // UNIQUE keyword
 
-	// supportsType: engine accepts a `type`/`using` clause. When typeClosedSet
-	// is non-nil, an unknown value is a hard error; otherwise the value is
-	// passed through to the engine verbatim.
+	// supportsType: engine accepts a type/using clause. When typeClosedSet is
+	// non-nil, an unknown value is a hard error; else passed through verbatim.
 	supportsType  bool
-	typeClosedSet []string // closed set of recognized type values (lowercased)
+	typeClosedSet []string // recognized type values (lowercased)
 }
 
-// indexCapabilities encodes the §3.1 matrix. Engines absent from this map use
-// indexCapDefault (basic CREATE INDEX, no extras).
+// Engines absent from this map use indexCapDefault (basic CREATE INDEX).
 var indexCapabilities = map[dbio.Type]indexCapability{
 	dbio.TypeDbPostgres: {supportsWhere: true, supportsInclude: true, supportsUnique: true, supportsType: true},
 	dbio.TypeDbRedshift: {noIndexes: true},
@@ -494,10 +489,18 @@ var indexCapabilities = map[dbio.Type]indexCapability{
 		supportsWhere: true, supportsInclude: true, supportsUnique: true,
 		supportsType: true, typeClosedSet: []string{"clustered", "nonclustered"},
 	},
-	dbio.TypeDbClickhouse: {supportsType: true}, // handled inline in create_table
-	dbio.TypeDbProton:     {supportsType: true},
+	// ClickHouse data-skipping indexes are declared inline in CREATE TABLE
+	// (see injectInlineIndexes); standalone CREATE INDEX is unsupported, so the
+	// standalone path is a no-op here.
+	dbio.TypeDbClickhouse: {noIndexes: true},
+	dbio.TypeDbProton:     {noIndexes: true},
 	dbio.TypeDbSnowflake:  {noIndexes: true},
-	dbio.TypeDbBigQuery:   {supportsType: true, typeClosedSet: []string{"search"}},
+	// BigQuery has no plain secondary index (only CREATE SEARCH/VECTOR INDEX,
+	// not generated here); treat table_keys.index as a no-op.
+	dbio.TypeDbBigQuery: {noIndexes: true},
+	// StarRocks indexes (BITMAP/inverted) only apply to specific column/table
+	// models and don't fit the generic CREATE INDEX form; no-op for now.
+	dbio.TypeDbStarRocks: {noIndexes: true},
 	dbio.TypeDbDuckDb:     {supportsUnique: true},
 	dbio.TypeDbMotherDuck: {supportsUnique: true},
 	dbio.TypeDbOracle:     {supportsUnique: true, supportsType: true, typeClosedSet: []string{"bitmap"}},

--- a/core/dbio/database/schemata_keys.go
+++ b/core/dbio/database/schemata_keys.go
@@ -503,6 +503,7 @@ var indexCapabilities = map[dbio.Type]indexCapability{
 	dbio.TypeDbStarRocks: {noIndexes: true},
 	dbio.TypeDbDuckDb:     {supportsUnique: true},
 	dbio.TypeDbMotherDuck: {supportsUnique: true},
+	dbio.TypeDbDuckLake:   {noIndexes: true}, // DuckLake does not support indexes
 	dbio.TypeDbOracle:     {supportsUnique: true, supportsType: true, typeClosedSet: []string{"bitmap"}},
 	dbio.TypeDbSQLite:     {supportsWhere: true, supportsUnique: true},
 }

--- a/core/dbio/database/schemata_keys_test.go
+++ b/core/dbio/database/schemata_keys_test.go
@@ -1,0 +1,377 @@
+package database
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/flarco/g"
+	"github.com/slingdata-io/sling-cli/core/dbio"
+	"github.com/slingdata-io/sling-cli/core/dbio/iop"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file consolidates the index-related tests for the database package:
+//   - TableKeys.ParseIndexes parsing (the table_keys.index list forms)
+//   - TableIndex.CreateDDL rendering across every index-capable engine
+//
+// The cross-engine DDL matrix is hard-coded inline (see indexMatrixCases) rather
+// than kept as a tree of checked-in golden .sql files, so the expected output
+// lives next to the cases that produce it.
+
+// ---------------------------------------------------------------------------
+// ParseIndexes
+// ---------------------------------------------------------------------------
+
+// tkFromYAML parses a table_keys YAML block into TableKeys (exercising the
+// custom UnmarshalJSON via the YAML->JSON round-trip used by the config loader).
+func tkFromYAML(t *testing.T, yamlStr string) TableKeys {
+	t.Helper()
+	var raw map[string]any
+	require.NoError(t, g.UnmarshalYAML(yamlStr, &raw))
+
+	var tk TableKeys
+	require.NoError(t, g.JSONUnmarshal([]byte(g.Marshal(raw["table_keys"])), &tk))
+	return tk
+}
+
+var idxKnownCols = iop.Columns{
+	{Name: "col1"}, {Name: "col2"}, {Name: "col3"},
+	{Name: "search_col"}, {Name: "org_id"}, {Name: "project_id"},
+	{Name: "created_at"}, {Name: "status"}, {Name: "name"},
+}
+
+func TestParseIndexesStringEntry(t *testing.T) {
+	tk := tkFromYAML(t, `
+table_keys:
+  index:
+    - search_col
+`)
+	defs, err := tk.ParseIndexes("mytable", idxKnownCols, 63)
+	require.NoError(t, err)
+	require.Len(t, defs, 1)
+	assert.Equal(t, "idx_mytable_search_col", defs[0].Name)
+	require.Len(t, defs[0].Columns, 1)
+	assert.Equal(t, "search_col", defs[0].Columns[0].Name)
+}
+
+func TestParseIndexesCompositeAnonymous(t *testing.T) {
+	tk := tkFromYAML(t, `
+table_keys:
+  index:
+    - [col1, col2]
+`)
+	defs, err := tk.ParseIndexes("mytable", idxKnownCols, 63)
+	require.NoError(t, err)
+	require.Len(t, defs, 1)
+	require.Len(t, defs[0].Columns, 2)
+	assert.Equal(t, "col1", defs[0].Columns[0].Name)
+	assert.Equal(t, "col2", defs[0].Columns[1].Name)
+	assert.Equal(t, "idx_mytable_col1_col2", defs[0].Name)
+}
+
+func TestParseIndexesNamedSimple(t *testing.T) {
+	tk := tkFromYAML(t, `
+table_keys:
+  index:
+    - idx_search: [col1, col2]
+`)
+	defs, err := tk.ParseIndexes("mytable", idxKnownCols, 63)
+	require.NoError(t, err)
+	require.Len(t, defs, 1)
+	assert.Equal(t, "idx_search", defs[0].Name)
+	require.Len(t, defs[0].Columns, 2)
+}
+
+func TestParseIndexesNamedComplex(t *testing.T) {
+	tk := tkFromYAML(t, `
+table_keys:
+  index:
+    - idx_lower_name:
+        expression: LOWER(name)
+        type: btree
+    - idx_org_active:
+        columns: [org_id, project_id]
+        where: deleted_at IS NULL
+        unique: true
+    - idx_sorted:
+        columns:
+          - { name: created_at, sort: desc }
+          - { name: project_id }
+        type: btree
+        include: [status]
+`)
+	defs, err := tk.ParseIndexes("mytable", idxKnownCols, 63)
+	require.NoError(t, err)
+	require.Len(t, defs, 3)
+
+	byName := map[string]iop.IndexDef{}
+	for _, d := range defs {
+		byName[d.Name] = d
+	}
+
+	lower := byName["idx_lower_name"]
+	assert.Equal(t, "LOWER(name)", lower.Expression)
+	assert.Equal(t, "btree", lower.Type)
+	assert.Empty(t, lower.Columns)
+
+	active := byName["idx_org_active"]
+	assert.True(t, active.Unique)
+	assert.Equal(t, "deleted_at IS NULL", active.Where)
+	require.Len(t, active.Columns, 2)
+
+	sorted := byName["idx_sorted"]
+	require.Len(t, sorted.Columns, 2)
+	assert.Equal(t, "created_at", sorted.Columns[0].Name)
+	assert.Equal(t, "desc", sorted.Columns[0].Sort)
+	assert.Equal(t, []string{"status"}, sorted.Include)
+}
+
+func TestParseIndexesMixed(t *testing.T) {
+	tk := tkFromYAML(t, `
+table_keys:
+  index:
+    - search_col
+    - [col1, col2]
+    - idx_named: [col3]
+    - idx_complex:
+        columns: [org_id]
+        unique: true
+`)
+	defs, err := tk.ParseIndexes("mytable", idxKnownCols, 63)
+	require.NoError(t, err)
+	require.Len(t, defs, 4)
+}
+
+func TestParseIndexesExpressionAnonymous(t *testing.T) {
+	tk := tkFromYAML(t, `
+table_keys:
+  index:
+    - [col1, "LOWER(col2)"]
+`)
+	defs, err := tk.ParseIndexes("mytable", idxKnownCols, 63)
+	require.NoError(t, err)
+	require.Len(t, defs, 1)
+	require.Len(t, defs[0].Columns, 2)
+	assert.Equal(t, "col1", defs[0].Columns[0].Name)
+	assert.Equal(t, "LOWER(col2)", defs[0].Columns[1].Name)
+}
+
+func TestParseIndexesUnknownColumn(t *testing.T) {
+	tk := tkFromYAML(t, `
+table_keys:
+  index:
+    - nonexistent_col
+`)
+	_, err := tk.ParseIndexes("mytable", idxKnownCols, 63)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown column")
+}
+
+func TestParseIndexesOldFlatForm(t *testing.T) {
+	// existing single-key index: [col1, col2] -> two separate single-col indexes
+	tk := tkFromYAML(t, `
+table_keys:
+  index: [col1, col2]
+`)
+	defs, err := tk.ParseIndexes("mytable", idxKnownCols, 63)
+	require.NoError(t, err)
+	require.Len(t, defs, 2)
+	assert.Equal(t, "idx_mytable_col1", defs[0].Name)
+	assert.Equal(t, "idx_mytable_col2", defs[1].Name)
+}
+
+func TestParseIndexesOtherKeysUnaffected(t *testing.T) {
+	tk := tkFromYAML(t, `
+table_keys:
+  primary: [col1]
+  unique: [col2]
+  index:
+    - idx_x:
+        columns: [col3]
+`)
+	assert.Equal(t, []string{"col1"}, []string(tk[iop.PrimaryKey]))
+	assert.Equal(t, []string{"col2"}, []string(tk[iop.UniqueKey]))
+
+	defs, err := tk.ParseIndexes("mytable", idxKnownCols, 63)
+	require.NoError(t, err)
+	require.Len(t, defs, 1)
+	assert.Equal(t, "idx_x", defs[0].Name)
+}
+
+func TestParseIndexesMutualExclusion(t *testing.T) {
+	tk := tkFromYAML(t, `
+table_keys:
+  index:
+    - idx_bad:
+        columns: [col1]
+        expression: LOWER(col2)
+`)
+	_, err := tk.ParseIndexes("mytable", idxKnownCols, 63)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+// ---------------------------------------------------------------------------
+// CreateDDL matrix
+// ---------------------------------------------------------------------------
+
+// indexMatrixCase pairs an IndexDef with the expected CreateDDL output per
+// engine. It renders through the real template system and needs no live database.
+type indexMatrixCase struct {
+	name string
+	def  iop.IndexDef
+	want map[dbio.Type]string
+}
+
+var indexMatrixCases = []indexMatrixCase{
+	{
+		name: "single_col",
+		def:  iop.IndexDef{Name: "idx_single", Columns: []iop.IndexColumn{{Name: "col1"}}},
+		want: map[dbio.Type]string{
+			dbio.TypeDbPostgres:  `create index if not exists "idx_single" on "public"."mytable" ("col1")`,
+			dbio.TypeDbMySQL:     "create index `idx_single` on `public`.`mytable` (`col1`)",
+			dbio.TypeDbMariaDB:   "create index `idx_single` on `public`.`mytable` (`col1`)",
+			dbio.TypeDbSQLServer: `create index "idx_single" on "public"."mytable" ("col1")`,
+			dbio.TypeDbOracle:    `create index "idx_single" on "public"."mytable" ("col1")`,
+			dbio.TypeDbDuckDb:    `create index "idx_single" on "public"."mytable" ("col1")`,
+			dbio.TypeDbSQLite:    `create index if not exists "idx_single" on "public"."mytable" ("col1")`,
+		},
+	},
+	{
+		name: "composite_sorted",
+		def:  iop.IndexDef{Name: "idx_comp", Columns: []iop.IndexColumn{{Name: "col1"}, {Name: "col2", Sort: "desc"}}},
+		want: map[dbio.Type]string{
+			dbio.TypeDbPostgres:  `create index if not exists "idx_comp" on "public"."mytable" ("col1", "col2" DESC)`,
+			dbio.TypeDbMySQL:     "create index `idx_comp` on `public`.`mytable` (`col1`, `col2` DESC)",
+			dbio.TypeDbMariaDB:   "create index `idx_comp` on `public`.`mytable` (`col1`, `col2` DESC)",
+			dbio.TypeDbSQLServer: `create index "idx_comp" on "public"."mytable" ("col1", "col2" DESC)`,
+			dbio.TypeDbOracle:    `create index "idx_comp" on "public"."mytable" ("col1", "col2" DESC)`,
+			dbio.TypeDbDuckDb:    `create index "idx_comp" on "public"."mytable" ("col1", "col2" DESC)`,
+			dbio.TypeDbSQLite:    `create index if not exists "idx_comp" on "public"."mytable" ("col1", "col2" DESC)`,
+		},
+	},
+	{
+		name: "unique",
+		def:  iop.IndexDef{Name: "idx_uniq", Columns: []iop.IndexColumn{{Name: "email"}}, Unique: true},
+		want: map[dbio.Type]string{
+			dbio.TypeDbPostgres:  `create unique index if not exists "idx_uniq" on "public"."mytable" ("email")`,
+			dbio.TypeDbMySQL:     "create unique index `idx_uniq` on `public`.`mytable` (`email`)",
+			dbio.TypeDbMariaDB:   "create unique index `idx_uniq` on `public`.`mytable` (`email`)",
+			dbio.TypeDbSQLServer: `create unique index "idx_uniq" on "public"."mytable" ("email")`,
+			dbio.TypeDbOracle:    `create unique index "idx_uniq" on "public"."mytable" ("email")`,
+			dbio.TypeDbDuckDb:    `create unique index "idx_uniq" on "public"."mytable" ("email")`,
+			dbio.TypeDbSQLite:    `create unique index if not exists "idx_uniq" on "public"."mytable" ("email")`,
+		},
+	},
+	{
+		name: "partial_where",
+		def:  iop.IndexDef{Name: "idx_partial", Columns: []iop.IndexColumn{{Name: "org_id"}}, Where: "deleted_at IS NULL"},
+		want: map[dbio.Type]string{
+			// engines without partial-index support drop the where clause (with a warning)
+			dbio.TypeDbPostgres:  `create index if not exists "idx_partial" on "public"."mytable" ("org_id") where deleted_at IS NULL`,
+			dbio.TypeDbMySQL:     "create index `idx_partial` on `public`.`mytable` (`org_id`)",
+			dbio.TypeDbMariaDB:   "create index `idx_partial` on `public`.`mytable` (`org_id`)",
+			dbio.TypeDbSQLServer: `create index "idx_partial" on "public"."mytable" ("org_id") where deleted_at IS NULL`,
+			dbio.TypeDbOracle:    `create index "idx_partial" on "public"."mytable" ("org_id")`,
+			dbio.TypeDbDuckDb:    `create index "idx_partial" on "public"."mytable" ("org_id")`,
+			dbio.TypeDbSQLite:    `create index if not exists "idx_partial" on "public"."mytable" ("org_id") where deleted_at IS NULL`,
+		},
+	},
+	{
+		name: "covering_include",
+		def:  iop.IndexDef{Name: "idx_cover", Columns: []iop.IndexColumn{{Name: "col1"}}, Include: []string{"status", "name"}},
+		want: map[dbio.Type]string{
+			// engines without covering-index support drop the include clause (with a warning)
+			dbio.TypeDbPostgres:  `create index if not exists "idx_cover" on "public"."mytable" ("col1") include ("status", "name")`,
+			dbio.TypeDbMySQL:     "create index `idx_cover` on `public`.`mytable` (`col1`)",
+			dbio.TypeDbMariaDB:   "create index `idx_cover` on `public`.`mytable` (`col1`)",
+			dbio.TypeDbSQLServer: `create index "idx_cover" on "public"."mytable" ("col1") include ("status", "name")`,
+			dbio.TypeDbOracle:    `create index "idx_cover" on "public"."mytable" ("col1")`,
+			dbio.TypeDbDuckDb:    `create index "idx_cover" on "public"."mytable" ("col1")`,
+			dbio.TypeDbSQLite:    `create index if not exists "idx_cover" on "public"."mytable" ("col1")`,
+		},
+	},
+	{
+		name: "expression",
+		def:  iop.IndexDef{Name: "idx_expr", Expression: "LOWER(name)"},
+		want: map[dbio.Type]string{
+			dbio.TypeDbPostgres:  `create index if not exists "idx_expr" on "public"."mytable" (LOWER(name))`,
+			dbio.TypeDbMySQL:     "create index `idx_expr` on `public`.`mytable` (LOWER(name))",
+			dbio.TypeDbMariaDB:   "create index `idx_expr` on `public`.`mytable` (LOWER(name))",
+			dbio.TypeDbSQLServer: `create index "idx_expr" on "public"."mytable" (LOWER(name))`,
+			dbio.TypeDbOracle:    `create index "idx_expr" on "public"."mytable" (LOWER(name))`,
+			dbio.TypeDbDuckDb:    `create index "idx_expr" on "public"."mytable" (LOWER(name))`,
+			dbio.TypeDbSQLite:    `create index if not exists "idx_expr" on "public"."mytable" (LOWER(name))`,
+		},
+	},
+}
+
+// indexMatrixEngines: engines that support secondary indexes and render real DDL.
+var indexMatrixEngines = []dbio.Type{
+	dbio.TypeDbPostgres,
+	dbio.TypeDbMySQL,
+	dbio.TypeDbMariaDB,
+	dbio.TypeDbSQLServer,
+	dbio.TypeDbOracle,
+	dbio.TypeDbDuckDb,
+	dbio.TypeDbSQLite,
+}
+
+func TestIndexDDLMatrix(t *testing.T) {
+	for _, engine := range indexMatrixEngines {
+		for _, c := range indexMatrixCases {
+			t.Run(string(engine)+"/"+c.name, func(t *testing.T) {
+				want, ok := c.want[engine]
+				require.True(t, ok, "missing expected DDL for %s/%s", engine, c.name)
+
+				tbl := &Table{Name: "mytable", Schema: "public", Dialect: engine}
+				ti := TableIndex{Def: c.def, Table: tbl}
+				got := ti.CreateDDL()
+
+				assert.Equal(t, strings.TrimSpace(want), strings.TrimSpace(got))
+			})
+		}
+	}
+}
+
+// TestIndexDDLMatrixCoverage ensures every index-capable engine has expected
+// output for every case, so adding a connector forces adding its matrix coverage.
+func TestIndexDDLMatrixCoverage(t *testing.T) {
+	for _, engine := range indexMatrixEngines {
+		for _, c := range indexMatrixCases {
+			_, ok := c.want[engine]
+			assert.True(t, ok, "missing matrix coverage for %s/%s", engine, c.name)
+		}
+	}
+}
+
+// TestIndexDDLClosedSetError verifies a closed-set type violation errors out
+// (returns empty DDL after warning) on SQL Server, but passes through on
+// passthrough engines like Postgres.
+func TestIndexDDLClosedSetError(t *testing.T) {
+	// SQL Server: unknown type -> rejected (empty DDL)
+	tbl := &Table{Name: "t", Schema: "dbo", Dialect: dbio.TypeDbSQLServer}
+	ti := TableIndex{Def: iop.IndexDef{Name: "idx", Columns: []iop.IndexColumn{{Name: "c"}}, Type: "gin"}, Table: tbl}
+	assert.Empty(t, ti.CreateDDL(), "sqlserver should reject unknown closed-set type")
+
+	// SQL Server: valid clustered -> renders
+	ti = TableIndex{Def: iop.IndexDef{Name: "idx", Columns: []iop.IndexColumn{{Name: "c"}}, Type: "clustered"}, Table: tbl}
+	got := ti.CreateDDL()
+	assert.Contains(t, strings.ToUpper(got), "CLUSTERED")
+
+	// Postgres: passthrough type -> renders with USING
+	tbl = &Table{Name: "t", Schema: "public", Dialect: dbio.TypeDbPostgres}
+	ti = TableIndex{Def: iop.IndexDef{Name: "idx", Columns: []iop.IndexColumn{{Name: "c"}}, Type: "gin"}, Table: tbl}
+	got = ti.CreateDDL()
+	assert.Contains(t, got, "using gin")
+}
+
+// TestIndexDDLNoIndexEngines verifies no-index engines render nothing.
+func TestIndexDDLNoIndexEngines(t *testing.T) {
+	for _, engine := range []dbio.Type{dbio.TypeDbRedshift, dbio.TypeDbSnowflake} {
+		tbl := &Table{Name: "t", Schema: "public", Dialect: engine}
+		ti := TableIndex{Def: iop.IndexDef{Name: "idx", Columns: []iop.IndexColumn{{Name: "c"}}}, Table: tbl}
+		assert.Empty(t, ti.CreateDDL(), "%s should render no index DDL", engine)
+	}
+}

--- a/core/dbio/database/transaction.go
+++ b/core/dbio/database/transaction.go
@@ -670,6 +670,17 @@ func (il IsolationLevel) AsSqlIsolationLevel() sql.IsolationLevel {
 	return sql.LevelDefault
 }
 
+type CDCSlotLevel string
+
+const (
+	CDCSlotLevelStream CDCSlotLevel = "stream"
+	CDCSlotLevelShared CDCSlotLevel = "shared"
+)
+
+func (sl CDCSlotLevel) String() string {
+	return string(sl)
+}
+
 type Operation string
 
 const (

--- a/core/dbio/database/transaction.go
+++ b/core/dbio/database/transaction.go
@@ -357,7 +357,7 @@ func InsertBatchStream(conn Connection, tx Transaction, tableFName string, ds *i
 			case conn.GetType().IsMySQLLike():
 				row = processMySqlLikeInsertRow(bColumns, row)
 			case conn.GetType().IsSQLServer():
-				// row = processSQLServerInsertRow(bColumns, row)
+				row = processSQLServerInsertRow(bColumns, row)
 			}
 			vals = append(vals, row...)
 		}

--- a/core/dbio/dbio_types.go
+++ b/core/dbio/dbio_types.go
@@ -741,6 +741,8 @@ func (ft FileType) Exts() []string {
 	switch ft {
 	case FileTypeExcel:
 		return []string{".xlsx", ".xlsm", ".xls"}
+	case FileTypeJsonLines:
+		return []string{".jsonl", ".ndjson", ".jsonlines"}
 	default:
 		return []string{ft.Ext()}
 	}

--- a/core/dbio/filesys/fs.go
+++ b/core/dbio/filesys/fs.go
@@ -1395,6 +1395,8 @@ func WriteDataflowReadyViaDuckDB(fs FileSysClient, df *iop.Dataflow, uri string,
 	// merge into single stream to push into duckdb
 	duckSc := duck.DefaultCsvConfig()
 	duckSc.FileMaxRows = sc.FileMaxRows
+	duckSc.TargetType = sc.TargetType
+	duckSc.BinaryAsHex = sc.BinaryAsHex
 
 	switch fs.GetProp("duckdb_copy_method", "copy_method") {
 	case "csv_http":

--- a/core/dbio/iop/arrow.go
+++ b/core/dbio/iop/arrow.go
@@ -615,7 +615,17 @@ func parseTimeOfDayE(val interface{}) (time.Time, error) {
 		return t, nil
 	}
 	s := strings.TrimSpace(cast.ToString(val))
-	for _, layout := range []string{"15:04:05.9999999", "15:04:05.999999", "15:04:05", "15:04"} {
+	for _, layout := range []string{
+		"15:04:05.999999999",
+		"15:04:05.999999",
+		"15:04:05.999",
+		"15:04:05",
+		"15:04:05.999999999Z07:00",
+		"15:04:05.999999Z07:00",
+		"15:04:05Z07:00",
+		"15:04:05-07",
+		"15:04",
+	} {
 		if t, err := time.Parse(layout, s); err == nil {
 			return t, nil
 		}

--- a/core/dbio/iop/arrow.go
+++ b/core/dbio/iop/arrow.go
@@ -584,6 +584,12 @@ func ColumnsToArrowSchema(columns Columns) *arrow.Schema {
 			default:
 				arrowType = arrow.FixedWidthTypes.Timestamp_us // iceberg does not support nano, micro as default
 			}
+		case TimeType, TimezType:
+			// Iceberg Time (microsecond precision), matching iopTypeToIcebergPrimitiveType
+			arrowType = arrow.FixedWidthTypes.Time64us
+		case UUIDType:
+			// Iceberg UUID via the arrow.uuid extension, matching iopTypeToIcebergPrimitiveType
+			arrowType = extensions.NewUUIDType()
 		case StringType, TextType, JsonType:
 			arrowType = arrow.BinaryTypes.String
 		case BinaryType:
@@ -600,6 +606,21 @@ func ColumnsToArrowSchema(columns Columns) *arrow.Schema {
 	}
 
 	return arrow.NewSchema(fields, nil)
+}
+
+// parseTimeOfDayE parses a value into time.Time, also handling bare time-of-day
+// strings (e.g. "08:30:00") that cast.ToTimeE rejects for lacking a date
+func parseTimeOfDayE(val interface{}) (time.Time, error) {
+	if t, err := cast.ToTimeE(val); err == nil {
+		return t, nil
+	}
+	s := strings.TrimSpace(cast.ToString(val))
+	for _, layout := range []string{"15:04:05.9999999", "15:04:05.999999", "15:04:05", "15:04"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, g.Error("could not parse time-of-day value: %v", val)
 }
 
 func AppendToBuilder(builder array.Builder, col *Column, val interface{}) {
@@ -863,7 +884,7 @@ func AppendToBuilder(builder array.Builder, col *Column, val interface{}) {
 			}
 		}
 	case *array.Time32Builder:
-		tVal, _ := cast.ToTimeE(val)
+		tVal, _ := parseTimeOfDayE(val)
 		// Time32 can be seconds or milliseconds since midnight
 		dt := b.Type().(*arrow.Time32Type)
 		if dt.Unit == arrow.Second {
@@ -874,7 +895,7 @@ func AppendToBuilder(builder array.Builder, col *Column, val interface{}) {
 			b.Append(arrow.Time32(millis))
 		}
 	case *array.Time64Builder:
-		tVal, _ := cast.ToTimeE(val)
+		tVal, _ := parseTimeOfDayE(val)
 		// Time64 can be microseconds or nanoseconds since midnight
 		dt := b.Type().(*arrow.Time64Type)
 		if dt.Unit == arrow.Microsecond {

--- a/core/dbio/iop/arrow_test.go
+++ b/core/dbio/iop/arrow_test.go
@@ -194,7 +194,7 @@ func TestArrowReaderWithSelectedColumns(t *testing.T) {
 // ColumnsToArrowSchema must map time/timez/uuid to their native Arrow types so the
 // schema matches iopTypeToIcebergPrimitiveType. Previously they fell through to
 // String, causing "cannot promote string to time/uuid" when appending to Iceberg.
-func TestColumnsToArrowSchemaTimeUUID(t *testing.T) {
+func TestArrowColumnsToArrowSchemaTimeUUID(t *testing.T) {
 	columns := Columns{
 		{Name: "t", Type: TimeType, Position: 1},
 		{Name: "tz", Type: TimezType, Position: 2},
@@ -212,7 +212,7 @@ func TestColumnsToArrowSchemaTimeUUID(t *testing.T) {
 // AppendToBuilder must fill a Time64 builder from a bare time-of-day string (as
 // emitted by SQL `time` columns). Previously cast.ToTimeE rejected these and the
 // value silently zeroed to 00:00:00.
-func TestAppendToBuilderTimeOfDay(t *testing.T) {
+func TestArrowAppendToBuilderTimeOfDay(t *testing.T) {
 	col := &Column{Name: "t", Type: TimeType}
 	builder := array.NewTime64Builder(memory.NewGoAllocator(), &arrow.Time64Type{Unit: arrow.Microsecond})
 	defer builder.Release()
@@ -230,7 +230,7 @@ func TestAppendToBuilderTimeOfDay(t *testing.T) {
 	assert.True(t, arr.IsNull(2), "nil should append null")
 }
 
-func TestParseTimeOfDayE(t *testing.T) {
+func TestArrowParseTimeOfDayE(t *testing.T) {
 	for _, s := range []string{"08:30:00.0000000", "08:30:00", "08:30"} {
 		tVal, err := parseTimeOfDayE(s)
 		assert.NoError(t, err, "input %q", s)
@@ -250,7 +250,7 @@ func TestParseTimeOfDayE(t *testing.T) {
 // AppendToBuilder must round-trip a canonical UUID string into the arrow.uuid
 // extension builder. With the schema fix, uuid columns now map to UUIDBuilder
 // instead of String, so this value path is exercised end-to-end.
-func TestAppendToBuilderUUID(t *testing.T) {
+func TestArrowAppendToBuilderUUID(t *testing.T) {
 	col := &Column{Name: "u", Type: UUIDType}
 	builder := extensions.NewUUIDBuilder(memory.NewGoAllocator())
 	defer builder.Release()

--- a/core/dbio/iop/arrow_test.go
+++ b/core/dbio/iop/arrow_test.go
@@ -6,6 +6,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/extensions"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 )
@@ -185,4 +189,60 @@ func TestArrowReaderWithSelectedColumns(t *testing.T) {
 	}
 
 	assert.Equal(t, len(testData), rowCount)
+}
+
+// ColumnsToArrowSchema must map time/timez/uuid to their native Arrow types so the
+// schema matches iopTypeToIcebergPrimitiveType. Previously they fell through to
+// String, causing "cannot promote string to time/uuid" when appending to Iceberg.
+func TestColumnsToArrowSchemaTimeUUID(t *testing.T) {
+	columns := Columns{
+		{Name: "t", Type: TimeType, Position: 1},
+		{Name: "tz", Type: TimezType, Position: 2},
+		{Name: "u", Type: UUIDType, Position: 3},
+	}
+
+	schema := ColumnsToArrowSchema(columns)
+
+	assert.IsType(t, &arrow.Time64Type{}, schema.Field(0).Type)
+	assert.IsType(t, &arrow.Time64Type{}, schema.Field(1).Type)
+	_, isUUID := schema.Field(2).Type.(*extensions.UUIDType)
+	assert.True(t, isUUID, "uuid column should map to the arrow.uuid extension type, got %T", schema.Field(2).Type)
+}
+
+// AppendToBuilder must fill a Time64 builder from a bare time-of-day string (as
+// emitted by SQL `time` columns). Previously cast.ToTimeE rejected these and the
+// value silently zeroed to 00:00:00.
+func TestAppendToBuilderTimeOfDay(t *testing.T) {
+	col := &Column{Name: "t", Type: TimeType}
+	builder := array.NewTime64Builder(memory.NewGoAllocator(), &arrow.Time64Type{Unit: arrow.Microsecond})
+	defer builder.Release()
+
+	AppendToBuilder(builder, col, "08:30:00.0000000")
+	AppendToBuilder(builder, col, "08:30:00")
+	AppendToBuilder(builder, col, nil)
+
+	arr := builder.NewTime64Array()
+	defer arr.Release()
+
+	wantMicros := arrow.Time64(int64((8*3600 + 30*60) * 1e6))
+	assert.Equal(t, wantMicros, arr.Value(0), "fractional time-of-day not parsed")
+	assert.Equal(t, wantMicros, arr.Value(1), "plain time-of-day not parsed")
+	assert.True(t, arr.IsNull(2), "nil should append null")
+}
+
+func TestParseTimeOfDayE(t *testing.T) {
+	for _, s := range []string{"08:30:00.0000000", "08:30:00", "08:30"} {
+		tVal, err := parseTimeOfDayE(s)
+		assert.NoError(t, err, "input %q", s)
+		assert.Equal(t, 8, tVal.Hour())
+		assert.Equal(t, 30, tVal.Minute())
+	}
+
+	// full datetime still works (delegates to cast.ToTimeE)
+	tVal, err := parseTimeOfDayE("2023-01-02 15:04:05")
+	assert.NoError(t, err)
+	assert.Equal(t, 15, tVal.Hour())
+
+	_, err = parseTimeOfDayE("not a time")
+	assert.Error(t, err)
 }

--- a/core/dbio/iop/arrow_test.go
+++ b/core/dbio/iop/arrow_test.go
@@ -246,3 +246,24 @@ func TestParseTimeOfDayE(t *testing.T) {
 	_, err = parseTimeOfDayE("not a time")
 	assert.Error(t, err)
 }
+
+// AppendToBuilder must round-trip a canonical UUID string into the arrow.uuid
+// extension builder. With the schema fix, uuid columns now map to UUIDBuilder
+// instead of String, so this value path is exercised end-to-end.
+func TestAppendToBuilderUUID(t *testing.T) {
+	col := &Column{Name: "u", Type: UUIDType}
+	builder := extensions.NewUUIDBuilder(memory.NewGoAllocator())
+	defer builder.Release()
+
+	AppendToBuilder(builder, col, "B86D9F47-F5E1-44A1-9576-1AEF61206EB1") // uppercase
+	AppendToBuilder(builder, col, "b86d9f47-f5e1-44a1-9576-1aef61206eb1") // lowercase
+	AppendToBuilder(builder, col, nil)
+
+	arr := builder.NewArray().(*extensions.UUIDArray)
+	defer arr.Release()
+
+	want := "b86d9f47-f5e1-44a1-9576-1aef61206eb1"
+	assert.Equal(t, want, arr.ValueStr(0), "uppercase uuid should normalize and round-trip")
+	assert.Equal(t, want, arr.ValueStr(1), "lowercase uuid should round-trip")
+	assert.True(t, arr.IsNull(2), "nil should append null")
+}

--- a/core/dbio/iop/column_modifiers.go
+++ b/core/dbio/iop/column_modifiers.go
@@ -1,0 +1,521 @@
+package iop
+
+import (
+	"crypto/md5"
+	"fmt"
+	"strings"
+
+	"github.com/flarco/g"
+	"github.com/spf13/cast"
+)
+
+// IndexDef is the unified internal representation of an index, populated both
+// from the columns: inline modifier DSL and from target_options.table_keys.index.
+// DDL generation reads from this single source of truth.
+type IndexDef struct {
+	Name       string        `json:"name,omitempty"`       // auto-generated if empty
+	Columns    []IndexColumn `json:"columns,omitempty"`    // mutually exclusive with Expression
+	Expression string        `json:"expression,omitempty"` // raw SQL for expression indexes
+	Unique     bool          `json:"unique,omitempty"`
+	Where      string        `json:"where,omitempty"`
+	Type       string        `json:"type,omitempty"` // btree / hash / gin / ...
+	Include    []string      `json:"include,omitempty"`
+
+	// Priority is used only while merging column-inline composite indexes (same
+	// index Name across multiple columns); it orders the columns and is not part
+	// of the rendered DDL.
+	Priority int `json:"priority,omitempty"`
+}
+
+// IndexColumn is one column (or per-column expression) within an index.
+type IndexColumn struct {
+	Name string `json:"name"`           // column name or expression
+	Sort string `json:"sort,omitempty"` // "asc" / "desc" / ""
+}
+
+// ColumnNames returns the column/expression names of the index.
+func (id IndexDef) ColumnNames() (names []string) {
+	for _, c := range id.Columns {
+		names = append(names, c.Name)
+	}
+	return
+}
+
+// reservedModifiers are recognized as well-formed but not yet supported in v1.
+// The tokenizer accepts their shape and returns a clear "not yet supported" error
+// so they can be added later without grammar changes.
+var reservedModifiers = map[string]bool{
+	"default":        true,
+	"check":          true,
+	"auto_increment": true,
+	"identity":       true,
+}
+
+// ParseModifiers parses the column type slot for the modifier DSL:
+//
+//	<type> [<modifier> ...]
+//
+// where <modifier> is one of: not_null, nullable, primary_key, unique,
+// description(<text>), index, index(<kwargs>), unique_index(<kwargs>).
+//
+// It mutates the column's Type, Metadata, Description and inline index metadata.
+// It must be called on the type slot only (after the `|` runtime-constraint split
+// performed by SetConstraint).
+func (col *Column) ParseModifiers() (err error) {
+	raw := strings.TrimSpace(string(col.Type))
+	if raw == "" {
+		return nil
+	}
+
+	tokens, err := tokenizeModifiers(raw)
+	if err != nil {
+		return g.Error(err, "could not parse modifiers for column %s", col.Name)
+	}
+	if len(tokens) <= 1 {
+		return nil // just a type, no modifiers
+	}
+
+	// first token is the type (may itself carry (length)/(precision,scale))
+	col.Type = ColumnType(tokens[0])
+
+	var indexDefs []IndexDef
+	sawNotNull, sawNullable := false, false
+
+	for _, tok := range tokens[1:] {
+		name, payload, hasPayload := splitModifier(tok)
+		lname := strings.ToLower(name)
+
+		// reserved-but-unsupported modifiers (with or without payload)
+		if reservedModifiers[lname] {
+			return g.Error("column %s: modifier %q is not yet supported", col.Name, lname)
+		}
+
+		switch lname {
+		case "not_null":
+			if hasPayload {
+				return g.Error("column %s: modifier not_null does not take arguments", col.Name)
+			}
+			sawNotNull = true
+			col.SetMetadata(ColMetaNullable.String(), "false")
+			col.SetMetadata(ColMetaDDLExplicit.String(), "true")
+		case "nullable":
+			if hasPayload {
+				return g.Error("column %s: modifier nullable does not take arguments", col.Name)
+			}
+			sawNullable = true
+			col.SetMetadata(ColMetaNullable.String(), "true")
+			col.SetMetadata(ColMetaDDLExplicit.String(), "true")
+		case "primary_key":
+			if hasPayload {
+				return g.Error("column %s: modifier primary_key does not take arguments", col.Name)
+			}
+			col.SetMetadata(ColMetaIsPrimaryKey.String(), "true")
+			col.SetMetadata(ColMetaDDLExplicit.String(), "true")
+		case "unique":
+			if hasPayload {
+				return g.Error("column %s: modifier unique does not take arguments", col.Name)
+			}
+			col.SetMetadata(ColMetaUnique.String(), "true")
+			col.SetMetadata(ColMetaDDLExplicit.String(), "true")
+		case "description":
+			if !hasPayload {
+				return g.Error("column %s: modifier description requires a value, e.g. description('...')", col.Name)
+			}
+			text, err := parseStringPayload(payload)
+			if err != nil {
+				return g.Error(err, "column %s: invalid description value", col.Name)
+			}
+			col.Description = text
+			col.SetMetadata(ColMetaDescription.String(), text)
+			col.SetMetadata(ColMetaDDLExplicit.String(), "true")
+		case "index", "unique_index":
+			def, err := parseIndexModifier(payload, hasPayload, lname == "unique_index")
+			if err != nil {
+				return g.Error(err, "column %s: invalid %s modifier", col.Name, lname)
+			}
+			indexDefs = append(indexDefs, def)
+		default:
+			return g.Error("column %s: unknown modifier %q", col.Name, name)
+		}
+	}
+
+	if sawNotNull && sawNullable {
+		return g.Error("column %s: conflicting modifiers not_null and nullable", col.Name)
+	}
+
+	if len(indexDefs) > 0 {
+		col.SetMetadata(ColMetaIndex.String(), g.Marshal(indexDefs))
+	}
+
+	return nil
+}
+
+// tokenizeModifiers splits a string on whitespace while keeping balanced parens
+// and quoted runs (single quotes, double quotes and backticks) intact.
+func tokenizeModifiers(s string) (tokens []string, err error) {
+	var b strings.Builder
+	depth := 0
+	var quote rune // 0 if not in quote, else the quote rune
+
+	flush := func() {
+		if b.Len() > 0 {
+			tokens = append(tokens, b.String())
+			b.Reset()
+		}
+	}
+
+	for _, r := range s {
+		switch {
+		case quote != 0:
+			b.WriteRune(r)
+			if r == quote {
+				quote = 0
+			}
+		case r == '\'' || r == '"' || r == '`':
+			quote = r
+			b.WriteRune(r)
+		case r == '(':
+			depth++
+			b.WriteRune(r)
+		case r == ')':
+			depth--
+			if depth < 0 {
+				return nil, g.Error("unbalanced parenthesis")
+			}
+			b.WriteRune(r)
+		case (r == ' ' || r == '\t' || r == '\n') && depth == 0:
+			flush()
+		default:
+			b.WriteRune(r)
+		}
+	}
+
+	if depth != 0 {
+		return nil, g.Error("unbalanced parenthesis")
+	}
+	if quote != 0 {
+		return nil, g.Error("unterminated quote")
+	}
+	flush()
+
+	return tokens, nil
+}
+
+// splitModifier separates a modifier token into its name and optional
+// parenthesized payload. e.g. "index(name=foo)" => ("index", "name=foo", true).
+func splitModifier(tok string) (name, payload string, hasPayload bool) {
+	idx := strings.Index(tok, "(")
+	if idx < 0 {
+		return tok, "", false
+	}
+	name = tok[:idx]
+	// payload is everything between the first ( and the matching trailing )
+	inner := tok[idx+1:]
+	inner = strings.TrimSuffix(inner, ")")
+	return name, inner, true
+}
+
+// parseStringPayload parses a single string argument that may be wrapped in
+// single quotes, double quotes or backticks. Doubled quotes ('' or "") unescape
+// to a single quote, matching SQL string-literal conventions.
+func parseStringPayload(payload string) (string, error) {
+	s := strings.TrimSpace(payload)
+	if s == "" {
+		return "", nil
+	}
+	if len(s) >= 2 && (s[0] == '\'' || s[0] == '"' || s[0] == '`') {
+		q := s[0]
+		if s[len(s)-1] != q {
+			return "", g.Error("unterminated quoted value: %s", payload)
+		}
+		inner := s[1 : len(s)-1]
+		switch q {
+		case '\'':
+			inner = strings.ReplaceAll(inner, "''", "'")
+		case '"':
+			inner = strings.ReplaceAll(inner, `""`, `"`)
+		}
+		return inner, nil
+	}
+	return s, nil
+}
+
+// parseIndexModifier parses the kwargs of an index(...)/unique_index(...) modifier.
+func parseIndexModifier(payload string, hasPayload, unique bool) (def IndexDef, err error) {
+	def.Unique = unique
+
+	if !hasPayload || strings.TrimSpace(payload) == "" {
+		return def, nil // bare `index` / `index()`
+	}
+
+	kwargs, err := parseKwargs(payload)
+	if err != nil {
+		return def, err
+	}
+
+	for k, v := range kwargs {
+		switch strings.ToLower(k) {
+		case "name":
+			def.Name = v
+		case "priority":
+			def.Priority = cast.ToInt(v)
+		case "sort":
+			sort := strings.ToLower(v)
+			if sort != "asc" && sort != "desc" {
+				return def, g.Error("invalid sort value %q (expected asc/desc)", v)
+			}
+			// applied to the column placeholder below
+			def.Columns = []IndexColumn{{Sort: sort}}
+		case "where":
+			def.Where = v
+		case "type", "using":
+			def.Type = strings.ToLower(v)
+		case "include":
+			for _, part := range strings.Split(v, ",") {
+				if p := strings.TrimSpace(part); p != "" {
+					def.Include = append(def.Include, p)
+				}
+			}
+		case "unique":
+			def.Unique = cast.ToBool(v)
+		default:
+			return def, g.Error("unknown index kwarg %q", k)
+		}
+	}
+
+	return def, nil
+}
+
+// parseKwargs parses a comma-separated list of key=value pairs where values may
+// be single-quoted or backtick-quoted (commas inside quotes are preserved).
+func parseKwargs(payload string) (kwargs map[string]string, err error) {
+	kwargs = map[string]string{}
+
+	parts, err := splitTopLevel(payload, ',')
+	if err != nil {
+		return nil, err
+	}
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		eq := strings.Index(part, "=")
+		if eq < 0 {
+			return nil, g.Error("invalid index kwarg %q (expected key=value)", part)
+		}
+		key := strings.TrimSpace(part[:eq])
+		val, err := parseStringPayload(strings.TrimSpace(part[eq+1:]))
+		if err != nil {
+			return nil, err
+		}
+		kwargs[key] = val
+	}
+
+	return kwargs, nil
+}
+
+// splitTopLevel splits on sep while respecting balanced parens and quoted runs.
+func splitTopLevel(s string, sep rune) (parts []string, err error) {
+	var b strings.Builder
+	depth := 0
+	var quote rune
+
+	for _, r := range s {
+		switch {
+		case quote != 0:
+			b.WriteRune(r)
+			if r == quote {
+				quote = 0
+			}
+		case r == '\'' || r == '"' || r == '`':
+			quote = r
+			b.WriteRune(r)
+		case r == '(':
+			depth++
+			b.WriteRune(r)
+		case r == ')':
+			depth--
+			b.WriteRune(r)
+		case r == sep && depth == 0:
+			parts = append(parts, b.String())
+			b.Reset()
+		default:
+			b.WriteRune(r)
+		}
+	}
+	if quote != 0 {
+		return nil, g.Error("unterminated quote")
+	}
+	parts = append(parts, b.String())
+
+	return parts, nil
+}
+
+// CollectInlineIndexes gathers the inline index definitions declared across all
+// columns via the columns: modifier DSL and merges them into final []IndexDef.
+//
+// Columns sharing the same index Name form a composite index, ordered by
+// Priority. Per-column attributes are Priority and Sort; shared attributes
+// (Where, Type, Unique, Include) must be identical (or omitted) across every
+// column declaring the same named index, else an error is returned. Anonymous
+// indexes (no Name) are auto-named idx_<table>_<col> and never merged.
+func (cols Columns) CollectInlineIndexes(tableName string, maxLength int) (defs []IndexDef, err error) {
+	// in-progress named composite: the def plus the per-column priorities
+	type composite struct {
+		def        *IndexDef
+		priorities []int
+	}
+
+	order := []string{} // preserve declaration order of named composites
+	named := map[string]*composite{}
+
+	for _, col := range cols {
+		for _, raw := range col.GetIndexDefs() {
+			colName := col.Name
+			sort := ""
+			if len(raw.Columns) == 1 {
+				sort = raw.Columns[0].Sort
+			}
+
+			if raw.Name == "" {
+				// anonymous single-column index, auto-named, never merged
+				defs = append(defs, IndexDef{
+					Name:    MakeIndexName(tableName, []string{colName}, maxLength),
+					Columns: []IndexColumn{{Name: colName, Sort: sort}},
+					Unique:  raw.Unique,
+					Where:   raw.Where,
+					Type:    raw.Type,
+					Include: raw.Include,
+				})
+				continue
+			}
+
+			// named index: merge by name
+			existing, ok := named[raw.Name]
+			if !ok {
+				named[raw.Name] = &composite{
+					def: &IndexDef{
+						Name:    raw.Name,
+						Columns: []IndexColumn{{Name: colName, Sort: sort}},
+						Unique:  raw.Unique,
+						Where:   raw.Where,
+						Type:    raw.Type,
+						Include: raw.Include,
+					},
+					priorities: []int{raw.Priority},
+				}
+				order = append(order, raw.Name)
+				continue
+			}
+
+			// consistency checks for shared attributes
+			if err = mergeSharedAttr("where", raw.Name, &existing.def.Where, raw.Where); err != nil {
+				return nil, err
+			}
+			if err = mergeSharedAttr("type", raw.Name, &existing.def.Type, raw.Type); err != nil {
+				return nil, err
+			}
+			exInc := strings.Join(existing.def.Include, ",")
+			if err = mergeSharedAttr("include", raw.Name, &exInc, strings.Join(raw.Include, ",")); err != nil {
+				return nil, err
+			}
+			if exInc != "" {
+				existing.def.Include = strings.Split(exInc, ",")
+			}
+			// unique: if any column declares unique_index, the whole index is unique
+			if raw.Unique {
+				existing.def.Unique = true
+			}
+
+			existing.def.Columns = append(existing.def.Columns, IndexColumn{Name: colName, Sort: sort})
+			existing.priorities = append(existing.priorities, raw.Priority)
+		}
+	}
+
+	// finalize named composites: validate priorities, order columns by priority
+	for _, name := range order {
+		c := named[name]
+
+		seen := map[int]bool{}
+		anySet := false
+		for _, p := range c.priorities {
+			if p != 0 {
+				anySet = true
+				if seen[p] {
+					return nil, g.Error("index %q: duplicate priority %d", name, p)
+				}
+				seen[p] = true
+			}
+		}
+
+		if anySet && len(c.def.Columns) > 1 {
+			// stable insertion sort columns by priority (dependency-free)
+			for i := 1; i < len(c.def.Columns); i++ {
+				for j := i; j > 0 && c.priorities[j-1] > c.priorities[j]; j-- {
+					c.priorities[j-1], c.priorities[j] = c.priorities[j], c.priorities[j-1]
+					c.def.Columns[j-1], c.def.Columns[j] = c.def.Columns[j], c.def.Columns[j-1]
+				}
+			}
+		}
+
+		defs = append(defs, *c.def)
+	}
+
+	return defs, nil
+}
+
+// mergeSharedAttr enforces that a shared index attribute is identical (or
+// omitted) across all columns declaring the same named index.
+func mergeSharedAttr(attr, idxName string, existing *string, incoming string) error {
+	if incoming == "" {
+		return nil
+	}
+	if *existing == "" {
+		*existing = incoming
+		return nil
+	}
+	if *existing != incoming {
+		return g.Error("index %q: conflicting %s values (%q vs %q); shared index attributes must match across columns", idxName, attr, *existing, incoming)
+	}
+	return nil
+}
+
+// MakeIndexName builds a deterministic index name from a table name and the
+// index's column/expression names. When the result exceeds maxLength (the
+// dialect's identifier limit), it truncates and appends a short stable hash
+// suffix so distinct auto-named indexes never collide on a shared prefix.
+func MakeIndexName(tableName string, parts []string, maxLength int) string {
+	clean := func(s string) string {
+		// keep identifier-friendly characters for the readable portion
+		s = strings.ToLower(s)
+		s = replacePattern.ReplaceAllString(s, "_")
+		return strings.Trim(s, "_")
+	}
+
+	nameParts := []string{"idx", clean(tableName)}
+	for _, p := range parts {
+		if c := clean(p); c != "" {
+			nameParts = append(nameParts, c)
+		}
+	}
+	full := strings.Join(nameParts, "_")
+
+	if maxLength <= 0 || len(full) <= maxLength {
+		return full
+	}
+
+	// deterministic 6-char hash of the full untruncated name
+	sum := md5.Sum([]byte(full))
+	hash := fmt.Sprintf("%x", sum)[:6]
+
+	keep := maxLength - 7 // "_" + 6-char hash
+	if keep < 1 {
+		keep = 1
+	}
+	if keep > len(full) {
+		keep = len(full)
+	}
+	return full[:keep] + "_" + hash
+}

--- a/core/dbio/iop/column_modifiers_test.go
+++ b/core/dbio/iop/column_modifiers_test.go
@@ -1,0 +1,345 @@
+package iop
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// parseCol is a helper that runs the same pipeline as ColumnsPrepared:
+// SetConstraint -> ParseModifiers -> SetLengthPrecisionScale
+func parseCol(t *testing.T, name, typeStr string) (Column, error) {
+	t.Helper()
+	col := Column{Name: name, Type: ColumnType(typeStr)}
+	col.SetConstraint()
+	err := col.ParseModifiers()
+	if err != nil {
+		return col, err
+	}
+	col.SetLengthPrecisionScale()
+	return col, nil
+}
+
+func TestParseModifiersSingle(t *testing.T) {
+	// not_null
+	col, err := parseCol(t, "id", "bigint not_null")
+	require.NoError(t, err)
+	assert.Equal(t, BigIntType, col.Type)
+	assert.False(t, col.IsNullable())
+	assert.True(t, col.IsDDLExplicit())
+
+	// nullable
+	col, err = parseCol(t, "notes", "text nullable")
+	require.NoError(t, err)
+	assert.True(t, col.IsNullable())
+
+	// primary_key
+	col, err = parseCol(t, "id", "bigint primary_key")
+	require.NoError(t, err)
+	assert.True(t, col.IsPrimaryKey())
+
+	// unique
+	col, err = parseCol(t, "email", "text unique")
+	require.NoError(t, err)
+	assert.True(t, col.HasUniqueConstraint())
+}
+
+func TestParseModifiersDescription(t *testing.T) {
+	col, err := parseCol(t, "desc_col", "text description('hello world')")
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", col.Description)
+	assert.Equal(t, TextType, col.Type)
+
+	// nested parens in payload
+	col, err = parseCol(t, "desc_col", "text description('see (note)')")
+	require.NoError(t, err)
+	assert.Equal(t, "see (note)", col.Description)
+
+	// doubled single-quote escaping
+	col, err = parseCol(t, "desc_col", "text description('it''s fine')")
+	require.NoError(t, err)
+	assert.Equal(t, "it's fine", col.Description)
+
+	// double-quote inside single-quoted value
+	col, err = parseCol(t, "desc_col", `text description('she said "hi"')`)
+	require.NoError(t, err)
+	assert.Equal(t, `she said "hi"`, col.Description)
+
+	// double-quoted payload (single quote inside is a literal)
+	col, err = parseCol(t, "desc_col", `text description("hello world won't do")`)
+	require.NoError(t, err)
+	assert.Equal(t, "hello world won't do", col.Description)
+
+	// doubled double-quote escaping inside double-quoted value
+	col, err = parseCol(t, "desc_col", `text description("she said ""hi""")`)
+	require.NoError(t, err)
+	assert.Equal(t, `she said "hi"`, col.Description)
+}
+
+func TestParseModifiersOrderIndependence(t *testing.T) {
+	a, err := parseCol(t, "id", "bigint not_null primary_key")
+	require.NoError(t, err)
+	b, err := parseCol(t, "id", "bigint primary_key not_null")
+	require.NoError(t, err)
+
+	assert.False(t, a.IsNullable())
+	assert.True(t, a.IsPrimaryKey())
+	assert.Equal(t, a.IsNullable(), b.IsNullable())
+	assert.Equal(t, a.IsPrimaryKey(), b.IsPrimaryKey())
+}
+
+func TestParseModifiersCaseInsensitive(t *testing.T) {
+	col, err := parseCol(t, "id", "bigint NOT_NULL Primary_Key")
+	require.NoError(t, err)
+	assert.False(t, col.IsNullable())
+	assert.True(t, col.IsPrimaryKey())
+
+	col, err = parseCol(t, "desc_col", "text Description('hi')")
+	require.NoError(t, err)
+	assert.Equal(t, "hi", col.Description)
+}
+
+func TestParseModifiersConflict(t *testing.T) {
+	_, err := parseCol(t, "id", "bigint not_null nullable")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicting")
+}
+
+func TestParseModifiersWithRuntimeConstraint(t *testing.T) {
+	col := Column{Name: "val", Type: ColumnType("int not_null | value > 0")}
+	col.SetConstraint()
+	// after SetConstraint, the type slot retains the modifiers, the | is split off
+	require.NoError(t, col.ParseModifiers())
+	col.SetLengthPrecisionScale()
+
+	assert.Equal(t, ColumnType("int"), col.Type) // normalization to "integer" happens later in NewColumns
+	assert.False(t, col.IsNullable())
+	// runtime constraint expression preserved
+	if col.Constraint != nil {
+		assert.Equal(t, "value > 0", col.Constraint.Expression)
+	}
+}
+
+func TestParseModifiersLengthPrecision(t *testing.T) {
+	col, err := parseCol(t, "amount", "decimal(10,2) not_null")
+	require.NoError(t, err)
+	assert.Equal(t, DecimalType, col.Type)
+	assert.Equal(t, 10, col.DbPrecision)
+	assert.Equal(t, 2, col.DbScale)
+	assert.False(t, col.IsNullable())
+
+	col, err = parseCol(t, "name", "string(100) unique")
+	require.NoError(t, err)
+	assert.Equal(t, StringType, col.Type)
+	assert.Equal(t, 100, col.DbPrecision)
+	assert.True(t, col.HasUniqueConstraint())
+}
+
+func TestParseModifiersIndex(t *testing.T) {
+	// bare index
+	col, err := parseCol(t, "search_col", "text index")
+	require.NoError(t, err)
+	defs := col.GetIndexDefs()
+	require.Len(t, defs, 1)
+	assert.False(t, defs[0].Unique)
+
+	// index()
+	col, err = parseCol(t, "search_col", "text index()")
+	require.NoError(t, err)
+	require.Len(t, col.GetIndexDefs(), 1)
+
+	// index(name=foo)
+	col, err = parseCol(t, "c", "text index(name=foo)")
+	require.NoError(t, err)
+	defs = col.GetIndexDefs()
+	require.Len(t, defs, 1)
+	assert.Equal(t, "foo", defs[0].Name)
+
+	// index with priority/sort
+	col, err = parseCol(t, "ts", "timestamptz index(name=foo, priority=3, sort=desc)")
+	require.NoError(t, err)
+	defs = col.GetIndexDefs()
+	require.Len(t, defs, 1)
+	assert.Equal(t, "foo", defs[0].Name)
+	assert.Equal(t, 3, defs[0].Priority)
+	require.Len(t, defs[0].Columns, 1)
+	assert.Equal(t, "desc", defs[0].Columns[0].Sort)
+
+	// index with where
+	col, err = parseCol(t, "org_id", "uuid index(name=foo, where='deleted_at IS NULL')")
+	require.NoError(t, err)
+	defs = col.GetIndexDefs()
+	require.Len(t, defs, 1)
+	assert.Equal(t, "deleted_at IS NULL", defs[0].Where)
+
+	// index with a double-quoted where containing single-quoted SQL literals
+	col, err = parseCol(t, "created_at", `timestamp index(name=idx_x, where="created_at = '2001-01-01'")`)
+	require.NoError(t, err)
+	defs = col.GetIndexDefs()
+	require.Len(t, defs, 1)
+	assert.Equal(t, "idx_x", defs[0].Name)
+	assert.Equal(t, "created_at = '2001-01-01'", defs[0].Where)
+
+	// index with type
+	col, err = parseCol(t, "doc", "json index(name=foo, type=gin)")
+	require.NoError(t, err)
+	defs = col.GetIndexDefs()
+	require.Len(t, defs, 1)
+	assert.Equal(t, "gin", defs[0].Type)
+
+	// unique_index
+	col, err = parseCol(t, "email", "text unique_index(name=bar)")
+	require.NoError(t, err)
+	defs = col.GetIndexDefs()
+	require.Len(t, defs, 1)
+	assert.True(t, defs[0].Unique)
+	assert.Equal(t, "bar", defs[0].Name)
+}
+
+func TestParseModifiersIndexBacktick(t *testing.T) {
+	col, err := parseCol(t, "org_id", "uuid index(name=foo, where=`x is null`)")
+	require.NoError(t, err)
+	defs := col.GetIndexDefs()
+	require.Len(t, defs, 1)
+	assert.Equal(t, "x is null", defs[0].Where)
+}
+
+func TestParseModifiersReserved(t *testing.T) {
+	reserved := []string{
+		"int default(now())",
+		"int check(value >= 0)",
+		"int auto_increment",
+		"int identity",
+		"int identity(1, 1)",
+	}
+	for _, ts := range reserved {
+		_, err := parseCol(t, "c", ts)
+		require.Error(t, err, "expected error for %q", ts)
+		assert.Contains(t, err.Error(), "not yet supported", "for %q", ts)
+	}
+}
+
+func TestParseModifiersNoModifiers(t *testing.T) {
+	// plain types must be unaffected
+	col, err := parseCol(t, "c", "text")
+	require.NoError(t, err)
+	assert.Equal(t, TextType, col.Type)
+	assert.True(t, col.IsNullable())
+	assert.False(t, col.IsDDLExplicit())
+	assert.Nil(t, col.GetIndexDefs())
+
+	col, err = parseCol(t, "c", "decimal(10,2)")
+	require.NoError(t, err)
+	assert.Equal(t, DecimalType, col.Type)
+	assert.Equal(t, 10, col.DbPrecision)
+	assert.Equal(t, 2, col.DbScale)
+}
+
+func TestMakeIndexName(t *testing.T) {
+	// short name passes through
+	assert.Equal(t, "idx_bar_foo", MakeIndexName("bar", []string{"foo"}, 63))
+
+	// composite
+	assert.Equal(t, "idx_t_a_b", MakeIndexName("t", []string{"a", "b"}, 63))
+
+	// truncation with deterministic hash suffix
+	long := MakeIndexName("verylongtablename", []string{"verylongcolumnnameone", "verylongcolumnnametwo"}, 30)
+	assert.LessOrEqual(t, len(long), 30)
+	long2 := MakeIndexName("verylongtablename", []string{"verylongcolumnnameone", "verylongcolumnnametwo"}, 30)
+	assert.Equal(t, long, long2, "must be deterministic")
+
+	// distinct inputs that share a truncation prefix get distinct hashes
+	a := MakeIndexName("t", []string{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_x"}, 20)
+	b := MakeIndexName("t", []string{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_y"}, 20)
+	assert.NotEqual(t, a, b)
+}
+
+func mkCol(t *testing.T, name, typeStr string) Column {
+	t.Helper()
+	col, err := parseCol(t, name, typeStr)
+	require.NoError(t, err)
+	return col
+}
+
+func TestCollectInlineIndexesComposite(t *testing.T) {
+	cols := Columns{
+		mkCol(t, "timestamp", "timestamptz index(name=idx_hb, priority=3, sort=desc)"),
+		mkCol(t, "project_id", "uuid index(name=idx_hb, priority=1)"),
+		mkCol(t, "agent_id", "uuid index(name=idx_hb, priority=2)"),
+	}
+	defs, err := cols.CollectInlineIndexes("heartbeats", 63)
+	require.NoError(t, err)
+	require.Len(t, defs, 1)
+
+	d := defs[0]
+	assert.Equal(t, "idx_hb", d.Name)
+	require.Len(t, d.Columns, 3)
+	// ordered by priority
+	assert.Equal(t, "project_id", d.Columns[0].Name)
+	assert.Equal(t, "agent_id", d.Columns[1].Name)
+	assert.Equal(t, "timestamp", d.Columns[2].Name)
+	assert.Equal(t, "desc", d.Columns[2].Sort)
+}
+
+func TestCollectInlineIndexesConsistencyViolation(t *testing.T) {
+	cols := Columns{
+		mkCol(t, "a", "uuid index(name=idx_x, where='deleted_at IS NULL')"),
+		mkCol(t, "b", "uuid index(name=idx_x, where='created_at IS NULL')"),
+	}
+	_, err := cols.CollectInlineIndexes("t", 63)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicting where")
+}
+
+func TestCollectInlineIndexesDuplicatePriority(t *testing.T) {
+	cols := Columns{
+		mkCol(t, "a", "uuid index(name=idx_x, priority=1)"),
+		mkCol(t, "b", "uuid index(name=idx_x, priority=1)"),
+	}
+	_, err := cols.CollectInlineIndexes("t", 63)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate priority")
+}
+
+func TestCollectInlineIndexesAutoName(t *testing.T) {
+	cols := Columns{
+		mkCol(t, "search_col", "text index"),
+	}
+	defs, err := cols.CollectInlineIndexes("bar", 63)
+	require.NoError(t, err)
+	require.Len(t, defs, 1)
+	assert.Equal(t, "idx_bar_search_col", defs[0].Name)
+	require.Len(t, defs[0].Columns, 1)
+	assert.Equal(t, "search_col", defs[0].Columns[0].Name)
+}
+
+func TestCollectInlineIndexesUniqueShared(t *testing.T) {
+	cols := Columns{
+		mkCol(t, "email", "text unique_index(name=idx_email)"),
+	}
+	defs, err := cols.CollectInlineIndexes("users", 63)
+	require.NoError(t, err)
+	require.Len(t, defs, 1)
+	assert.True(t, defs[0].Unique)
+}
+
+func TestTokenizeModifiers(t *testing.T) {
+	toks, err := tokenizeModifiers("bigint not_null primary_key")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"bigint", "not_null", "primary_key"}, toks)
+
+	// parens keep payload together
+	toks, err = tokenizeModifiers("text index(name=foo, priority=1)")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"text", "index(name=foo, priority=1)"}, toks)
+
+	// quotes preserve spaces
+	toks, err = tokenizeModifiers("uuid index(where='a b c')")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"uuid", "index(where='a b c')"}, toks)
+
+	// unbalanced
+	_, err = tokenizeModifiers("text index(name=foo")
+	require.Error(t, err)
+}

--- a/core/dbio/iop/datatype.go
+++ b/core/dbio/iop/datatype.go
@@ -2071,8 +2071,9 @@ func (s *Selector) OrderFields(fields []string) []string {
 }
 
 // ApplySelect filters, renames, and reorders fields per the select grammar:
-//   "field" include · "-field" exclude · "field as new" rename
-//   "*" all-not-pinned · "prefix*"/"*suffix" glob include · "-prefix*"/"-*suffix" glob exclude
+//
+//	"field" include · "-field" exclude · "field as new" rename
+//	"*" all-not-pinned · "prefix*"/"*suffix" glob include · "-prefix*"/"-*suffix" glob exclude
 //
 // Output follows expression order; `*` and globs expand in source order and
 // skip names pinned elsewhere in the list (so `[id, *, created_at]` keeps
@@ -2350,7 +2351,9 @@ func ApplySelectExprs(fields []string, selectExprs []string) (newFields []string
 		}
 		if matched == "" {
 			if newName != "" {
-				return nil, g.Error("field '%s' not found for rename", field)
+				// pass through unmatched rename as a SQL expression alias
+				newFields = append(newFields, field+" as "+newName)
+				continue
 			}
 			if !hasSelectAll {
 				return nil, g.Error("field '%s' not found", field)

--- a/core/dbio/iop/datatype.go
+++ b/core/dbio/iop/datatype.go
@@ -122,6 +122,17 @@ const (
 	// Primary Key
 	ColMetaIsPrimaryKey ColMetaKey = "is_primary_key" // "true" if column is part of primary key
 
+	// Unique
+	ColMetaUnique ColMetaKey = "unique" // "true" if column has a UNIQUE constraint
+
+	// Index (JSON-encoded []IndexDef contributed by this column's inline index modifiers)
+	ColMetaIndex ColMetaKey = "index"
+
+	// DDLExplicit marks that DDL constraints were declared explicitly via the
+	// columns: modifier DSL (not_null, primary_key, unique, description), so they
+	// should be rendered at CREATE time even when schema-migration is not enabled.
+	ColMetaDDLExplicit ColMetaKey = "ddl_explicit"
+
 	// Foreign Keys (JSON struct)
 	ColMetaForeignKey ColMetaKey = "foreign_key"
 
@@ -139,7 +150,8 @@ func (cmk ColMetaKey) String() string {
 // ColMetaKeys is a list of all column metadata keys
 var ColMetaKeys = []ColMetaKey{
 	ColMetaAutoIncrement, ColMetaIdentitySeed, ColMetaIdentityIncr,
-	ColMetaNullable, ColMetaDefaultValue, ColMetaIsPrimaryKey, ColMetaForeignKey,
+	ColMetaNullable, ColMetaDefaultValue, ColMetaIsPrimaryKey, ColMetaUnique,
+	ColMetaIndex, ColMetaDDLExplicit, ColMetaForeignKey,
 	ColMetaCheckConstraint, ColMetaDescription,
 }
 
@@ -698,6 +710,7 @@ func (cols Columns) Coerce(castCols Columns, hasHeader bool, casing ColumnCasing
 			newCols[i].DbPrecision = lo.Ternary(col.DbPrecision > 0, col.DbPrecision, newCols[i].DbPrecision)
 			newCols[i].DbScale = lo.Ternary(col.DbScale > 0, col.DbScale, newCols[i].DbScale)
 			newCols[i].Sourced = true
+			newCols[i].mergeDDLMetadata(col)
 			if !newCols[i].Type.IsValid() {
 				g.Warn("Provided unknown column type (%s) for column '%s'. Using string.", newCols[i].Type, newCols[i].Name)
 				newCols[i].Type = StringType
@@ -715,6 +728,7 @@ func (cols Columns) Coerce(castCols Columns, hasHeader bool, casing ColumnCasing
 
 		if castCol != nil {
 			col = *castCol
+			newCols[i].mergeDDLMetadata(col)
 			if col.Type.IsValid() {
 				g.Debug("casting column '%s' as '%s'", col.Name, col.Type)
 				newCols[i].Type = col.Type
@@ -1124,6 +1138,27 @@ func (col *Column) EvaluateConstraint(value any, sp *StreamProcessor) (err error
 	return
 }
 
+// mergeDDLMetadata copies the DDL-relevant metadata (nullable, primary_key,
+// unique, index, description, ddl_explicit) and Description from src onto col.
+// Used when coercing the configured columns: declarations onto the streamed
+// columns so the modifier DSL survives to DDL generation. Only keys present in
+// src are copied (source-derived metadata is otherwise preserved).
+func (col *Column) mergeDDLMetadata(src Column) {
+	if src.Metadata != nil {
+		for _, key := range []ColMetaKey{
+			ColMetaNullable, ColMetaIsPrimaryKey, ColMetaUnique,
+			ColMetaIndex, ColMetaDescription, ColMetaDDLExplicit,
+		} {
+			if v, ok := src.Metadata[key.String()]; ok {
+				col.SetMetadata(key.String(), v)
+			}
+		}
+	}
+	if src.Description != "" {
+		col.Description = src.Description
+	}
+}
+
 func (col *Column) SetMetadata(key string, value string) {
 	if col.Metadata == nil {
 		col.Metadata = map[string]string{}
@@ -1170,6 +1205,41 @@ func (col *Column) IsPrimaryKey() bool {
 		return false
 	}
 	return col.Metadata[ColMetaIsPrimaryKey.String()] == "true"
+}
+
+// HasUniqueConstraint returns true if the column has a UNIQUE constraint declared
+// via the columns: modifier DSL.
+func (col *Column) HasUniqueConstraint() bool {
+	if col.Metadata == nil {
+		return false
+	}
+	return col.Metadata[ColMetaUnique.String()] == "true"
+}
+
+// IsDDLExplicit returns true if DDL constraints were declared explicitly via the
+// columns: modifier DSL (so they apply at CREATE time without schema-migration).
+func (col *Column) IsDDLExplicit() bool {
+	if col.Metadata == nil {
+		return false
+	}
+	return col.Metadata[ColMetaDDLExplicit.String()] == "true"
+}
+
+// GetIndexDefs returns the inline index definitions declared on this column
+// via the columns: modifier DSL (index/index(...)/unique_index(...)).
+func (col *Column) GetIndexDefs() (defs []IndexDef) {
+	if col.Metadata == nil {
+		return nil
+	}
+	val := col.Metadata[ColMetaIndex.String()]
+	if val == "" {
+		return nil
+	}
+	if err := g.Unmarshal(val, &defs); err != nil {
+		g.Warn("could not parse index metadata for column %s: %s", col.Name, err.Error())
+		return nil
+	}
+	return defs
 }
 
 // GetForeignKey returns the foreign key info if present

--- a/core/dbio/iop/datatype.go
+++ b/core/dbio/iop/datatype.go
@@ -1507,28 +1507,30 @@ remap:
 			// Binary columns: fill the () with an explicit byte length so the
 			// target doesn't fall back to a small account-default size (which
 			// truncates large LOBs, e.g. Oracle BLOB/LONG RAW -> Snowflake).
-			// Use the sourced/known length when available, otherwise the
-			// connector's max binary length. Cap at that maximum.
 			maxBinaryLength := cast.ToInt(template.Value("variable.max_binary_length"))
+			maxBinaryType := template.Value("variable.max_binary_type")
 
 			length := col.Stats.MaxLen
 			if col.Sourced && col.DbPrecision > 0 {
 				length = col.DbPrecision
 			}
-			if length <= 0 || (maxBinaryLength > 0 && length > maxBinaryLength) {
-				// unknown or over the cap -> use the maximum the target allows
-				length = maxBinaryLength
-			}
 
-			if length > 0 {
-				nativeType = strings.ReplaceAll(
-					nativeType,
-					"()",
-					fmt.Sprintf("(%d)", length),
-				)
+			overMax := maxBinaryLength > 0 && length > maxBinaryLength
+			if (length <= 0 || overMax) && maxBinaryType != "" {
+				// unknown or over the sized limit -> use the unbounded type
+				// (e.g. varbinary(max), longblob)
+				nativeType = maxBinaryType
+			} else if length <= 0 || overMax {
+				if maxBinaryLength > 0 {
+					length = maxBinaryLength
+				}
+				if length > 0 {
+					nativeType = strings.ReplaceAll(nativeType, "()", fmt.Sprintf("(%d)", length))
+				} else {
+					nativeType = strings.ReplaceAll(nativeType, "()", "")
+				}
 			} else {
-				// no max configured for this connector; drop the ()
-				nativeType = strings.ReplaceAll(nativeType, "()", "")
+				nativeType = strings.ReplaceAll(nativeType, "()", fmt.Sprintf("(%d)", length))
 			}
 		} else if col.IsInteger() {
 			if !col.Sourced && length < env.DdlDefDecLength {

--- a/core/dbio/iop/datatype_test.go
+++ b/core/dbio/iop/datatype_test.go
@@ -1350,3 +1350,19 @@ func TestSelectorOrderFields(t *testing.T) {
 		assert.Equal(t, expected, s.OrderFields(fields))
 	})
 }
+
+func TestFlattenRecord(t *testing.T) {
+	rec := map[string]any{"id": 1, "owner": map[string]any{"login": "x", "id": 9}, "name": "r"}
+
+	t.Run("DepthZeroFlattensAllNesting", func(t *testing.T) {
+		out := FlattenRecord(rec, 0)
+		assert.Equal(t, "x", out["owner__login"])
+		assert.EqualValues(t, 9, out["owner__id"])
+		assert.Nil(t, out["owner"])
+	})
+
+	t.Run("NegativeDepthLeavesRecordUnchanged", func(t *testing.T) {
+		out := FlattenRecord(rec, -1)
+		assert.NotNil(t, out["owner"])
+	})
+}

--- a/core/dbio/iop/duckdb.go
+++ b/core/dbio/iop/duckdb.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/flarco/g"
@@ -47,13 +48,23 @@ type DuckDb struct {
 }
 
 type duckDbQuery struct {
-	SQL     string
-	Context *g.Context
-	reader  *io.PipeReader
-	writer  *io.PipeWriter
-	err     error
-	started bool
-	done    bool
+	SQL       string
+	Context   *g.Context
+	reader    *io.PipeReader
+	writer    *io.PipeWriter
+	err       error
+	started   bool
+	done      bool
+	closed    chan struct{} // closed when the query finishes, to stop the watcher
+	closeOnce sync.Once
+}
+
+// finish stops the watcher goroutine started in newQuery. Safe to call multiple times.
+func (dq *duckDbQuery) finish() {
+	if dq == nil || dq.closed == nil {
+		return
+	}
+	dq.closeOnce.Do(func() { close(dq.closed) })
 }
 
 // NewDuckDb creates a new DuckDb instance with the given context and properties
@@ -631,6 +642,7 @@ func (duck *DuckDb) ExecContext(ctx context.Context, sql string, args ...any) (r
 	defer duck.Context.Unlock()
 
 	dq := duck.newQuery(ctx, sql)
+	defer dq.finish()
 
 	result = duckDbResult{}
 
@@ -677,12 +689,48 @@ func (duck *DuckDb) newQuery(ctx context.Context, sql string) (query *duckDbQuer
 		Context: g.NewContext(ctx),
 		reader:  stdOutReader,
 		writer:  stdOutWriter,
+		closed:  make(chan struct{}),
 	}
+
+	// watcher: unblock a stuck reader (and release duck.Context's lock) when the
+	// query context is cancelled, or the process dies / its stdout scanner stops
+	// before the EOF marker arrives. Otherwise ConsumeCsvReader blocks forever.
+	dq := duck.query
+	go func() {
+		ticker := time.NewTicker(500 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-dq.closed:
+				return
+			case <-dq.Context.Ctx.Done():
+				err := g.Error(dq.Context.Ctx.Err(), "duckdb query context cancelled")
+				dq.err = err
+				dq.writer.CloseWithError(err)
+				dq.reader.CloseWithError(err)
+				return
+			case <-ticker.C:
+				if duck.Proc != nil && !dq.done && (duck.Proc.Exited() || duck.Proc.ScanErr != nil) {
+					reason := "duckdb process exited before query completed"
+					if duck.Proc.ScanErr != nil {
+						reason = "duckdb stdout scanner stopped before query completed"
+					}
+					err := g.Error("%s: %s", reason, duck.Proc.CmdErrorText())
+					dq.err = err
+					dq.writer.CloseWithError(err)
+					dq.reader.CloseWithError(err)
+					return
+				}
+			}
+		}
+	}()
+
 	return duck.query
 }
 
 // waitForResult waits for the execution of a SQL query and returns the result
 func (duck *DuckDb) waitForResult(dq *duckDbQuery) (result sql.Result, err error) {
+	defer dq.finish()
 
 	stdOutReaderB := bufio.NewReader(dq.reader)
 
@@ -871,6 +919,7 @@ func (duck *DuckDb) StreamContext(ctx context.Context, sql string, options ...ma
 	// start and submit sql
 	err = duck.SubmitSQL(sql, false)
 	if err != nil {
+		dq.finish()
 		duck.Context.Unlock() // release lock
 		return nil, g.Error(err, "Failed to submit SQL")
 	}
@@ -894,6 +943,7 @@ func (duck *DuckDb) StreamContext(ctx context.Context, sql string, options ...ma
 	ds.SetConfig(map[string]string{"delimiter": ",", "header": "true", "transforms": g.Marshal(transforms), "null_if": `\N\`})
 
 	ds.Defer(func() {
+		dq.finish()
 		duck.Context.Mux.TryLock()
 		duck.Context.Unlock() // release lock
 	})

--- a/core/dbio/iop/duckdb.go
+++ b/core/dbio/iop/duckdb.go
@@ -511,12 +511,20 @@ func (duck *DuckDb) Close() error {
 	case <-timer.C:
 		if duck.Proc.Cmd != nil {
 			g.Debug("killing pid %s", duck.Proc.Cmd.Process.Pid)
-			duck.Proc.Cmd.Process.Kill()
+			duck.kill()
 		}
 	}
 	duck.Proc.Cmd = nil
 
 	return nil
+}
+
+// kill kills the DuckDB process to abort an in-flight query; the next query re-opens a fresh process
+func (duck *DuckDb) kill() {
+	duck.SetProp("connected", "false")
+	if duck.Proc != nil && duck.Proc.Cmd != nil && duck.Proc.Cmd.Process != nil {
+		duck.Proc.Cmd.Process.Kill()
+	}
 }
 
 // Exec executes a SQL query and returns the result
@@ -708,6 +716,7 @@ func (duck *DuckDb) newQuery(ctx context.Context, sql string) (query *duckDbQuer
 				dq.err = err
 				dq.writer.CloseWithError(err)
 				dq.reader.CloseWithError(err)
+				duck.kill() // kill the proc so it won't block subsequent queries
 				return
 			case <-ticker.C:
 				if duck.Proc != nil && !dq.done && (duck.Proc.Exited() || duck.Proc.ScanErr != nil) {

--- a/core/dbio/iop/duckdb.go
+++ b/core/dbio/iop/duckdb.go
@@ -1562,13 +1562,12 @@ func (duck *DuckDb) DataflowToHttpStream(df *Dataflow, sc StreamConfig) (streamP
 	df.SetBatchLimit(sc.BatchLimit)
 	ds := MergeDataflow(df)
 
-	// Propagate TargetType from the source dataflow so CastToStringCSV knows
-	// to hex-encode binary columns destined for Snowflake / BigQuery. The
-	// caller (e.g. WriteDataflowReadyViaDuckDB) passes a default CSV config
-	// that does not preserve this — without this copy, binary BLOBs would
-	// stream as raw bytes and break DuckDB's CSV parser.
+	// Propagate hex-encoding intent from the source dataflow so CastToStringCSV
 	if sc.TargetType == "" && ds.Sp != nil && ds.Sp.Config.TargetType != "" {
 		sc.TargetType = ds.Sp.Config.TargetType
+	}
+	if ds.Sp != nil && ds.Sp.Config.BinaryAsHex {
+		sc.BinaryAsHex = true
 	}
 
 	go func() {

--- a/core/dbio/iop/duckdb_test.go
+++ b/core/dbio/iop/duckdb_test.go
@@ -131,6 +131,74 @@ func TestDuckDb(t *testing.T) {
 	})
 }
 
+// TestDuckDbNoDeadlock guards against the reader hanging forever on the result
+// pipe (holding the lock and stalling all subsequent queries).
+func TestDuckDbNoDeadlock(t *testing.T) {
+
+	// run fn with a hard deadline; fails (not hangs) if it does not return in time
+	runWithDeadline := func(t *testing.T, d time.Duration, fn func()) {
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			fn()
+		}()
+		select {
+		case <-done:
+		case <-time.After(d):
+			t.Fatal("query did not return in time — reader is deadlocked on the result pipe")
+		}
+	}
+
+	t.Run("context cancellation unblocks reader", func(t *testing.T) {
+		duck := NewDuckDb(context.Background())
+		defer duck.Close()
+
+		// prime the connection
+		_, err := duck.Exec("select 1")
+		assert.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(200 * time.Millisecond)
+			cancel()
+		}()
+
+		runWithDeadline(t, 30*time.Second, func() {
+			// cancellation must unblock the reader; don't assert on err value
+			_, _ = duck.QueryContext(ctx, "select count(*) from range(1, 100000000000)")
+		})
+
+		// the connection must still be usable afterwards (lock released)
+		runWithDeadline(t, 30*time.Second, func() {
+			data, err := duck.Query("select 42 as n")
+			if assert.NoError(t, err) && assert.Len(t, data.Rows, 1) {
+				assert.Equal(t, int64(42), data.Rows[0][0])
+			}
+		})
+	})
+
+	t.Run("oversized line does not hang", func(t *testing.T) {
+		// a ~200KB line exceeds the scan buffer, so the stdout scanner stops on
+		// bufio.ErrTooLong; the watcher must detect it and unblock the reader.
+		duck := NewDuckDb(context.Background(), "max_buffer_size=1024")
+
+		runWithDeadline(t, 30*time.Second, func() {
+			_, err := duck.Query("select repeat('x', 200000) as big")
+			assert.Error(t, err)
+		})
+
+		// new connection with normal buffer must work fine (sanity)
+		duck2 := NewDuckDb(context.Background())
+		defer duck2.Close()
+		runWithDeadline(t, 30*time.Second, func() {
+			data, err := duck2.Query("select 7 as n")
+			if assert.NoError(t, err) && assert.Len(t, data.Rows, 1) {
+				assert.Equal(t, int64(7), data.Rows[0][0])
+			}
+		})
+	})
+}
+
 func TestDuckDbStreamArrow(t *testing.T) {
 	t.Run("StreamArrow basic query", func(t *testing.T) {
 		duck := NewDuckDb(context.Background())

--- a/core/dbio/iop/json.go
+++ b/core/dbio/iop/json.go
@@ -75,6 +75,15 @@ func NewJSONStream(ds *Datastream, decoder decoderLike, flatten int, jmespath st
 
 // SetOrderedKeys publishes the post-select column order. First call wins;
 // subsequent calls are dropped (the channel is 1-buffered).
+// Flatten returns the jsonStream's flatten depth (max nesting level expanded
+// into `__`-joined keys). Negative means records are kept as raw JSON.
+func (js *jsonStream) Flatten() int {
+	if js == nil {
+		return 0
+	}
+	return js.flatten
+}
+
 func (js *jsonStream) SetOrderedKeys(keys []string) {
 	if js == nil || js.orderedKeysCh == nil {
 		return
@@ -290,6 +299,22 @@ func (js *jsonStream) orderKeys(rec map[string]any) []string {
 	}
 	sort.Strings(remaining)
 	return append(keys, remaining...)
+}
+
+// FlattenRecord flattens a record's nested objects/arrays into `__`-joined
+// keys, matching the jsonStream's flattening (Delimiter "__", Safe). depth is
+// the max flatten level (use 1 for the API default); depth < 0 returns the
+// record unchanged. This lets callers apply a `select` against flattened
+// field names (e.g. `owner__login`) the same way the stream does downstream.
+func FlattenRecord(rec map[string]any, depth int) map[string]any {
+	if depth < 0 {
+		return rec
+	}
+	out, err := flat.Flatten(rec, &flat.Options{Delimiter: "__", Safe: true, MaxDepth: depth})
+	if err != nil {
+		return rec
+	}
+	return out
 }
 
 func (js *jsonStream) addColumn(cols ...Column) {
@@ -561,3 +586,4 @@ func FirstObjectKeysInOrder(b []byte) ([]string, error) {
 	}
 	return keys, nil
 }
+

--- a/core/dbio/iop/queue.go
+++ b/core/dbio/iop/queue.go
@@ -2,12 +2,14 @@ package iop
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"os"
 	"path"
 	"reflect"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/flarco/g"
 	"github.com/flarco/g/json"
@@ -16,6 +18,7 @@ import (
 )
 
 type Queue struct {
+	Name    string        `json:"name"`
 	Path    string        `json:"path"`
 	File    *os.File      `json:"-"`
 	Reader  *bufio.Reader `json:"-"`
@@ -25,6 +28,26 @@ type Queue struct {
 	reading bool // whether queue is in reading mode
 	writing bool // whether queue is in writing mode
 	keep    bool
+}
+
+// donePath is the sentinel file (next to the queue file, so it works across
+// processes) signaling the producer finished writing. Tailing readers watch it.
+func (q *Queue) donePath() string {
+	return q.Path + ".done"
+}
+
+// MarkDone writes the done-sentinel; call after the producer flushed all writes.
+func (q *Queue) MarkDone() error {
+	f, err := os.OpenFile(q.donePath(), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return g.Error(err, "could not write queue done-sentinel: %s", q.donePath())
+	}
+	return f.Close()
+}
+
+// IsDone reports whether the producer has signaled completion.
+func (q *Queue) IsDone() bool {
+	return g.PathExists(q.donePath())
 }
 
 var queues = cmap.New[*Queue]()
@@ -63,6 +86,7 @@ func NewQueue(name string) (q *Queue, err error) {
 	}
 
 	q = &Queue{
+		Name:    name,
 		Path:    tmpFile.Name(),
 		File:    tmpFile,
 		writing: true, // start in writing mode
@@ -166,6 +190,24 @@ func explodeItems(data any) ([]any, bool) {
 		items[i] = val.Index(i).Interface()
 	}
 	return items, true
+}
+
+// Flush flushes and syncs buffered writes to disk; call before MarkDone.
+func (q *Queue) Flush() error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.Writer != nil {
+		if err := q.Writer.Flush(); err != nil {
+			return g.Error(err, "failed to flush queue writer")
+		}
+	}
+	if q.File != nil && q.writing {
+		if err := q.File.Sync(); err != nil {
+			return g.Error(err, "failed to sync queue file")
+		}
+	}
+	return nil
 }
 
 // startWriting prepares the queue for writing
@@ -360,6 +402,7 @@ func (q *Queue) Close() error {
 			if err := os.Remove(path); err != nil {
 				return err
 			}
+			os.Remove(q.donePath()) // best-effort sentinel cleanup
 		}
 
 		q.reading = false
@@ -374,4 +417,96 @@ func CloseQueues() {
 	for _, q := range queues.Items() {
 		q.Close()
 	}
+}
+
+// QueuePollInterval is how often a tailing reader re-checks the file at EOF.
+var QueuePollInterval = 50 * time.Millisecond
+
+// QueueReader is an independent tailing reader over a Queue file. Each consumer
+// gets its own fd and offset, so all consumers see every record (broadcast).
+// Polls for growth + watches the done-sentinel (no OS file-watch); cross-platform.
+type QueueReader struct {
+	queue  *Queue
+	file   *os.File
+	reader *bufio.Reader
+}
+
+// NewReader opens a fresh tailing reader at the start of the file; caller Closes it.
+func (q *Queue) NewReader() (*QueueReader, error) {
+	// flush our writer (in-process); cross-process the producer flushes its own
+	q.mu.Lock()
+	if q.Writer != nil {
+		q.Writer.Flush()
+	}
+	q.mu.Unlock()
+
+	// read-only; Go opens with shared access on Windows, so concurrent append is fine
+	file, err := os.OpenFile(q.Path, os.O_RDONLY, 0644)
+	if err != nil {
+		return nil, g.Error(err, "could not open queue file for tailing: %s", q.Path)
+	}
+
+	return &QueueReader{
+		queue:  q,
+		file:   file,
+		reader: bufio.NewReader(file),
+	}, nil
+}
+
+// Next returns the next record, blocking (polling) at EOF until the producer
+// appends more or signals done. Returns hasMore=false when done and drained, or
+// when ctx is cancelled (so a failing sibling unblocks all readers promptly).
+func (qr *QueueReader) Next(ctx context.Context) (data any, hasMore bool, err error) {
+	for {
+		line, readErr := qr.reader.ReadString('\n')
+
+		if readErr == nil {
+			return decodeJSONLine(line), true, nil
+		}
+
+		if readErr != io.EOF {
+			return nil, false, g.Error(readErr, "failed to read from queue: %s", qr.queue.Path)
+		}
+
+		// EOF with a partial (no-newline) line: emit it if done, else wait for the newline
+		if len(line) > 0 {
+			if qr.queue.IsDone() {
+				return decodeJSONLine(line), true, nil
+			}
+			if seekErr := qr.rewind(int64(len(line))); seekErr != nil {
+				return nil, false, seekErr
+			}
+		} else if qr.queue.IsDone() {
+			return nil, false, nil // clean EOF and producer done
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, false, nil
+		case <-time.After(QueuePollInterval):
+		}
+
+		// re-create reader so it picks up newly-appended bytes (bufio caches EOF)
+		qr.reader = bufio.NewReader(qr.file)
+	}
+}
+
+// rewind moves the file offset back n bytes to re-read a partial trailing line.
+func (qr *QueueReader) rewind(n int64) error {
+	if _, err := qr.file.Seek(-n, io.SeekCurrent); err != nil {
+		return g.Error(err, "failed to rewind queue reader: %s", qr.queue.Path)
+	}
+	qr.reader = bufio.NewReader(qr.file)
+	return nil
+}
+
+// Close releases the reader's file descriptor.
+func (qr *QueueReader) Close() error {
+	if qr.file != nil {
+		err := qr.file.Close()
+		qr.file = nil
+		qr.reader = nil
+		return err
+	}
+	return nil
 }

--- a/core/dbio/iop/queue_test.go
+++ b/core/dbio/iop/queue_test.go
@@ -1,6 +1,7 @@
 package iop
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -695,4 +696,132 @@ func TestChunkFunction(t *testing.T) {
 
 		assert.Equal(t, 0, len(chunks), "Should have no chunks for empty queue")
 	})
+}
+
+// drainReader reads all items from a tailing reader until the producer is done.
+func drainReader(t *testing.T, qr *QueueReader) []any {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	items := []any{}
+	for {
+		item, hasMore, err := qr.Next(ctx)
+		assert.NoError(t, err)
+		if !hasMore {
+			break
+		}
+		items = append(items, item)
+	}
+	return items
+}
+
+// TestQueueReader_TailWhileWriting: reader blocks at EOF, picks up later appends,
+// stops on the done-sentinel.
+func TestQueueReader_TailWhileWriting(t *testing.T) {
+	q, err := NewQueue("test-tail")
+	assert.NoError(t, err)
+	defer q.Close()
+
+	reader, err := q.NewReader()
+	assert.NoError(t, err)
+	defer reader.Close()
+
+	got := make(chan []any, 1)
+	go func() { got <- drainReader(t, reader) }()
+
+	// produce slowly, after the reader is already tailing (blocked at EOF)
+	for i := 1; i <= 5; i++ {
+		time.Sleep(20 * time.Millisecond)
+		assert.NoError(t, q.Append(map[string]any{"id": i}))
+	}
+	assert.NoError(t, q.Flush())
+	assert.NoError(t, q.MarkDone())
+
+	select {
+	case items := <-got:
+		assert.Len(t, items, 5, "reader should have tailed all 5 records")
+	case <-time.After(10 * time.Second):
+		t.Fatal("reader did not finish after producer marked done")
+	}
+}
+
+// TestQueueReader_Broadcast: each independent reader sees every record (broadcast,
+// not competing-consumers).
+func TestQueueReader_Broadcast(t *testing.T) {
+	q, err := NewQueue("test-broadcast")
+	assert.NoError(t, err)
+	defer q.Close()
+
+	const n = 50
+	const consumers = 10
+
+	readers := make([]*QueueReader, consumers)
+	results := make([][]any, consumers)
+	for i := range readers {
+		readers[i], err = q.NewReader()
+		assert.NoError(t, err)
+		defer readers[i].Close()
+	}
+
+	done := make(chan int, consumers)
+	for i := range readers {
+		go func(idx int) {
+			results[idx] = drainReader(t, readers[idx])
+			done <- idx
+		}(i)
+	}
+
+	for i := 1; i <= n; i++ {
+		assert.NoError(t, q.Append(map[string]any{"id": i}))
+	}
+	assert.NoError(t, q.Flush())
+	assert.NoError(t, q.MarkDone())
+
+	for range readers {
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Fatal("a reader did not finish")
+		}
+	}
+
+	for i := range results {
+		assert.Lenf(t, results[i], n, "reader %d should see all %d records", i, n)
+	}
+}
+
+// TestQueueReader_ContextCancel: a blocked reader unblocks on context cancel
+// (fail-fast), even if the producer never marks done.
+func TestQueueReader_ContextCancel(t *testing.T) {
+	q, err := NewQueue("test-cancel")
+	assert.NoError(t, err)
+	defer q.Close()
+
+	reader, err := q.NewReader()
+	assert.NoError(t, err)
+	defer reader.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	finished := make(chan struct{})
+	go func() {
+		for {
+			_, hasMore, err := reader.Next(ctx)
+			assert.NoError(t, err)
+			if !hasMore {
+				close(finished)
+				return
+			}
+		}
+	}()
+
+	// reader is now blocked at EOF (no records, not done); cancel should unblock it
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-finished:
+	case <-time.After(5 * time.Second):
+		t.Fatal("reader did not unblock on context cancel")
+	}
 }

--- a/core/dbio/iop/stream_processor.go
+++ b/core/dbio/iop/stream_processor.go
@@ -76,6 +76,7 @@ type StreamConfig struct {
 	DeleteFile      bool           `json:"delete"` // whether to delete before writing
 	BoolAsInt       bool           `json:"-"`
 	EscapeBackslash bool           `json:"-"`       // escape backslashes for MySQL LOAD DATA
+	BinaryAsHex     bool           `json:"-"`       // hex-encode binary in CSV
 	Columns         Columns        `json:"columns"` // list of column types. Can be partial list! likely is!
 	Transforms      Transform
 
@@ -1189,7 +1190,7 @@ func (sp *StreamProcessor) CastToStringCSV(i int, val any, valType ...ColumnType
 			return tVal.Format("2006-01-02 15:04:05.999999999") + " +00"
 		}
 		return tVal.Format("2006-01-02 15:04:05.999999999 -07")
-	case typ.IsBinary() && g.In(sp.Config.TargetType, dbio.TypeDbSnowflake, dbio.TypeDbBigQuery):
+	case typ.IsBinary() && (sp.Config.BinaryAsHex || g.In(sp.Config.TargetType, dbio.TypeDbSnowflake, dbio.TypeDbBigQuery)):
 		return Transforms.BinaryToHex(cast.ToString(val))
 	default:
 		strVal := cast.ToString(val)

--- a/core/dbio/iop/stream_processor.go
+++ b/core/dbio/iop/stream_processor.go
@@ -1190,7 +1190,7 @@ func (sp *StreamProcessor) CastToStringCSV(i int, val any, valType ...ColumnType
 			return tVal.Format("2006-01-02 15:04:05.999999999") + " +00"
 		}
 		return tVal.Format("2006-01-02 15:04:05.999999999 -07")
-	case typ.IsBinary() && (sp.Config.BinaryAsHex || g.In(sp.Config.TargetType, dbio.TypeDbSnowflake, dbio.TypeDbBigQuery)):
+	case typ.IsBinary() && sp.Config.BinaryAsHex:
 		return Transforms.BinaryToHex(cast.ToString(val))
 	default:
 		strVal := cast.ToString(val)

--- a/core/dbio/templates/_properties.yaml
+++ b/core/dbio/templates/_properties.yaml
@@ -6,31 +6,39 @@ oracle:
   kind: database
   required: ["host", "port", "username"]
   url_template: ['oracle://{username}:{password}@{host}:{port}/{sid}', 'oracle://{username}:{password}@{tns}']
+  docs: https://docs.slingdata.io/connections/database-connections/oracle
   properties:
     name:
       type: text
       title: Connection Name
       description: 'The name of the connection. No spaces are allowed, will be all caps. Example: ORCL_FINANCE'
+      examples: ['ORCL_FINANCE', 'ORACLE_PROD', 'ORA_ANALYTICS']
     sid:
       type: text
       title: SID or Service Name
       description: 'The Oracle System ID / Service Name of the instance'
+      examples: ['ORCL', 'XE', 'ORCLPDB1']
     tns:
       type: text
       description: 'The Oracle TNS string of the instance'
+      examples: ['(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=hostname)(PORT=1521))(CONNECT_DATA=(SID=ORCL)))']
     host:
       type: text
       description: 'The hostname / ip of the connection, e.g.: my.server.com or 192.65.43.11'
+      examples: ['oracle.example.com', '192.168.1.100', 'localhost']
     username:
       type: text
       description: 'The username to access the instance'
+      examples: ['hr', 'system', 'myuser']
     password:
       type: text
       description: 'The password to access the instance'
+      examples: ['mypassword123']
       secret: true
     port:
       type: integer
       description: 'The port of the instance'
+      examples: ['1521', '1522']
       default: 1521
 
 snowflake:
@@ -39,76 +47,105 @@ snowflake:
   fields: ["host", "database", "schema", "role", "username", "password", "warehouse"]
   required: ["host", "database", "schema", "role", "username", "password"]
   url_template: 'snowflake://{username}:{password}@{host}.snowflakecomputing.com:443/{database}?schema={schema}&warehouse={warehouse}'
+  docs: https://docs.slingdata.io/connections/database-connections/snowflake
   properties:
     name:
       type: text
       title: Connection Name
       description: 'The name of the connection. No spaces are allowed, will be all caps. Example: DB_MARKETING'
+      examples: ['DB_MARKETING', 'SNOWFLAKE_PROD', 'SF_ANALYTICS']
     host:
       type: text
       description: 'The hostname of the connection, e.g.: pua90768.us-east-11'
+      examples: ['xy12345.us-east-1', 'myorg-myaccount', 'pua90768.us-east-1']
     database:
       type: text
       description: 'The database name of the instance'
+      examples: ['ANALYTICS', 'PRODUCTION', 'DEV']
     role:
       type: text
       description: 'The role name of the user'
+      examples: ['ACCOUNTADMIN', 'SYSADMIN', 'ANALYST']
     warehouse:
       type: text
       description: 'The warehouse name to use'
+      examples: ['COMPUTE_WH', 'ANALYTICS_WH', 'DEV_WH']
     schema:
       type: text
       description: 'The default schema to use when connecting, e.g. public'
+      examples: ['PUBLIC', 'STAGING', 'ANALYTICS']
       default: public
     username:
       type: text
       description: 'The username to access the instance'
+      examples: ['admin', 'myuser', 'analytics_user']
     password:
       type: text
       description: 'The password to access the instance'
+      examples: ['mypassword123']
       secret: true
+    token:
+      type: text
+      description: 'Token for OAuth or PAT (Programmatic Access Token) authentication'
+      examples: ['ver:1-hint:123456-ETMsDgA...']
+      secret: true
+    authenticator:
+      type: dropdown
+      options: ['snowflake', 'externalbrowser', 'snowflake_jwt', 'oauth', 'programmatic_access_token', 'username_password_mfa']
+      description: 'The authentication method to use'
+      examples: ['snowflake', 'programmatic_access_token', 'snowflake_jwt']
 
 redshift:
   title: 'Redshift'
   kind: database
   required: ["host", "port", "database", "username", 'aws_bucket', 'aws_access_key_id', 'aws_secret_access_key']
   url_template: 'redshift://{username}:{password}@{host}:{port}/{database}?sslmode={sslmode}'
+  docs: https://docs.slingdata.io/connections/database-connections/redshift
   properties:
     database:
       type: text
       description: 'The database name of the instance'
+      examples: ['dev', 'production', 'analytics']
     host:
       type: text
       description: 'The hostname of the connection, e.g.: redshift-cluster-1.abcdefg.us-east-1.redshift.amazonaws.com'
+      examples: ['redshift-cluster-1.abcdefg.us-east-1.redshift.amazonaws.com', 'my-redshift.us-west-2.redshift.amazonaws.com']
     username:
       type: text
       description: 'The username to access the instance'
+      examples: ['admin', 'analyst', 'etl_user']
     password:
       type: text
       description: 'The password to access the instance'
+      examples: ['mypassword123']
       secret: true
     port:
       type: integer
       description: 'The port of the instance'
+      examples: ['5439']
       default: 5439
     sslmode:
       type: dropdown
       options: ['disable', 'require']
       title: SSL mode
       description: the SSL mode to use when connection
+      examples: ['disable', 'require']
       default: disable
     aws_bucket:
       type: text
       title: Bucket name
       description: The name of the S3 Bucket for Bulk Loading
+      examples: ['my-redshift-bucket', 'etl-staging-bucket']
     aws_access_key_id:
       type: text
       title: AWS Access Key
       description: The AWS Access Key ID to access the bucket for Bulk Loading
+      examples: ['AKIAIOSFODNN7EXAMPLE']
     aws_secret_access_key:
       type: text
       title: AWS Secret Key
       description: The AWS Secret Key to access the bucket for Bulk Loading
+      examples: ['wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY']
       secret: true
 
 postgres:
@@ -116,33 +153,85 @@ postgres:
   kind: database
   required: ["host", "port", "database", "username"]
   url_template: 'postgresql://{username}:{password}@{host}:{port}/{database}?sslmode={sslmode}'
+  docs: https://docs.slingdata.io/connections/database-connections/postgres
   properties:
     name:
       type: text
       title: Connection Name
       description: 'The name of the connection. No spaces are allowed, will be all caps. Example: PG_MARKETING'
+      examples: ['PG_MARKETING', 'POSTGRES_PROD', 'PG_ANALYTICS']
     database:
       type: text
       description: 'The database name of the instance'
+      examples: ['mydb', 'production', 'analytics']
     host:
       type: text
       description: 'The hostname / ip of the connection, e.g.: my.server.com or 192.65.43.11'
+      examples: ['localhost', '192.168.1.100', 'postgres.example.com']
     username:
       type: text
       description: 'The username to access the instance'
+      examples: ['postgres', 'myuser', 'admin']
     password:
       type: text
       description: 'The password to access the instance'
+      examples: ['mypassword123']
       secret: true
     port:
       type: integer
       description: 'The port of the instance'
+      examples: ['5432']
       default: 5432
     sslmode:
       type: dropdown
       options: ['disable', 'require']
       title: SSL mode to use
+      examples: ['disable', 'require']
       default: disable
+    gcp_project:
+      type: text
+      title: GCP Project ID (for Cloud SQL)
+      description: 'The GCP project ID containing the Cloud SQL instance'
+      examples: ['my-gcp-project', 'analytics-prod', 'data-warehouse-123']
+    gcp_region:
+      type: text
+      title: GCP Region (for Cloud SQL)
+      description: 'The GCP region where the Cloud SQL instance is located'
+      examples: ['us-central1', 'us-east1', 'europe-west1']
+    gcp_instance:
+      type: text
+      title: Cloud SQL Instance Name
+      description: 'The Cloud SQL instance name (when using Cloud SQL IAM authentication)'
+      examples: ['my-postgres-instance', 'prod-pg-instance', 'analytics-db']
+    gcp_use_iam_auth:
+      type: boolean
+      title: Use Cloud SQL IAM Authentication
+      description: 'Enable Google Cloud SQL IAM authentication instead of password'
+      examples: [true, false]
+      default: false
+    gcp_use_private_ip:
+      type: boolean
+      title: Use Private IP (for Cloud SQL)
+      description: 'Use private IP instead of public IP for Cloud SQL connection'
+      examples: [true, false]
+      default: false
+    gcp_credentials_file:
+      type: text
+      title: GCP Credentials File Path
+      description: 'Path to GCP service account JSON key file (optional, uses ADC if not provided)'
+      examples: ['/path/to/service-account.json', './credentials/gcp-key.json']
+    gcp_credentials_json:
+      type: text
+      title: GCP Credentials JSON
+      description: 'GCP service account JSON content as string (alternative to file path)'
+      examples: ['{"type":"service_account",...}']
+      secret: true
+    gcp_lazy_refresh:
+      type: boolean
+      title: Enable Lazy Refresh (for serverless)
+      description: 'Enable lazy refresh mode for Cloud SQL connections in serverless environments'
+      examples: [true, false]
+      default: false
 
 
 bigquery:
@@ -150,31 +239,38 @@ bigquery:
   kind: database
   required: ["dataset", "project", "credentials_json"]
   url_template: 'bigquery://{project}/{location}/{dataset}'
+  docs: https://docs.slingdata.io/connections/database-connections/bigquery
   properties:
     name:
       type: text
       title: Connection Name
       description: 'The name of the connection. No spaces are allowed, will be all caps. Example: BQ_DWH'
+      examples: ['BQ_DWH', 'BIGQUERY_PROD', 'BQ_ANALYTICS']
     dataset:
       type: text
       title: Dataset ID
       description: 'The BigQuery dataset id'
+      examples: ['analytics', 'staging', 'raw_data']
     project:
       type: text
       title: Project ID
       description: 'The GCP project ID for the project containing the dataset.'
+      examples: ['my-gcp-project', 'analytics-prod', 'data-warehouse-123']
     credentials_json:
       type: text
       title: Upload Service Account JSON
       description: 'Upload Service Account JSON'
+      examples: ['/path/to/service-account.json']
     location:
       type: dropdown
       options: ['asia-east1','asia-east2','asia-northeast1','asia-northeast2','asia-northeast3','asia-south1','asia-southeast1','asia-southeast2','australia-southeast1','europe-north1','europe-west1','europe-west2','europe-west3','europe-west4','europe-west6','northamerica-northeast1','southamerica-east1','us-central1','us-east1','us-east4','us-west1','us-west2','us-west3','us-west4']
       description: The dataset regional location
+      examples: ['US', 'EU', 'us-central1']
     gc_bucket:
       type: text
       title: Google Cloud Bucket
       description: The name of the Google Cloud Storage Bucket
+      examples: ['my-gcs-bucket', 'bigquery-staging', 'etl-bucket']
 
 
 mysql:
@@ -182,83 +278,190 @@ mysql:
   kind: database
   required: ["host", "port", "database", "username"]
   url_template: 'mysql://{username}:{password}@{host}:{port}/{database}'
+  docs: https://docs.slingdata.io/connections/database-connections/mysql
   properties:
     name:
       type: text
       title: Connection Name
       description: 'The name of the connection. No spaces are allowed, will be all caps. Example: DB_MARKETING'
+      examples: ['DB_MARKETING', 'MYSQL_PROD', 'MY_ANALYTICS']
     database:
       type: text
       description: 'The database name of the instance'
+      examples: ['mydb', 'production', 'ecommerce']
     host:
       type: text
       description: 'The hostname / ip of the connection, e.g.: my.server.com or 192.65.43.11'
+      examples: ['localhost', '192.168.1.100', 'mysql.example.com']
     username:
       type: text
       description: 'The username to access the instance'
+      examples: ['root', 'admin', 'myuser']
     password:
       type: text
       description: 'The password to access the instance'
+      examples: ['mypassword123']
       secret: true
     port:
       type: integer
       description: 'The port of the instance'
+      examples: ['3306']
       default: 3306
-      
+
+    # Google Cloud SQL IAM Authentication Properties
+    gcp_project:
+      type: text
+      title: GCP Project ID (for Cloud SQL)
+      description: 'The GCP project ID containing the Cloud SQL instance'
+      examples: ['my-gcp-project', 'production-project']
+    gcp_region:
+      type: text
+      title: GCP Region (for Cloud SQL)
+      description: 'The GCP region where the Cloud SQL instance is located'
+      examples: ['us-central1', 'europe-west1', 'asia-southeast1']
+    gcp_instance:
+      type: text
+      title: Cloud SQL Instance Name
+      description: 'The name of the Cloud SQL instance'
+      examples: ['my-mysql-instance', 'production-db']
+    gcp_use_iam_auth:
+      type: boolean
+      title: Use Cloud SQL IAM Authentication
+      description: 'Enable IAM authentication for Cloud SQL connections'
+      default: false
+    gcp_use_private_ip:
+      type: boolean
+      title: Use Private IP (for Cloud SQL)
+      description: 'Connect to Cloud SQL instance using private IP (requires VPC connectivity)'
+      default: false
+    gcp_credentials_file:
+      type: text
+      title: GCP Credentials File Path
+      description: 'Path to GCP service account credentials JSON file'
+      examples: ['/path/to/service-account.json']
+    gcp_credentials_json:
+      type: text
+      title: GCP Credentials JSON
+      description: 'GCP service account credentials as JSON string (alternative to credentials_file)'
+      secret: true
+    gcp_lazy_refresh:
+      type: boolean
+      title: Enable Lazy Refresh (for serverless)
+      description: 'Enable lazy refresh mode for serverless environments (Cloud Run, Cloud Functions)'
+      default: false
+
 sqlserver:
   title: 'MS SQL Server'
   kind: database
   required: ["host", "port", "database", "username"]
   url_template: 'sqlserver://{username}:{password}@{host}:{port}/{database}'
+  docs: https://docs.slingdata.io/connections/database-connections/sqlserver
   properties:
     name:
       type: text
       title: Connection Name
       description: 'The name of the connection. No spaces are allowed, will be all caps. Example: DB_MARKETING'
+      examples: ['DB_MARKETING', 'SQLSERVER_PROD', 'MSSQL_ANALYTICS']
     database:
       type: text
       description: 'The database name of the instance'
+      examples: ['master', 'AdventureWorks', 'MyDatabase']
     host:
       type: text
       description: 'The hostname / ip of the connection, e.g.: my.server.com or 192.65.43.11'
+      examples: ['localhost', '192.168.1.100', 'sqlserver.example.com']
     username:
       type: text
       description: 'The username to access the instance'
+      examples: ['sa', 'admin', 'sqluser']
     password:
       type: text
       description: 'The password to access the instance'
+      examples: ['mypassword123']
       secret: true
     port:
       type: integer
       description: 'The port of the instance'
+      examples: ['1433']
       default: 1433
-      
+
+    # Google Cloud SQL Properties (Non-IAM)
+    # Note: Cloud SQL for SQL Server does NOT support IAM authentication
+    # These properties enable Cloud SQL Proxy connectivity with standard SQL Server authentication
+    gcp_project:
+      type: text
+      title: GCP Project ID (for Cloud SQL)
+      description: 'The GCP project ID containing the Cloud SQL instance'
+      examples: ['my-gcp-project', 'production-project']
+    gcp_region:
+      type: text
+      title: GCP Region (for Cloud SQL)
+      description: 'The GCP region where the Cloud SQL instance is located'
+      examples: ['us-central1', 'europe-west1', 'asia-southeast1']
+    gcp_instance:
+      type: text
+      title: Cloud SQL Instance Name
+      description: 'The name of the Cloud SQL instance'
+      examples: ['my-sqlserver-instance', 'production-db']
+    gcp_use_cloud_sql:
+      type: boolean
+      title: Use Cloud SQL Connectivity
+      description: 'Enable Cloud SQL Proxy connectivity (password still required - IAM auth not supported for SQL Server)'
+      default: false
+    gcp_use_private_ip:
+      type: boolean
+      title: Use Private IP (for Cloud SQL)
+      description: 'Connect to Cloud SQL instance using private IP (requires VPC connectivity)'
+      default: false
+    gcp_credentials_file:
+      type: text
+      title: GCP Credentials File Path
+      description: 'Path to GCP service account credentials JSON file'
+      examples: ['/path/to/service-account.json']
+    gcp_credentials_json:
+      type: text
+      title: GCP Credentials JSON
+      description: 'GCP service account credentials as JSON string (alternative to credentials_file)'
+      secret: true
+    gcp_lazy_refresh:
+      type: boolean
+      title: Enable Lazy Refresh (for serverless)
+      description: 'Enable lazy refresh mode for Cloud SQL connections in serverless environments'
+      default: false
+
 azuresql:
   title: 'Azure SQL Server'
   kind: database
   required: ["host", "port", "database", "username"]
   url_template: 'sqlserver://{username}:{password}@{host}:{port}/{database}'
+  docs: https://docs.slingdata.io/connections/database-connections/sqlserver
   properties:
     name:
       type: text
       title: Connection Name
       description: 'The name of the connection. No spaces are allowed, will be all caps. Example: DB_MARKETING'
+      examples: ['DB_MARKETING', 'AZURESQL_PROD', 'AZ_ANALYTICS']
     database:
       type: text
       description: 'The database name of the instance'
+      examples: ['mydb', 'production', 'analytics']
     host:
       type: text
       description: 'The hostname, e.g.: my.server.database.windows.net'
+      examples: ['myserver.database.windows.net', 'prod-sql.database.windows.net']
     username:
       type: text
       description: 'The username to access the instance'
+      examples: ['admin', 'sqladmin', 'azureuser']
     password:
       type: text
       description: 'The password to access the instance'
+      examples: ['mypassword123']
       secret: true
     port:
       type: integer
       description: 'The port of the instance'
+      examples: ['1433']
       default: 1433
 
 s3:
@@ -266,87 +469,945 @@ s3:
   kind: file
   required: ["bucket", "access_key_id", "secret_access_key"]
   url_template: 's3://{bucket}'
+  docs: https://docs.slingdata.io/connections/file-connections/s3
   properties:
     name:
       type: text
       title: Connection Name
       description: 'The name of the S3 connection. No spaces are allowed, will be all caps. Example: S3_MAIN'
+      examples: ['S3_MAIN', 'S3_BACKUP', 'S3_ANALYTICS']
     bucket:
       type: text
       title: Bucket name
       description: The name of the S3 Bucket
+      examples: ['my-data-bucket', 'analytics-storage', 'backup-bucket']
     access_key_id:
       type: text
       title: AWS Access Key
       description: The AWS Access Key ID to access the bucket
+      examples: ['AKIAIOSFODNN7EXAMPLE']
     secret_access_key:
       type: text
       title: AWS Secret Key
       description: The AWS Secret Key to access the bucket
+      examples: ['wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY']
       secret: true
     endpoint:
       type: text
       title: Endpoint Hostname
       description: The hostname of the endpoint (e.g. nyc3.digitaloceanspaces.com)
+      examples: ['nyc3.digitaloceanspaces.com', 's3.amazonaws.com']
 
 azure:
   title: 'Azure Storage'
   kind: file
   required: ["account", "sas_svc_url"]
   url_template: 'azure://{account}'
+  docs: https://docs.slingdata.io/connections/file-connections/azure
   properties:
     name:
       type: text
       title: Connection Name
       description: 'The name of the connection. No spaces are allowed, will be all caps. Example: AZ_CSV_ARCHIVE'
+      examples: ['AZ_CSV_ARCHIVE', 'AZURE_BACKUP', 'AZ_STORAGE']
     account:
       type: text
       title: Storage Account Name
       description: The name of the Azure Storage Account
+      examples: ['mystorageaccount', 'prodstorageacct', 'datastorageaz']
     sas_svc_url: 
       title: Azure Shared access signature
       type: text
       description: The Shared access signature to access the storage account
+      examples: ['https://myaccount.blob.core.windows.net/?sv=2019-02-02&ss=bfqt&srt=sco&sp=rwdlacup&se=2020-01-01T00:00:00Z&st=2019-01-01T00:00:00Z&spr=https,http&sig=abcdefghijklmnop']
 
 gs:
   title: 'Google Storage'
   kind: file
   required: ["bucket", "credentials_json"]
   url_template: 'gs://{bucket}'
+  docs: https://docs.slingdata.io/connections/file-connections/gs
   properties:
     name:
       type: text
       title: Connection Name
       description: 'The name of the connection. No spaces are allowed, will be all caps. Example: GS_ARCHIVE'
+      examples: ['GS_ARCHIVE', 'GCS_BACKUP', 'GS_STORAGE']
     bucket:
       type: text
       title: Google Cloud Bucket
       description: The name of the Google Cloud Storage Bucket
+      examples: ['my-gcs-bucket', 'data-lake-bucket', 'backup-storage']
     credentials_json:
       type: upload-google
       title: Upload Service Account JSON
       description: 'Upload Service Account JSON'
+      examples: ['/path/to/service-account.json']
 
 sftp:
   title: 'SFTP'
   kind: file
   required: ["host", "port", "username"]
+  docs: https://docs.slingdata.io/connections/file-connections/sftp
   properties:
     name:
       type: text
       title: Connection Name
       description: 'The name of the SFTP connection. No spaces are allowed, will be all caps. Example: SFTP_BACKUPS'
+      examples: ['SFTP_BACKUPS', 'SFTP_UPLOAD', 'SFTP_MAIN']
     host:
       type: text
       description: 'The hostname or IP of the server'
+      examples: ['sftp.example.com', '192.168.1.50', 'files.mydomain.com']
     username:
       type: text
       description: 'The username to use to access the server'
+      examples: ['ftpuser', 'upload', 'backup_user']
     password:
       type: text
       description: 'Optional: The password to use to access the server'
+      examples: ['mypassword123']
       secret: true
     port:
       type: integer
       description: 'The port of the server'
+      examples: ['22', '2222']
       default: 22
+
+mariadb:
+  title: 'MariaDB'
+  kind: database
+  required: ["host", "port", "database", "username"]
+  url_template: 'mysql://{username}:{password}@{host}:{port}/{database}'
+  docs: https://docs.slingdata.io/connections/database-connections/mariadb
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: MDB_MAIN'
+      examples: ['MDB_MAIN', 'MARIADB_PROD', 'MDB_ANALYTICS']
+    database:
+      type: text
+      description: 'The database name of the instance'
+      examples: ['mydb', 'production', 'ecommerce']
+    host:
+      type: text
+      description: 'The hostname / ip of the connection'
+      examples: ['localhost', '192.168.1.100', 'mariadb.example.com']
+    username:
+      type: text
+      description: 'The username to access the instance'
+      examples: ['root', 'admin', 'myuser']
+    password:
+      type: text
+      description: 'The password to access the instance'
+      examples: ['mypassword123']
+      secret: true
+    port:
+      type: integer
+      description: 'The port of the instance'
+      examples: ['3306']
+      default: 3306
+    charset:
+      type: text
+      description: 'Character set to use'
+      examples: ['utf8mb4', 'latin1']
+      default: utf8mb4
+    tls:
+      type: boolean
+      description: 'Enable TLS encryption'
+      examples: [true, false]
+      default: false
+
+duckdb:
+  title: 'DuckDB'
+  kind: database
+  required: ["instance"]
+  url_template: 'duckdb://{instance}'
+  docs: https://docs.slingdata.io/connections/database-connections/duckdb
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: DUCKDB_MAIN'
+      examples: ['DUCKDB_MAIN', 'DUCK_ANALYTICS', 'DDB_LOCAL']
+    instance:
+      type: text
+      description: 'Local file path of the database file'
+      examples: ['/path/to/database.db', './data/mydatabase.duckdb', ':memory:']
+    schema:
+      type: text
+      description: 'Default schema name'
+      examples: ['main', 'staging', 'analytics']
+    read_only:
+      type: boolean
+      description: 'Open connection in readonly mode'
+      examples: [true, false]
+      default: false
+
+motherduck:
+  title: 'MotherDuck'
+  kind: database
+  required: ["token"]
+  url_template: 'motherduck://{token}@{database}'
+  docs: https://docs.slingdata.io/connections/database-connections/motherduck
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: MD_MAIN'
+      examples: ['MD_MAIN', 'MOTHERDUCK_PROD', 'MD_ANALYTICS']
+    token:
+      type: text
+      description: 'MotherDuck authentication token'
+      examples: ['md_abcd1234efgh5678ijkl9012mnop3456']
+      secret: true
+    database:
+      type: text
+      description: 'Database name'
+      examples: ['my_database', 'analytics', 'prod']
+    schema:
+      type: text
+      description: 'Default schema name'
+      examples: ['main', 'staging']
+
+sqlite:
+  title: 'SQLite'
+  kind: database
+  required: ["instance"]
+  url_template: 'sqlite://{instance}'
+  docs: https://docs.slingdata.io/connections/database-connections/sqlite
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: SQLITE_MAIN'
+      examples: ['SQLITE_MAIN', 'SQLITE_LOCAL', 'SL_TEST']
+    instance:
+      type: text
+      description: 'Local file path of the database file'
+      examples: ['/path/to/database.db', './data/sqlite.db', ':memory:']
+    busy_timeout:
+      type: integer
+      description: 'Busy timeout in milliseconds'
+      examples: ['5000', '10000']
+      default: 5000
+
+clickhouse:
+  title: 'ClickHouse'
+  kind: database
+  required: ["host"]
+  url_template: 'clickhouse://{username}:{password}@{host}:{port}/{database}'
+  docs: https://docs.slingdata.io/connections/database-connections/clickhouse
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: CH_MAIN'
+      examples: ['CH_MAIN', 'CLICKHOUSE_PROD', 'CH_ANALYTICS']
+    host:
+      type: text
+      description: 'ClickHouse server hostname'
+      examples: ['localhost', 'clickhouse.example.com', '192.168.1.100']
+    port:
+      type: integer
+      description: 'Port number'
+      examples: ['9000', '8123']
+      default: 9000
+    user:
+      type: text
+      description: 'Username for authentication'
+      examples: ['default', 'admin', 'clickhouse_user']
+      default: default
+    password:
+      type: text
+      description: 'Password for authentication'
+      examples: ['mypassword123']
+      secret: true
+    database:
+      type: text
+      description: 'Database name'
+      examples: ['default', 'analytics', 'logs']
+      default: default
+    secure:
+      type: boolean
+      description: 'Use secure connection'
+      examples: [true, false]
+      default: false
+
+mongodb:
+  title: 'MongoDB'
+  kind: database
+  required: ["host", "database"]
+  url_template: 'mongodb://{username}:{password}@{host}:{port}/{database}'
+  docs: https://docs.slingdata.io/connections/database-connections/mongodb
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: MONGO_MAIN'
+      examples: ['MONGO_MAIN', 'MONGODB_PROD', 'MDB_DOCUMENTS']
+    host:
+      type: text
+      description: 'MongoDB server hostname'
+      examples: ['localhost', 'mongodb.example.com', 'cluster0.abcde.mongodb.net']
+    port:
+      type: integer
+      description: 'Port number'
+      examples: ['27017']
+      default: 27017
+    user:
+      type: text
+      description: 'Username for authentication'
+      examples: ['admin', 'dbuser', 'mongo_user']
+    password:
+      type: text
+      description: 'Password for authentication'
+      examples: ['mypassword123']
+      secret: true
+    database:
+      type: text
+      description: 'Database name'
+      examples: ['myapp', 'production', 'analytics']
+    auth_source:
+      type: text
+      description: 'Authentication database'
+      examples: ['admin', 'myapp']
+      default: admin
+    ssl:
+      type: boolean
+      description: 'Use SSL connection'
+      examples: [true, false]
+      default: false
+
+databricks:
+  title: 'Databricks'
+  kind: database
+  required: ["host", "token", "http_path"]
+  url_template: 'databricks://{token}@{host}:{port}/{database}'
+  docs: https://docs.slingdata.io/connections/database-connections/databricks
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: DBR_MAIN'
+      examples: ['DBR_MAIN', 'DATABRICKS_PROD', 'DBR_ANALYTICS']
+    host:
+      type: text
+      description: 'Databricks hostname'
+      examples: ['dbc-xxxxxxx', 'adbxxxxx']
+    token:
+      type: text
+      description: 'Personal access token'
+      examples: ['xxxxxxxxxxxxx']
+      secret: true
+    http_path:
+      type: text
+      description: 'SQL warehouse HTTP path'
+      examples: ['/sql/1.0/warehouses/abcdef1234567890', '/sql/protocolv1/o/1234567890123456/0123-456789-test123']
+    catalog:
+      type: text
+      description: 'Unity catalog name'
+      examples: ['main', 'hive_metastore', 'analytics_catalog']
+    schema:
+      type: text
+      description: 'Schema name'
+      examples: ['default', 'analytics', 'staging']
+
+trino:
+  title: 'Trino'
+  kind: database
+  required: ["host", "user", "catalog"]
+  url_template: 'trino://{user}@{host}:{port}/{catalog}'
+  docs: https://docs.slingdata.io/connections/database-connections/trino
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: TRINO_MAIN'
+      examples: ['TRINO_MAIN', 'TRINO_PROD', 'TR_ANALYTICS']
+    host:
+      type: text
+      description: 'Trino coordinator hostname'
+      examples: ['trino.example.com', 'localhost', '192.168.1.100']
+    port:
+      type: integer
+      description: 'Port number'
+      examples: ['8080', '443']
+      default: 8080
+    user:
+      type: text
+      description: 'Username'
+      examples: ['admin', 'trino_user', 'analyst']
+    catalog:
+      type: text
+      description: 'Default catalog'
+      examples: ['hive', 'postgresql', 'memory']
+    schema:
+      type: text
+      description: 'Default schema'
+      examples: ['default', 'public', 'analytics']
+
+elasticsearch:
+  title: 'Elasticsearch'
+  kind: database
+  required: ["url"]
+  url_template: 'elasticsearch://{user}:{password}@{url}'
+  docs: https://docs.slingdata.io/connections/database-connections/elasticsearch
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: ES_MAIN'
+      examples: ['ES_MAIN', 'ELASTIC_PROD', 'ES_LOGS']
+    url:
+      type: text
+      description: 'Elasticsearch URL'
+      examples: ['http://localhost:9200', 'https://elasticsearch.example.com:9200', 'https://my-cluster.es.amazonaws.com']
+    user:
+      type: text
+      description: 'Username for authentication'
+      examples: ['elastic', 'admin', 'es_user']
+    password:
+      type: text
+      description: 'Password for authentication'
+      examples: ['mypassword123']
+      secret: true
+    index:
+      type: text
+      description: 'Default index name'
+      examples: ['logs', 'documents', 'analytics']
+
+d1:
+  title: 'Cloudflare D1'
+  kind: database
+  required: ["account_id", "database_id", "token"]
+  url_template: 'd1://{token}@{account_id}/{database_id}'
+  docs: https://docs.slingdata.io/connections/database-connections/d1
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: D1_MAIN'
+      examples: ['D1_MAIN', 'CLOUDFLARE_D1', 'D1_PROD']
+    account_id:
+      type: text
+      description: 'Cloudflare account ID'
+      examples: ['abcdef1234567890abcdef1234567890ab']
+    database_id:
+      type: text
+      description: 'D1 database ID'
+      examples: ['01234567-8901-2345-6789-012345678901']
+    token:
+      type: text
+      description: 'Cloudflare API token'
+      examples: ['abcdef1234567890abcdef1234567890ab_example']
+      secret: true
+
+azuretable:
+  title: 'Azure Table Storage'
+  kind: database
+  required: ["account"]
+  url_template: 'azuretable://{account}'
+  docs: https://docs.slingdata.io/connections/database-connections/azuretable
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: AZT_MAIN'
+      examples: ['AZT_MAIN', 'AZURE_TABLE', 'AZT_STORAGE']
+    account:
+      type: text
+      description: 'Azure storage account name'
+      examples: ['mystorageaccount', 'prodstorageacct']
+    sas_token:
+      type: text
+      description: 'Shared Access Signature token'
+      examples: ['sv=2019-02-02&ss=t&srt=sco&sp=rwdlacup&se=2020-01-01T00:00:00Z&st=2019-01-01T00:00:00Z&spr=https&sig=abcdefghijklmnop']
+      secret: true
+    account_key:
+      type: text
+      description: 'Azure storage account key'
+      examples: ['abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/==']
+      secret: true
+    table_name:
+      type: text
+      description: 'Specific table name for table-specific SAS tokens'
+      examples: ['MyTable', 'LogData', 'UserData']
+
+ftp:
+  title: 'FTP'
+  kind: file
+  required: ["host", "username", "password"]
+  url_template: 'ftp://{username}:{password}@{host}:{port}'
+  docs: https://docs.slingdata.io/connections/file-connections/ftp
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: FTP_MAIN'
+      examples: ['FTP_MAIN', 'FTP_BACKUP', 'FTP_UPLOAD']
+    host:
+      type: text
+      description: 'FTP server hostname'
+      examples: ['ftp.example.com', '192.168.1.50', 'files.mydomain.com']
+    port:
+      type: integer
+      description: 'Port number'
+      examples: ['21', '2121']
+      default: 21
+    user:
+      type: text
+      description: 'Username for authentication'
+      examples: ['ftpuser', 'upload', 'backup_user']
+    password:
+      type: text
+      description: 'Password for authentication'
+      examples: ['mypassword123']
+      secret: true
+    passive:
+      type: boolean
+      description: 'Use passive mode'
+      examples: [true, false]
+      default: true
+
+r2:
+  title: 'Cloudflare R2'
+  kind: file
+  required: ["bucket"]
+  url_template: 'r2://{bucket}'
+  docs: https://docs.slingdata.io/connections/file-connections/r2
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: R2_MAIN'
+      examples: ['R2_MAIN', 'CLOUDFLARE_R2', 'R2_BACKUP']
+    bucket:
+      type: text
+      description: 'R2 bucket name'
+      examples: ['my-r2-bucket', 'data-lake-r2', 'backup-storage-r2']
+    access_key_id:
+      type: text
+      description: 'R2 access key ID'
+      examples: ['abcdef1234567890abcdef12']
+    secret_access_key:
+      type: text
+      description: 'R2 secret access key'
+      examples: ['abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOP']
+      secret: true
+    endpoint:
+      type: text
+      description: 'R2 endpoint URL'
+      examples: ['https://abcdef1234567890abcdef1234567890.r2.cloudflarestorage.com']
+    region:
+      type: text
+      description: 'R2 region'
+      examples: ['auto', 'us-east-1']
+
+gdrive:
+  title: 'Google Drive'
+  kind: file
+  required: ["keyfile"]
+  url_template: 'gdrive://'
+  docs: https://docs.slingdata.io/connections/file-connections/gdrive
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: GDRIVE_MAIN'
+      examples: ['GDRIVE_MAIN', 'GOOGLE_DRIVE', 'GD_BACKUP']
+    keyfile:
+      type: text
+      description: 'Path to Service Account JSON file'
+      examples: ['/path/to/service-account.json', './credentials/gdrive-service.json']
+    folder_id:
+      type: text
+      description: 'Google Drive folder ID'
+      examples: ['1AbCdEfGhIjKlMnOpQrStUvWxYz', '0B1234567890abcdefghijklmnop']
+
+local:
+  title: 'Local File System'
+  kind: file
+  required: ["path"]
+  url_template: 'file://{path}'
+  docs: https://docs.slingdata.io/connections/file-connections/local
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: LOCAL_MAIN'
+      examples: ['LOCAL_MAIN', 'LOCAL_DATA', 'FILE_SYSTEM']
+    path:
+      type: text
+      description: 'Local file system path'
+      examples: ['/data', './files', '/home/user/data', 'C:\\Data']
+
+hdfs:
+  title: 'Hadoop HDFS'
+  kind: file
+  required: ["url"]
+  url_template: 'hdfs://{url}'
+  docs: https://docs.slingdata.io/connections/file-connections/hdfs
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: HDFS_MAIN'
+      examples: ['HDFS_MAIN', 'HADOOP_FS', 'HDFS_CLUSTER']
+    url:
+      type: text
+      description: 'HDFS URL'
+      examples: ['hdfs://namenode:9000', 'hdfs://hadoop-cluster.example.com:8020']
+    user:
+      type: text
+      description: 'HDFS user'
+      examples: ['hdfs', 'hadoop', 'datauser']
+
+http:
+  title: 'HTTP/HTTPS'
+  kind: file
+  required: ["url"]
+  url_template: 'http://{url}'
+  docs: https://docs.slingdata.io/connections/file-connections/http
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: HTTP_MAIN'
+      examples: ['HTTP_MAIN', 'WEB_API', 'HTTP_ENDPOINT']
+    url:
+      type: text
+      description: 'HTTP/HTTPS URL'
+      examples: ['https://api.example.com', 'http://files.example.com', 'https://data.mysite.com/api']
+    headers:
+      type: text
+      description: 'HTTP headers'
+      examples: ['Authorization: Bearer token123', 'Content-Type: application/json']
+    auth:
+      type: text
+      description: 'Authentication method'
+      examples: ['bearer', 'basic', 'apikey']
+
+api:
+  title: 'API Connection'
+  kind: api
+  required: ["url"]
+  url_template: 'api://{url}'
+  docs: https://docs.slingdata.io/connections/api-connections/api
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: API_MAIN'
+      examples: ['API_MAIN', 'REST_API', 'WEB_SERVICE']
+    url:
+      type: text
+      description: 'API base URL'
+      examples: ['https://api.example.com', 'https://jsonplaceholder.typicode.com', 'https://api.github.com']
+    headers:
+      type: text
+      description: 'HTTP headers'
+      examples: ['Authorization: Bearer token123', 'X-API-Key: abc123']
+    auth:
+      type: text
+      description: 'Authentication method'
+      examples: ['bearer', 'basic', 'oauth2']
+    token:
+      type: text
+      description: 'API token or key'
+      examples: ['abc123def456ghi789', 'bearer_token_here']
+      secret: true
+
+athena:
+  title: 'AWS Athena'
+  kind: database
+  required: ["region", "database", "s3_staging_dir"]
+  url_template: 'athena://{region}/{database}'
+  docs: https://docs.slingdata.io/connections/datalake-connections/athena
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: ATHENA_MAIN'
+      examples: ['ATHENA_MAIN', 'AWS_ATHENA', 'ATH_ANALYTICS']
+    region:
+      type: text
+      description: 'AWS region'
+      examples: ['us-east-1', 'us-west-2', 'eu-west-1']
+    database:
+      type: text
+      description: 'Athena database name'
+      examples: ['default', 'analytics', 'data_lake']
+    s3_staging_dir:
+      type: text
+      description: 'S3 location for query results'
+      examples: ['s3://my-athena-results/', 's3://query-results-bucket/athena-output/']
+    access_key_id:
+      type: text
+      description: 'AWS access key ID'
+      examples: ['AKIAIOSFODNN7EXAMPLE']
+    secret_access_key:
+      type: text
+      description: 'AWS secret access key'
+      examples: ['wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY']
+      secret: true
+    work_group:
+      type: text
+      description: 'Athena workgroup name'
+      examples: ['primary', 'analytics-workgroup', 'production']
+
+ducklake:
+  title: 'DuckLake'
+  kind: database
+  required: ["path"]
+  url_template: 'ducklake://{path}'
+  docs: https://docs.slingdata.io/connections/datalake-connections/ducklake
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: DUCKLAKE_MAIN'
+      examples: ['DUCKLAKE_MAIN', 'DUCK_LAKE', 'DL_ANALYTICS']
+    path:
+      type: text
+      description: 'DuckLake path'
+      examples: ['s3://my-data-lake/', './data/lake/', '/data/ducklake']
+    format:
+      type: text
+      description: 'Data format'
+      examples: ['parquet', 'delta', 'iceberg']
+
+iceberg:
+  title: 'Apache Iceberg'
+  kind: database
+  required: ["catalog_uri"]
+  url_template: 'iceberg://{catalog_uri}'
+  docs: https://docs.slingdata.io/connections/datalake-connections/iceberg
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: ICEBERG_MAIN'
+      examples: ['ICEBERG_MAIN', 'ICEBERG_CATALOG', 'ICE_ANALYTICS']
+    catalog_uri:
+      type: text
+      description: 'Iceberg catalog URI'
+      examples: ['thrift://localhost:9083', 'jdbc:postgresql://localhost:5432/iceberg', 'rest://catalog-rest-service:8181']
+    warehouse:
+      type: text
+      description: 'Warehouse path'
+      examples: ['s3://my-iceberg-warehouse/', '/data/warehouse/', 'gs://iceberg-warehouse/']
+
+iceberg2:
+  title: 'Apache Iceberg (DuckDB)'
+  kind: database
+  required: ["catalog_type"]
+  url_template: 'iceberg2://{catalog_type}'
+  docs: https://docs.slingdata.io/connections/datalake-connections/iceberg
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: ICEBERG2_MAIN'
+      examples: ['ICEBERG2_MAIN', 'ICEBERG2_CATALOG', 'ICE2_ANALYTICS']
+    catalog_type:
+      type: text
+      description: 'Catalog type: rest, glue, or s3tables'
+      examples: ['rest', 'glue', 's3tables']
+    catalog_name:
+      type: text
+      description: 'Name for the attached catalog (default: iceberg)'
+      examples: ['iceberg', 'my_catalog', 'prod_catalog']
+      default: iceberg
+    rest_uri:
+      type: text
+      description: 'REST catalog endpoint URL (required for rest catalog type)'
+      examples: ['https://catalog.example.com/iceberg', 'http://localhost:8181']
+    rest_warehouse:
+      type: text
+      description: 'Warehouse path for REST catalog'
+      examples: ['s3://my-warehouse/', 'warehouse1']
+    rest_token:
+      type: text
+      description: 'Bearer token for REST catalog authentication'
+      secret: true
+    rest_oauth_client_id:
+      type: text
+      description: 'OAuth2 client ID for REST catalog'
+    rest_oauth_client_secret:
+      type: text
+      description: 'OAuth2 client secret for REST catalog'
+      secret: true
+    rest_oauth_server_uri:
+      type: text
+      description: 'OAuth2 server URI for token endpoint'
+      examples: ['https://auth.example.com/oauth/token']
+    rest_oauth_scope:
+      type: text
+      description: 'OAuth2 scope (optional)'
+    glue_account_id:
+      type: text
+      description: 'AWS account ID (required for glue catalog type)'
+      examples: ['123456789012']
+    glue_region:
+      type: text
+      description: 'AWS region for Glue catalog'
+      examples: ['us-east-1', 'eu-west-1']
+    s3_tables_arn:
+      type: text
+      description: 'S3 Tables ARN (required for s3tables catalog type)'
+      examples: ['arn:aws:s3tables:us-east-1:123456789012:bucket/my-bucket']
+    s3_access_key_id:
+      type: text
+      description: 'AWS access key ID for S3 storage'
+    s3_secret_access_key:
+      type: text
+      description: 'AWS secret access key for S3 storage'
+      secret: true
+    s3_region:
+      type: text
+      description: 'AWS region for S3 storage'
+      examples: ['us-east-1', 'eu-west-1']
+    s3_session_token:
+      type: text
+      description: 'AWS session token (optional)'
+      secret: true
+    s3_endpoint:
+      type: text
+      description: 'Custom S3 endpoint URL (optional)'
+    azure_account_name:
+      type: text
+      description: 'Azure storage account name'
+    azure_account_key:
+      type: text
+      description: 'Azure storage account key'
+      secret: true
+    azure_sas_token:
+      type: text
+      description: 'Azure SAS token'
+      secret: true
+    gcs_access_key_id:
+      type: text
+      description: 'GCS HMAC access key ID'
+    gcs_secret_access_key:
+      type: text
+      description: 'GCS HMAC secret access key'
+      secret: true
+
+bigtable:
+  title: 'Google Cloud Bigtable'
+  kind: database
+  required: ["project", "instance"]
+  url_template: 'bigtable://{project}/{instance}'
+  docs: https://docs.slingdata.io/connections/database-connections/bigtable
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: BT_MAIN'
+      examples: ['BT_MAIN', 'BIGTABLE_PROD', 'GC_BIGTABLE']
+    project:
+      type: text
+      description: 'GCP project ID'
+      examples: ['my-gcp-project', 'analytics-prod', 'bigtable-project']
+    instance:
+      type: text
+      description: 'Bigtable instance name'
+      examples: ['my-instance', 'production-bt', 'analytics-bigtable']
+    keyfile:
+      type: text
+      description: 'Path to Service Account JSON file'
+      examples: ['/path/to/service-account.json', './credentials/bigtable-service.json']
+
+azuredwh:
+  title: 'Azure Synapse Analytics'
+  kind: database
+  required: ["host", "port", "database", "username"]
+  url_template: 'sqlserver://{username}:{password}@{host}:{port}/{database}'
+  docs: https://docs.slingdata.io/connections/database-connections/sqlserver
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: SYNAPSE_MAIN'
+      examples: ['SYNAPSE_MAIN', 'AZURE_DWH', 'SYN_ANALYTICS']
+    database:
+      type: text
+      description: 'Database name'
+      examples: ['master', 'datawarehouse', 'analytics']
+    host:
+      type: text
+      description: 'Synapse server hostname'
+      examples: ['mysynapse.sql.azuresynapse.net', 'prod-synapse-sql.azuresynapse.net']
+    username:
+      type: text
+      description: 'Username for authentication'
+      examples: ['sqladmin', 'admin', 'synapse_user']
+    password:
+      type: text
+      description: 'Password for authentication'
+      examples: ['mypassword123']
+      secret: true
+    port:
+      type: integer
+      description: 'Port number'
+      examples: ['1433']
+      default: 1433
+    schema:
+      type: text
+      description: 'Default schema name'
+      examples: ['dbo', 'analytics', 'staging']
+      default: dbo
+
+db2:
+  title: 'IBM DB2'
+  kind: database
+  required: ["host", "port", "database", "username"]
+  url_template: 'db2://{username}:{password}@{host}:{port}/{database}'
+  docs: https://docs.slingdata.io/connections/database-connections/db2
+  properties:
+    name:
+      type: text
+      title: Connection Name
+      description: 'The name of the connection. No spaces are allowed, will be all caps. Example: DB2_MAIN'
+      examples: ['DB2_MAIN', 'DB2_PROD', 'DB2_ANALYTICS']
+    host:
+      type: text
+      description: 'The hostname / IP of the DB2 server'
+      examples: ['localhost', '192.168.1.100', 'db2.example.com']
+    port:
+      type: integer
+      description: 'The port number of the DB2 server'
+      examples: ['50000', '50001']
+      default: 50000
+    database:
+      type: text
+      description: 'The database name'
+      examples: ['SAMPLE', 'TESTDB', 'PRODDB']
+    schema:
+      type: text
+      description: 'The default schema name (optional)'
+      examples: ['DB2INST1', 'MYSCHEMA', 'PUBLIC']
+    username:
+      type: text
+      description: 'The username to access the database'
+      examples: ['db2inst1', 'admin', 'myuser']
+    password:
+      type: text
+      description: 'The password to access the database'
+      examples: ['mypassword123']
+      secret: true
+    sslConnection:
+      type: boolean
+      description: 'Enable SSL connection'
+      examples: [true, false]
+      default: false
+    securityMechanism:
+      type: text
+      description: 'Security mechanism for authentication (optional)'
+      examples: ['', '3', '4', '9']
+    currentSchema:
+      type: text
+      description: 'Set the current schema after connection (optional)'
+      examples: ['DB2INST1', 'MYSCHEMA']

--- a/core/dbio/templates/athena.yaml
+++ b/core/dbio/templates/athena.yaml
@@ -65,6 +65,9 @@ core:
   merge_insert: |
     INSERT INTO {tgt_table} ({insert_fields})
     SELECT {src_fields} FROM {src_table} src
+    WHERE NOT EXISTS (
+      SELECT 1 FROM {tgt_table} tgt WHERE {src_tgt_pk_equal}
+    )
 
   # Athena does not support UPDATE, UPDATE_INSERT, or DELETE_INSERT on standard tables
   # Use Iceberg tables (TypeDbIceberg) for full merge support

--- a/core/dbio/templates/azuresql.yaml
+++ b/core/dbio/templates/azuresql.yaml
@@ -51,6 +51,9 @@ core:
   merge_insert: |
     INSERT INTO {tgt_table} ({insert_fields})
     SELECT {src_fields} FROM {src_table} src
+    WHERE NOT EXISTS (
+      SELECT 1 FROM {tgt_table} tgt WHERE {src_tgt_pk_equal}
+    )
 
   merge_update: |
     UPDATE tgt

--- a/core/dbio/templates/base.yaml
+++ b/core/dbio/templates/base.yaml
@@ -7,6 +7,7 @@ core:
   create_table: create table {table} ({col_types})
   create_index: create index {index} on {table} ({cols})
   create_unique_index: create unique index {index} on {table} ({cols})
+  create_index_full: create {unique} index {index} on {table} {using} ({cols}) {include} {where}
   insert: insert into {table} ({fields}) values ({values})
   update: update {table} set {set_fields} where {pk_fields_equal}
   delete_where_not_exist: |

--- a/core/dbio/templates/base.yaml
+++ b/core/dbio/templates/base.yaml
@@ -52,6 +52,9 @@ core:
   merge_insert: |
     INSERT INTO {tgt_table} ({insert_fields})
     SELECT {src_fields} FROM {src_table} src
+    WHERE NOT EXISTS (
+      SELECT 1 FROM {tgt_table} tgt WHERE {src_tgt_pk_equal}
+    )
 
   merge_update: |
     UPDATE {tgt_table} tgt

--- a/core/dbio/templates/bigquery.yaml
+++ b/core/dbio/templates/bigquery.yaml
@@ -41,6 +41,9 @@ core:
   merge_insert: |
     INSERT INTO {tgt_table} ({insert_fields})
     SELECT {src_fields} FROM {src_table} src
+    WHERE NOT EXISTS (
+      SELECT 1 FROM {tgt_table} tgt WHERE {src_tgt_pk_equal}
+    )
 
   merge_update: |
     UPDATE {tgt_table} tgt

--- a/core/dbio/templates/clickhouse.yaml
+++ b/core/dbio/templates/clickhouse.yaml
@@ -29,6 +29,9 @@ core:
   merge_insert: |
     INSERT INTO {tgt_table} ({insert_fields})
     SELECT {src_fields} FROM {src_table} src
+    WHERE ({src_pk_fields}) NOT IN (
+      SELECT {tgt_pk_fields} FROM {tgt_table}
+    )
 
   merge_delete_insert: |
     ALTER TABLE {tgt_table} DELETE

--- a/core/dbio/templates/connections.json
+++ b/core/dbio/templates/connections.json
@@ -1,0 +1,1181 @@
+{
+  "connections": {
+    "postgres": {
+      "name": "PostgreSQL",
+      "description": "PostgreSQL database connection",
+      "category": "database",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Hostname or IP address of the PostgreSQL server",
+          "required": true,
+          "examples": ["localhost", "192.168.1.100", "postgres.example.com"]
+        },
+        "port": {
+          "type": "number",
+          "description": "Port number",
+          "default": 5432,
+          "examples": ["5432"]
+        },
+        "user": {
+          "type": "string",
+          "description": "Username for authentication",
+          "required": true,
+          "examples": ["postgres", "myuser"]
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for authentication",
+          "required": true
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name",
+          "required": true,
+          "examples": ["mydb", "production"]
+        },
+        "schema": {
+          "type": "string",
+          "description": "Default schema name",
+          "examples": ["public", "analytics"]
+        },
+        "sslmode": {
+          "type": "string",
+          "description": "SSL connection mode",
+          "enum": ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"],
+          "default": "disable"
+        },
+        "role": {
+          "type": "string",
+          "description": "Role to assume after connection"
+        },
+        "ssh_private_key": {
+          "type": "string",
+          "description": "Path to SSH private key file"
+        },
+        "ssh_passphrase": {
+          "type": "string",
+          "description": "SSH key passphrase"
+        }
+      }
+    },
+    "mysql": {
+      "name": "MySQL",
+      "description": "MySQL database connection",
+      "category": "database",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Hostname or IP address of the MySQL server",
+          "required": true
+        },
+        "port": {
+          "type": "number",
+          "description": "Port number",
+          "default": 3306
+        },
+        "user": {
+          "type": "string",
+          "description": "Username for authentication",
+          "required": true
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for authentication",
+          "required": true
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name",
+          "required": true
+        },
+        "charset": {
+          "type": "string",
+          "description": "Character set to use",
+          "default": "utf8mb4"
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Enable TLS encryption",
+          "default": false
+        }
+      }
+    },
+    "mariadb": {
+      "name": "MariaDB",
+      "description": "MariaDB database connection",
+      "category": "database",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Hostname or IP address of the MariaDB server",
+          "required": true
+        },
+        "port": {
+          "type": "number",
+          "description": "Port number",
+          "default": 3306
+        },
+        "user": {
+          "type": "string",
+          "description": "Username for authentication",
+          "required": true
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for authentication",
+          "required": true
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name",
+          "required": true
+        },
+        "charset": {
+          "type": "string",
+          "description": "Character set to use",
+          "default": "utf8mb4"
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Enable TLS encryption",
+          "default": false
+        }
+      }
+    },
+    "duckdb": {
+      "name": "DuckDB",
+      "description": "DuckDB embedded database connection",
+      "category": "database",
+      "properties": {
+        "instance": {
+          "type": "string",
+          "description": "Local file path of the database file",
+          "required": true,
+          "examples": ["/path/to/database.db", "./data/mydatabase.duckdb"]
+        },
+        "schema": {
+          "type": "string",
+          "description": "Default schema name",
+          "examples": ["main", "staging"]
+        },
+        "duckdb_version": {
+          "type": "string",
+          "description": "DuckDB CLI version to use",
+          "examples": ["0.9.0", "0.8.1"]
+        },
+        "read_only": {
+          "type": "boolean",
+          "description": "Open connection in readonly mode",
+          "default": false
+        },
+        "interactive": {
+          "type": "boolean",
+          "description": "Use interactive mode instead of reopening connection",
+          "default": false
+        },
+        "copy_method": {
+          "type": "string",
+          "description": "Method for copying data into DuckDB",
+          "enum": ["csv_files", "csv_http", "arrow_http", "named_pipes"],
+          "default": "csv_http"
+        }
+      }
+    },
+    "motherduck": {
+      "name": "MotherDuck",
+      "description": "MotherDuck cloud DuckDB service",
+      "category": "database",
+      "properties": {
+        "token": {
+          "type": "string",
+          "description": "MotherDuck authentication token",
+          "required": true
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name"
+        },
+        "schema": {
+          "type": "string",
+          "description": "Default schema name"
+        }
+      }
+    },
+    "sqlite": {
+      "name": "SQLite",
+      "description": "SQLite embedded database connection",
+      "category": "database",
+      "properties": {
+        "instance": {
+          "type": "string",
+          "description": "Local file path of the database file",
+          "required": true,
+          "examples": ["/path/to/database.db", "./data/sqlite.db"]
+        },
+        "busy_timeout": {
+          "type": "number",
+          "description": "Busy timeout in milliseconds",
+          "default": 5000
+        }
+      }
+    },
+    "bigquery": {
+      "name": "Google BigQuery",
+      "description": "Google BigQuery data warehouse connection",
+      "category": "database",
+      "properties": {
+        "project": {
+          "type": "string",
+          "description": "GCP project ID",
+          "required": true,
+          "examples": ["my-gcp-project", "analytics-prod"]
+        },
+        "dataset": {
+          "type": "string",
+          "description": "Default dataset name",
+          "required": true,
+          "examples": ["analytics", "staging"]
+        },
+        "keyfile": {
+          "type": "string",
+          "description": "Path to Service Account JSON file",
+          "examples": ["/path/to/service-account.json"]
+        },
+        "method": {
+          "type": "string",
+          "description": "Authentication method",
+          "enum": ["service-account"],
+          "default": "service-account"
+        },
+        "location": {
+          "type": "string",
+          "description": "Location of the account",
+          "default": "US",
+          "examples": ["US", "EU", "us-central1"]
+        },
+        "gc_bucket": {
+          "type": "string",
+          "description": "Google Cloud Storage bucket for loading (recommended)",
+          "examples": ["my-gcs-bucket"]
+        },
+        "extra_scopes": {
+          "type": "array",
+          "description": "Additional authorization scopes"
+        }
+      }
+    },
+    "snowflake": {
+      "name": "Snowflake",
+      "description": "Snowflake cloud data warehouse connection",
+      "category": "database",
+      "properties": {
+        "account": {
+          "type": "string",
+          "description": "Snowflake account identifier",
+          "required": true,
+          "examples": ["xy12345.us-east-1", "myorg-myaccount"]
+        },
+        "user": {
+          "type": "string",
+          "description": "Username for authentication",
+          "required": true
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for authentication",
+          "required": true
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name",
+          "examples": ["ANALYTICS", "PRODUCTION"]
+        },
+        "schema": {
+          "type": "string",
+          "description": "Schema name",
+          "examples": ["PUBLIC", "STAGING"]
+        },
+        "warehouse": {
+          "type": "string",
+          "description": "Warehouse name",
+          "examples": ["COMPUTE_WH", "ANALYTICS_WH"]
+        },
+        "role": {
+          "type": "string",
+          "description": "Role to assume",
+          "examples": ["ACCOUNTADMIN", "SYSADMIN", "ANALYST"]
+        }
+      }
+    },
+    "redshift": {
+      "name": "Amazon Redshift",
+      "description": "Amazon Redshift data warehouse connection",
+      "category": "database",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Redshift cluster endpoint",
+          "required": true
+        },
+        "port": {
+          "type": "number",
+          "description": "Port number",
+          "default": 5439
+        },
+        "user": {
+          "type": "string",
+          "description": "Username for authentication",
+          "required": true
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for authentication",
+          "required": true
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name",
+          "required": true
+        },
+        "schema": {
+          "type": "string",
+          "description": "Default schema name",
+          "default": "public"
+        },
+        "sslmode": {
+          "type": "string",
+          "description": "SSL connection mode",
+          "enum": ["disable", "allow", "prefer", "require"],
+          "default": "prefer"
+        }
+      }
+    },
+    "clickhouse": {
+      "name": "ClickHouse",
+      "description": "ClickHouse OLAP database connection",
+      "category": "database",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "ClickHouse server hostname",
+          "required": true
+        },
+        "port": {
+          "type": "number",
+          "description": "Port number",
+          "default": 9000
+        },
+        "user": {
+          "type": "string",
+          "description": "Username for authentication",
+          "default": "default"
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for authentication"
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name",
+          "default": "default"
+        },
+        "secure": {
+          "type": "boolean",
+          "description": "Use secure connection",
+          "default": false
+        }
+      }
+    },
+    "mongodb": {
+      "name": "MongoDB",
+      "description": "MongoDB NoSQL database connection",
+      "category": "database",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "MongoDB server hostname",
+          "required": true
+        },
+        "port": {
+          "type": "number",
+          "description": "Port number",
+          "default": 27017
+        },
+        "user": {
+          "type": "string",
+          "description": "Username for authentication"
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for authentication"
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name",
+          "required": true
+        },
+        "auth_source": {
+          "type": "string",
+          "description": "Authentication database",
+          "default": "admin"
+        },
+        "ssl": {
+          "type": "boolean",
+          "description": "Use SSL connection",
+          "default": false
+        }
+      }
+    },
+    "oracle": {
+      "name": "Oracle",
+      "description": "Oracle database connection",
+      "category": "database",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Oracle server hostname",
+          "required": true
+        },
+        "port": {
+          "type": "number",
+          "description": "Port number",
+          "default": 1521
+        },
+        "user": {
+          "type": "string",
+          "description": "Username for authentication",
+          "required": true
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for authentication",
+          "required": true
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name or SID",
+          "required": true
+        },
+        "schema": {
+          "type": "string",
+          "description": "Default schema name"
+        }
+      }
+    },
+    "sqlserver": {
+      "name": "SQL Server",
+      "description": "Microsoft SQL Server database connection",
+      "category": "database",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "SQL Server hostname",
+          "required": true
+        },
+        "port": {
+          "type": "number",
+          "description": "Port number",
+          "default": 1433
+        },
+        "user": {
+          "type": "string",
+          "description": "Username for authentication",
+          "required": true
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for authentication",
+          "required": true
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name",
+          "required": true
+        },
+        "schema": {
+          "type": "string",
+          "description": "Default schema name",
+          "default": "dbo"
+        },
+        "encrypt": {
+          "type": "boolean",
+          "description": "Use encrypted connection",
+          "default": true
+        },
+        "trust_server_certificate": {
+          "type": "boolean",
+          "description": "Trust server certificate",
+          "default": false
+        }
+      }
+    },
+    "s3": {
+      "name": "Amazon S3",
+      "description": "Amazon S3 cloud storage connection",
+      "category": "storage",
+      "properties": {
+        "bucket": {
+          "type": "string",
+          "description": "S3 bucket name",
+          "required": true,
+          "examples": ["my-data-bucket", "analytics-storage"]
+        },
+        "region": {
+          "type": "string",
+          "description": "AWS region",
+          "examples": ["us-east-1", "us-west-2", "eu-west-1"]
+        },
+        "access_key_id": {
+          "type": "string",
+          "description": "AWS access key ID"
+        },
+        "secret_access_key": {
+          "type": "string",
+          "description": "AWS secret access key"
+        },
+        "session_token": {
+          "type": "string",
+          "description": "AWS session token for temporary credentials"
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "Custom S3 endpoint URL"
+        },
+        "force_path_style": {
+          "type": "boolean",
+          "description": "Force path-style requests",
+          "default": false
+        }
+      }
+    },
+    "gs": {
+      "name": "Google Cloud Storage",
+      "description": "Google Cloud Storage connection",
+      "category": "storage",
+      "properties": {
+        "bucket": {
+          "type": "string",
+          "description": "GCS bucket name",
+          "required": true
+        },
+        "keyfile": {
+          "type": "string",
+          "description": "Path to Service Account JSON file"
+        },
+        "project": {
+          "type": "string",
+          "description": "GCP project ID"
+        }
+      }
+    },
+    "azure": {
+      "name": "Azure Storage",
+      "description": "Azure Blob Storage connection",
+      "category": "storage",
+      "properties": {
+        "account": {
+          "type": "string",
+          "description": "Azure storage account name",
+          "required": true
+        },
+        "container": {
+          "type": "string",
+          "description": "Azure container name",
+          "required": true
+        },
+        "sas_token": {
+          "type": "string",
+          "description": "Shared Access Signature token"
+        },
+        "account_key": {
+          "type": "string",
+          "description": "Azure storage account key"
+        }
+      }
+    },
+    "ftp": {
+      "name": "FTP",
+      "description": "FTP file transfer connection",
+      "category": "storage",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "FTP server hostname",
+          "required": true
+        },
+        "port": {
+          "type": "number",
+          "description": "Port number",
+          "default": 21
+        },
+        "user": {
+          "type": "string",
+          "description": "Username for authentication",
+          "required": true
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for authentication",
+          "required": true
+        },
+        "passive": {
+          "type": "boolean",
+          "description": "Use passive mode",
+          "default": true
+        }
+      }
+    },
+    "sftp": {
+      "name": "SFTP",
+      "description": "SFTP secure file transfer connection",
+      "category": "storage",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "SFTP server hostname",
+          "required": true
+        },
+        "port": {
+          "type": "number",
+          "description": "Port number",
+          "default": 22
+        },
+        "user": {
+          "type": "string",
+          "description": "Username for authentication",
+          "required": true
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for authentication"
+        },
+        "private_key": {
+          "type": "string",
+          "description": "Path to private key file"
+        },
+        "passphrase": {
+          "type": "string",
+          "description": "Private key passphrase"
+        }
+      }
+    },
+    "athena": {
+      "name": "AWS Athena",
+      "description": "AWS Athena serverless query service",
+      "category": "datalake",
+      "properties": {
+        "region": {
+          "type": "string",
+          "description": "AWS region",
+          "required": true
+        },
+        "database": {
+          "type": "string",
+          "description": "Athena database name",
+          "required": true
+        },
+        "s3_staging_dir": {
+          "type": "string",
+          "description": "S3 location for query results",
+          "required": true
+        },
+        "access_key_id": {
+          "type": "string",
+          "description": "AWS access key ID"
+        },
+        "secret_access_key": {
+          "type": "string",
+          "description": "AWS secret access key"
+        },
+        "work_group": {
+          "type": "string",
+          "description": "Athena workgroup name"
+        }
+      }
+    },
+    "r2": {
+      "name": "Cloudflare R2",
+      "description": "Cloudflare R2 object storage",
+      "category": "storage",
+      "properties": {
+        "bucket": {
+          "type": "string",
+          "description": "R2 bucket name",
+          "required": true
+        },
+        "access_key_id": {
+          "type": "string",
+          "description": "R2 access key ID"
+        },
+        "secret_access_key": {
+          "type": "string",
+          "description": "R2 secret access key"
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "R2 endpoint URL"
+        },
+        "region": {
+          "type": "string",
+          "description": "R2 region"
+        }
+      }
+    },
+    "gdrive": {
+      "name": "Google Drive",
+      "description": "Google Drive storage connection",
+      "category": "storage",
+      "properties": {
+        "keyfile": {
+          "type": "string",
+          "description": "Path to Service Account JSON file"
+        },
+        "folder_id": {
+          "type": "string",
+          "description": "Google Drive folder ID"
+        }
+      }
+    },
+    "local": {
+      "name": "Local File System",
+      "description": "Local file system storage",
+      "category": "storage",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Local file system path",
+          "examples": ["/data", "./files", "/home/user/data"]
+        }
+      }
+    },
+    "hdfs": {
+      "name": "Hadoop HDFS",
+      "description": "Hadoop Distributed File System",
+      "category": "storage",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "HDFS URL",
+          "required": true
+        },
+        "user": {
+          "type": "string",
+          "description": "HDFS user"
+        }
+      }
+    },
+    "http": {
+      "name": "HTTP/HTTPS",
+      "description": "HTTP/HTTPS connection for web APIs",
+      "category": "storage",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "HTTP/HTTPS URL",
+          "required": true
+        },
+        "headers": {
+          "type": "string",
+          "description": "HTTP headers"
+        },
+        "auth": {
+          "type": "string",
+          "description": "Authentication method"
+        }
+      }
+    },
+    "d1": {
+      "name": "Cloudflare D1",
+      "description": "Cloudflare D1 serverless SQL database",
+      "category": "database",
+      "properties": {
+        "account_id": {
+          "type": "string",
+          "description": "Cloudflare account ID",
+          "required": true
+        },
+        "database_id": {
+          "type": "string",
+          "description": "D1 database ID",
+          "required": true
+        },
+        "token": {
+          "type": "string",
+          "description": "Cloudflare API token",
+          "required": true
+        }
+      }
+    },
+    "azuretable": {
+      "name": "Azure Table Storage",
+      "description": "Azure Table Storage NoSQL service",
+      "category": "database",
+      "properties": {
+        "account": {
+          "type": "string",
+          "description": "Azure storage account name",
+          "required": true
+        },
+        "sas_token": {
+          "type": "string",
+          "description": "Shared Access Signature token"
+        },
+        "account_key": {
+          "type": "string",
+          "description": "Azure storage account key"
+        }
+      }
+    },
+    "azuresql": {
+      "name": "Azure SQL Database",
+      "description": "Azure SQL Database connection",
+      "category": "database",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Azure SQL server hostname",
+          "required": true
+        },
+        "port": {
+          "type": "number",
+          "description": "Port number",
+          "default": 1433
+        },
+        "user": {
+          "type": "string",
+          "description": "Username for authentication",
+          "required": true
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for authentication",
+          "required": true
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name",
+          "required": true
+        },
+        "schema": {
+          "type": "string",
+          "description": "Default schema name",
+          "default": "dbo"
+        }
+      }
+    },
+    "azuredwh": {
+      "name": "Azure Synapse Analytics",
+      "description": "Azure Synapse Analytics (SQL Data Warehouse)",
+      "category": "database",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Synapse server hostname",
+          "required": true
+        },
+        "port": {
+          "type": "number",
+          "description": "Port number",
+          "default": 1433
+        },
+        "user": {
+          "type": "string",
+          "description": "Username for authentication",
+          "required": true
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for authentication",
+          "required": true
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name",
+          "required": true
+        },
+        "schema": {
+          "type": "string",
+          "description": "Default schema name",
+          "default": "dbo"
+        }
+      }
+    },
+    "databricks": {
+      "name": "Databricks",
+      "description": "Databricks lakehouse platform",
+      "category": "database",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Databricks hostname",
+          "required": true
+        },
+        "token": {
+          "type": "string",
+          "description": "Personal access token",
+          "required": true
+        },
+        "http_path": {
+          "type": "string",
+          "description": "SQL warehouse HTTP path",
+          "required": true
+        },
+        "catalog": {
+          "type": "string",
+          "description": "Unity catalog name"
+        },
+        "schema": {
+          "type": "string",
+          "description": "Schema name"
+        }
+      }
+    },
+    "trino": {
+      "name": "Trino",
+      "description": "Trino distributed SQL query engine",
+      "category": "database",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Trino coordinator hostname",
+          "required": true
+        },
+        "port": {
+          "type": "number",
+          "description": "Port number",
+          "default": 8080
+        },
+        "user": {
+          "type": "string",
+          "description": "Username",
+          "required": true
+        },
+        "catalog": {
+          "type": "string",
+          "description": "Default catalog",
+          "required": true
+        },
+        "schema": {
+          "type": "string",
+          "description": "Default schema"
+        }
+      }
+    },
+    "elasticsearch": {
+      "name": "Elasticsearch",
+      "description": "Elasticsearch search and analytics engine",
+      "category": "database",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "Elasticsearch URL",
+          "required": true
+        },
+        "user": {
+          "type": "string",
+          "description": "Username for authentication"
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for authentication"
+        },
+        "index": {
+          "type": "string",
+          "description": "Default index name"
+        }
+      }
+    },
+    "prometheus": {
+      "name": "Prometheus",
+      "description": "Prometheus monitoring system",
+      "category": "database",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "Prometheus URL",
+          "required": true
+        },
+        "user": {
+          "type": "string",
+          "description": "Username for authentication"
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for authentication"
+        }
+      }
+    },
+    "proton": {
+      "name": "Timeplus Proton",
+      "description": "Timeplus Proton streaming analytics",
+      "category": "database",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Proton server hostname",
+          "required": true
+        },
+        "port": {
+          "type": "number",
+          "description": "Port number",
+          "default": 8463
+        },
+        "user": {
+          "type": "string",
+          "description": "Username",
+          "default": "default"
+        },
+        "password": {
+          "type": "string",
+          "description": "Password"
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name",
+          "default": "default"
+        }
+      }
+    },
+    "exasol": {
+      "name": "Exasol",
+      "description": "Exasol analytics database",
+      "category": "database",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Exasol hostname",
+          "required": true
+        },
+        "port": {
+          "type": "number",
+          "description": "Port number",
+          "default": 8563
+        },
+        "user": {
+          "type": "string",
+          "description": "Username",
+          "required": true
+        },
+        "password": {
+          "type": "string",
+          "description": "Password",
+          "required": true
+        },
+        "schema": {
+          "type": "string",
+          "description": "Schema name"
+        }
+      }
+    },
+    "starrocks": {
+      "name": "StarRocks",
+      "description": "StarRocks analytics database",
+      "category": "database",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "StarRocks hostname",
+          "required": true
+        },
+        "port": {
+          "type": "number",
+          "description": "Port number",
+          "default": 9030
+        },
+        "user": {
+          "type": "string",
+          "description": "Username",
+          "required": true
+        },
+        "password": {
+          "type": "string",
+          "description": "Password",
+          "required": true
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name",
+          "required": true
+        }
+      }
+    },
+    "bigtable": {
+      "name": "Google Cloud Bigtable",
+      "description": "Google Cloud Bigtable NoSQL database",
+      "category": "database",
+      "properties": {
+        "project": {
+          "type": "string",
+          "description": "GCP project ID",
+          "required": true
+        },
+        "instance": {
+          "type": "string",
+          "description": "Bigtable instance name",
+          "required": true
+        },
+        "keyfile": {
+          "type": "string",
+          "description": "Path to Service Account JSON file"
+        }
+      }
+    },
+    "ducklake": {
+      "name": "DuckLake",
+      "description": "DuckLake data lakehouse",
+      "category": "datalake",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "DuckLake path",
+          "required": true
+        },
+        "format": {
+          "type": "string",
+          "description": "Data format"
+        }
+      }
+    },
+    "iceberg": {
+      "name": "Apache Iceberg",
+      "description": "Apache Iceberg table format",
+      "category": "datalake",
+      "properties": {
+        "catalog_uri": {
+          "type": "string",
+          "description": "Iceberg catalog URI",
+          "required": true
+        },
+        "warehouse": {
+          "type": "string",
+          "description": "Warehouse path"
+        }
+      }
+    },
+    "api": {
+      "name": "API Connection",
+      "description": "REST API connection",
+      "category": "storage",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "API base URL",
+          "required": true
+        },
+        "headers": {
+          "type": "string",
+          "description": "HTTP headers"
+        },
+        "auth": {
+          "type": "string",
+          "description": "Authentication method"
+        },
+        "token": {
+          "type": "string",
+          "description": "API token or key"
+        }
+      }
+    }
+  }
+}

--- a/core/dbio/templates/d1.yaml
+++ b/core/dbio/templates/d1.yaml
@@ -25,6 +25,9 @@ core:
   merge_insert: |
     INSERT INTO {tgt_table} ({insert_fields})
     SELECT {src_fields} FROM {src_table} src
+    WHERE ({src_pk_fields}) NOT IN (
+      SELECT {tgt_pk_fields} FROM {tgt_table}
+    )
 
   merge_update: |
     UPDATE {tgt_table} AS tgt

--- a/core/dbio/templates/databricks.yaml
+++ b/core/dbio/templates/databricks.yaml
@@ -146,6 +146,9 @@ core:
   merge_insert: |
     INSERT INTO {tgt_table} ({insert_fields})
     SELECT {src_fields} FROM {src_table} src
+    WHERE NOT EXISTS (
+      SELECT 1 FROM {tgt_table} tgt WHERE {src_tgt_pk_equal}
+    )
 
   merge_update: |
     UPDATE {tgt_table} tgt

--- a/core/dbio/templates/duckdb.yaml
+++ b/core/dbio/templates/duckdb.yaml
@@ -39,6 +39,9 @@ core:
   merge_insert: |
     INSERT INTO {tgt_table} ({insert_fields})
     SELECT {src_fields} FROM {src_table} src
+    WHERE NOT EXISTS (
+      SELECT 1 FROM {tgt_table} tgt WHERE {src_tgt_pk_equal}
+    )
 
   merge_update: |
     UPDATE {tgt_table} tgt

--- a/core/dbio/templates/exasol.yaml
+++ b/core/dbio/templates/exasol.yaml
@@ -55,6 +55,9 @@ core:
   merge_insert: |
     INSERT INTO {tgt_table} ({insert_fields})
     SELECT {src_fields} FROM {src_table} src
+    WHERE NOT EXISTS (
+      SELECT 1 FROM {tgt_table} tgt WHERE {src_tgt_pk_equal}
+    )
 
   merge_update: |
     UPDATE {tgt_table} tgt

--- a/core/dbio/templates/fabric.yaml
+++ b/core/dbio/templates/fabric.yaml
@@ -68,6 +68,9 @@ core:
   merge_insert: |
     INSERT INTO {tgt_table} ({insert_fields})
     SELECT {src_fields} FROM {src_table} src
+    WHERE NOT EXISTS (
+      SELECT 1 FROM {tgt_table} tgt WHERE {src_tgt_pk_equal}
+    )
 
   merge_update: |
     UPDATE tgt

--- a/core/dbio/templates/mariadb.yaml
+++ b/core/dbio/templates/mariadb.yaml
@@ -4,6 +4,7 @@ core:
   drop_index: drop index if exists {index} on {table}
   create_table: create table if not exists {table} ({col_types}) CHARACTER SET utf8mb4
   create_index: create index {index} on {table} ({cols})
+  create_index_full: create {unique} index {index} on {table} ({cols}) {using}
   insert: insert into {table} ({fields}) values ({values})
   update: update {table} set {set_fields} where {pk_fields_equal}
   alter_columns: alter table {table} modify {col_ddl}

--- a/core/dbio/templates/mariadb.yaml
+++ b/core/dbio/templates/mariadb.yaml
@@ -72,7 +72,7 @@ core:
     OPTIONALLY ENCLOSED BY '"'
     ESCAPED BY '\\'
     LINES TERMINATED BY '\n'
-    IGNORE 1 LINES
+    IGNORE 1 LINES{columns_spec}
 
   # Foreign key DDL template
   add_foreign_key: |
@@ -534,6 +534,7 @@ variable:
   bool_as: integer
   max_string_type: mediumtext
   max_string_length: 16777215
+  max_binary_length: 4294967295
   max_column_length: 64
 
 error_filter:
@@ -543,7 +544,7 @@ native_type_map:
   bigint: bigint
   binary: binary
   bit: binary
-  blob: text
+  blob: binary
   char: string
   date: date
   datetime: datetime
@@ -557,9 +558,9 @@ native_type_map:
   int: integer
   json: json
   linestring: string
-  longblob: text
+  longblob: binary
   longtext: text
-  mediumblob: text
+  mediumblob: binary
   mediumint: integer
   mediumtext: text
   multilinestring: string
@@ -572,7 +573,7 @@ native_type_map:
   text: text
   time: time
   timestamp: timestamp
-  tinyblob: text
+  tinyblob: binary
   "tinyint(1)": bool
   tinyint: smallint
   tinytext: text
@@ -587,7 +588,7 @@ native_type_map:
 
 general_type_map:
   bigint: bigint
-  binary: varbinary
+  binary: longblob
   bool: "tinyint(1)"
   date: date
   datetime: "datetime(6)"

--- a/core/dbio/templates/mariadb.yaml
+++ b/core/dbio/templates/mariadb.yaml
@@ -11,6 +11,10 @@ core:
   modify_column: '{column} {type}'
 
   # MariaDB only supports insert and delete_insert (no native MERGE support)
+  # MariaDB cannot reference the insert-target table in any subquery of an
+  # INSERT ... SELECT (error 1093), so a `WHERE NOT EXISTS (SELECT ... FROM tgt)`
+  # skip-existing guard is not possible here. Left as a plain INSERT; rely on a
+  # primary_key with merge_strategy update/delete_insert to avoid duplicates.
   merge_insert: |
     INSERT INTO {tgt_table} ({insert_fields})
     SELECT {src_fields} FROM {src_table} src

--- a/core/dbio/templates/motherduck.yaml
+++ b/core/dbio/templates/motherduck.yaml
@@ -9,6 +9,7 @@ core:
   truncate_table: delete from {table}
   insert_option: ""
   modify_column: 'alter {column} type {type}'
+  add_column_comment: COMMENT ON COLUMN {table}."{column}" IS {comment}
 
 
 metadata:

--- a/core/dbio/templates/mysql.yaml
+++ b/core/dbio/templates/mysql.yaml
@@ -72,7 +72,7 @@ core:
     OPTIONALLY ENCLOSED BY '"'
     ESCAPED BY '\\'
     LINES TERMINATED BY '\n'
-    IGNORE 1 LINES
+    IGNORE 1 LINES{columns_spec}
 
   # Foreign key DDL template
   add_foreign_key: |
@@ -537,6 +537,7 @@ variable:
   bool_as: integer
   max_string_type: mediumtext
   max_string_length: 16777215
+  max_binary_length: 4294967295
   max_column_length: 64
 
 error_filter:
@@ -546,7 +547,7 @@ native_type_map:
   bigint: bigint
   binary: binary
   bit: binary
-  blob: text
+  blob: binary
   char: string
   date: date
   datetime: datetime
@@ -560,9 +561,9 @@ native_type_map:
   int: integer
   json: json
   linestring: string
-  longblob: text
+  longblob: binary
   longtext: text
-  mediumblob: text
+  mediumblob: binary
   mediumint: integer
   mediumtext: text
   multilinestring: string
@@ -575,7 +576,7 @@ native_type_map:
   text: text
   time: time
   timestamp: timestamp
-  tinyblob: text
+  tinyblob: binary
   "tinyint(1)": bool
   tinyint: smallint
   tinytext: text
@@ -590,7 +591,7 @@ native_type_map:
 
 general_type_map:
   bigint: bigint
-  binary: varbinary
+  binary: longblob
   bool: "tinyint(1)"
   date: date
   datetime: "datetime(6)"

--- a/core/dbio/templates/mysql.yaml
+++ b/core/dbio/templates/mysql.yaml
@@ -4,6 +4,7 @@ core:
   drop_index: "select 'cannot drop if exists index for mysql' as col1"
   create_table: create table if not exists {table} ({col_types}) CHARACTER SET utf8mb4
   create_index: create index {index} on {table} ({cols})
+  create_index_full: create {unique} index {index} on {table} ({cols}) {using}
   insert: insert into {table} ({fields}) values ({values})
   update: update {table} set {set_fields} where {pk_fields_equal}
   alter_columns: alter table {table} modify {col_ddl}

--- a/core/dbio/templates/mysql.yaml
+++ b/core/dbio/templates/mysql.yaml
@@ -11,6 +11,10 @@ core:
   modify_column: '{column} {type}'
 
   # MySQL only supports insert and delete_insert (no native MERGE support)
+  # MySQL cannot reference the insert-target table in any subquery of an
+  # INSERT ... SELECT (error 1093), so a `WHERE NOT EXISTS (SELECT ... FROM tgt)`
+  # skip-existing guard is not possible here. Left as a plain INSERT; rely on a
+  # primary_key with merge_strategy update/delete_insert to avoid duplicates.
   merge_insert: |
     INSERT INTO {tgt_table} ({insert_fields})
     SELECT {src_fields} FROM {src_table} src

--- a/core/dbio/templates/oracle.yaml
+++ b/core/dbio/templates/oracle.yaml
@@ -88,6 +88,9 @@ core:
   merge_insert: |
     INSERT INTO {tgt_table} ({insert_fields})
     SELECT {src_fields} FROM {src_table} src
+    WHERE NOT EXISTS (
+      SELECT 1 FROM {tgt_table} tgt WHERE {src_tgt_pk_equal}
+    )
 
   merge_update: |
     MERGE INTO {tgt_table} tgt

--- a/core/dbio/templates/postgres.yaml
+++ b/core/dbio/templates/postgres.yaml
@@ -6,6 +6,7 @@ core:
   create_table: create table if not exists {table} ({col_types}) {partition_by}
   create_index: create index if not exists {index} on {table} ({cols})
   create_unique_index: create unique index if not exists {index} on {table} ({cols})
+  create_index_full: create {unique} index if not exists {index} on {table} {using} ({cols}) {include} {where}
   replace: insert into {table} ({fields}) values ({values}) on conflict ({pk_fields}) do update set {set_fields}
   replace_temp: |
     insert into {table} ({names})

--- a/core/dbio/templates/postgres.yaml
+++ b/core/dbio/templates/postgres.yaml
@@ -54,6 +54,9 @@ core:
   merge_insert: |
     INSERT INTO {tgt_table} ({insert_fields})
     SELECT {src_fields} FROM {src_table} src
+    WHERE NOT EXISTS (
+      SELECT 1 FROM {tgt_table} tgt WHERE {src_tgt_pk_equal}
+    )
 
   merge_update: |
     UPDATE {tgt_table} tgt

--- a/core/dbio/templates/proton.yaml
+++ b/core/dbio/templates/proton.yaml
@@ -18,6 +18,9 @@ core:
       )
 
   # Proton only supports insert (streaming database, no updates or deletes)
+  # Proton is a streaming engine and does not support correlated NOT EXISTS /
+  # NOT IN subqueries against the target stream, so a skip-existing guard is not
+  # possible here. Left as a plain INSERT.
   merge_insert: |
     INSERT INTO {tgt_table} ({insert_fields})
     SELECT {src_fields} FROM table({src_table}) src

--- a/core/dbio/templates/redshift.yaml
+++ b/core/dbio/templates/redshift.yaml
@@ -49,6 +49,9 @@ core:
   merge_insert: |
     INSERT INTO {tgt_table} ({insert_fields})
     SELECT {src_fields} FROM {src_table} src
+    WHERE NOT EXISTS (
+      SELECT 1 FROM {tgt_table} tgt WHERE {src_tgt_pk_equal}
+    )
 
   merge_delete_insert: |
     DELETE FROM {tgt_table} tgt

--- a/core/dbio/templates/snowflake.yaml
+++ b/core/dbio/templates/snowflake.yaml
@@ -128,6 +128,9 @@ core:
   merge_insert: |
     INSERT INTO {tgt_table} ({insert_fields})
     SELECT {src_fields} FROM {src_table} src
+    WHERE NOT EXISTS (
+      SELECT 1 FROM {tgt_table} tgt WHERE {src_tgt_pk_equal}
+    )
 
   merge_update: |
     UPDATE {tgt_table} tgt

--- a/core/dbio/templates/sqlite.yaml
+++ b/core/dbio/templates/sqlite.yaml
@@ -4,6 +4,7 @@ core:
   drop_index: drop index if exists {index}
   create_table: create table if not exists {table} ({col_types})
   create_unique_index: create unique index if not exists {index} on {table} ({cols})
+  create_index_full: create {unique} index if not exists {index} on {table} ({cols}) {where}
   replace: replace into {table} ({names}) values({values})
   truncate_table: delete from {table}
   insert_option: ""

--- a/core/dbio/templates/sqlite.yaml
+++ b/core/dbio/templates/sqlite.yaml
@@ -14,6 +14,9 @@ core:
   merge_insert: |
     INSERT INTO {tgt_table} ({insert_fields})
     SELECT {src_fields} FROM {src_table} src
+    WHERE ({src_pk_fields}) NOT IN (
+      SELECT {tgt_pk_fields} FROM {tgt_table}
+    )
 
   merge_update: |
     UPDATE {tgt_table} AS tgt

--- a/core/dbio/templates/sqlserver.yaml
+++ b/core/dbio/templates/sqlserver.yaml
@@ -51,6 +51,9 @@ core:
   merge_insert: |
     INSERT INTO {tgt_table} ({insert_fields})
     SELECT {src_fields} FROM {src_table} src
+    WHERE NOT EXISTS (
+      SELECT 1 FROM {tgt_table} tgt WHERE {src_tgt_pk_equal}
+    )
 
   merge_update: |
     UPDATE tgt

--- a/core/dbio/templates/sqlserver.yaml
+++ b/core/dbio/templates/sqlserver.yaml
@@ -528,6 +528,8 @@ variable:
   error_filter_table_exists: already
   max_string_type: nvarchar(max)
   max_string_length: 4000
+  max_binary_type: varbinary(max)
+  max_binary_length: 8000
   max_column_length: 128
 
 native_type_map:
@@ -563,7 +565,7 @@ native_type_map:
 
 general_type_map:
   bigint: bigint
-  binary: varbinary
+  binary: "varbinary()"
   bool: bit
   date: date
   datetime: datetime2

--- a/core/dbio/templates/starrocks.yaml
+++ b/core/dbio/templates/starrocks.yaml
@@ -23,6 +23,10 @@ core:
   # - All strategies work on Primary Key tables (created with table_keys.primary)
   # - Only 'insert' works on Duplicate Key tables (default)
   # See: https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket_part_index/DELETE/
+  # StarRocks Primary Key tables perform a native upsert on plain INSERT (rows
+  # with an existing primary key are replaced), which is the desired incremental
+  # behavior. Adding a NOT EXISTS / NOT IN skip-existing guard would defeat that
+  # by skipping updates, so merge_insert is left as a plain INSERT.
   merge_insert: |
     INSERT INTO {tgt_table} ({insert_fields})
     SELECT {src_fields} FROM {src_table} src

--- a/core/env/env.go
+++ b/core/env/env.go
@@ -39,8 +39,8 @@ var (
 	Executable     = ""
 	IsThreadChild  = cast.ToBool(os.Getenv("SLING_THREAD_CHILD"))
 	ExecID         = g.Getenv("SLING_EXEC_ID", NewExecID())
-	AgentID        = os.Getenv("SLING_AGENT_ID")
-	IsAgentMode    = AgentID != ""
+	RunnerID       = g.Getenv("SLING_RUNNER_ID", os.Getenv("SLING_AGENT_ID"))
+	IsRunnerMode   = RunnerID != ""
 
 	// File logging
 	debugLogFile *os.File

--- a/core/sling/config.go
+++ b/core/sling/config.go
@@ -1287,6 +1287,7 @@ type Config struct {
 	StreamName        string                   `json:"stream_name,omitempty" yaml:"stream_name,omitempty"`
 	ReplicationStream *ReplicationStreamConfig `json:"replication_stream,omitempty" yaml:"replication_stream,omitempty"`
 	DependsOn         []string                 `json:"depends_on,omitempty" yaml:"depends_on,omitempty"`
+	QueueStreaming    bool                     `json:"queue_streaming,omitempty" yaml:"queue_streaming,omitempty"`
 
 	SrcConn  connection.Connection `json:"-" yaml:"-"`
 	TgtConn  connection.Connection `json:"-" yaml:"-"`

--- a/core/sling/config.go
+++ b/core/sling/config.go
@@ -747,6 +747,11 @@ func (cfg *Config) Prepare() (err error) {
 		}
 	}
 
+	// validate column modifier DSL
+	if _, err = cfg.ColumnsPrepared(); err != nil {
+		return err
+	}
+
 	// validate conn data keys
 	for key := range cfg.SrcConn.Data {
 		if strings.Contains(key, ":") {
@@ -1327,56 +1332,60 @@ func (cfg *Config) HasIncrementalVal() bool {
 	return cfg.IncrementalValStr != "" && cfg.IncrementalValStr != "null"
 }
 
-// ColumnsPrepared returns the prepared columns
-func (cfg *Config) ColumnsPrepared() (columns iop.Columns) {
-
-	if cfg.Target.Columns != nil {
-		switch colsCasted := cfg.Target.Columns.(type) {
-		case map[string]any:
-			for colName, colType := range colsCasted {
-				col := iop.Column{
-					Name: colName,
-					Type: iop.ColumnType(cast.ToString(colType)),
-				}
-				columns = append(columns, col)
-			}
-		case map[any]any:
-			for colName, colType := range colsCasted {
-				col := iop.Column{
-					Name: cast.ToString(colName),
-					Type: iop.ColumnType(cast.ToString(colType)),
-				}
-				columns = append(columns, col)
-			}
-		case []map[string]any:
-			for _, colItem := range colsCasted {
-				col := iop.Column{}
-				g.Unmarshal(g.Marshal(colItem), &col)
-				columns = append(columns, col)
-			}
-		case []any:
-			for _, colItem := range colsCasted {
-				col := iop.Column{}
-				g.Unmarshal(g.Marshal(colItem), &col)
-				columns = append(columns, col)
-			}
-		case iop.Columns:
-			columns = colsCasted
-		default:
-			g.Warn("Config.Source.Options.Columns not handled: %T", cfg.Source.Options.Columns)
-		}
-
-		// parse constraint, length, precision, scale
-		for i := range columns {
-			columns[i].SetConstraint()
-			columns[i].SetLengthPrecisionScale()
-		}
-
-		// set as string so that StreamProcessor parses it
-		columns = iop.NewColumns(columns...)
+// ColumnsPrepared builds the prepared columns from cfg.Target.Columns and parses
+func (cfg *Config) ColumnsPrepared() (columns iop.Columns, err error) {
+	if cfg.Target.Columns == nil {
+		return nil, nil
 	}
 
-	return
+	switch colsCasted := cfg.Target.Columns.(type) {
+	case map[string]any:
+		for colName, colType := range colsCasted {
+			col := iop.Column{
+				Name: colName,
+				Type: iop.ColumnType(cast.ToString(colType)),
+			}
+			columns = append(columns, col)
+		}
+	case map[any]any:
+		for colName, colType := range colsCasted {
+			col := iop.Column{
+				Name: cast.ToString(colName),
+				Type: iop.ColumnType(cast.ToString(colType)),
+			}
+			columns = append(columns, col)
+		}
+	case []map[string]any:
+		for _, colItem := range colsCasted {
+			col := iop.Column{}
+			g.Unmarshal(g.Marshal(colItem), &col)
+			columns = append(columns, col)
+		}
+	case []any:
+		for _, colItem := range colsCasted {
+			col := iop.Column{}
+			g.Unmarshal(g.Marshal(colItem), &col)
+			columns = append(columns, col)
+		}
+	case iop.Columns:
+		columns = colsCasted
+	default:
+		g.Warn("Config.Target.Columns not handled: %T", cfg.Target.Columns)
+	}
+
+	// parse constraint, modifiers, length, precision, scale
+	for i := range columns {
+		columns[i].SetConstraint()
+		if e := columns[i].ParseModifiers(); e != nil && err == nil {
+			err = g.Error(e, "invalid column modifier")
+		}
+		columns[i].SetLengthPrecisionScale()
+	}
+
+	// set as string so that StreamProcessor parses it
+	columns = iop.NewColumns(columns...)
+
+	return columns, err
 }
 
 // TransformsPrepared returns the transforms columns

--- a/core/sling/config.go
+++ b/core/sling/config.go
@@ -1448,6 +1448,29 @@ func (cfg *Config) StreamID() string {
 	return g.MD5(cfg.Source.Conn, cfg.Target.Conn, cfg.StreamName, cfg.Target.Object)
 }
 
+// CDCSlotLevel returns the effective slot level after applying defaults
+func (cfg *Config) CDCSlotLevel() database.CDCSlotLevel {
+	supported := cfg.SrcConn.Type.IsPostgresLike() || cfg.SrcConn.Type.IsMySQLLike()
+
+	var level database.CDCSlotLevel
+	if cfg.ReplicationStream != nil && cfg.ReplicationStream.CDCOptions != nil {
+		level = g.PtrVal(cfg.ReplicationStream.CDCOptions.SlotLevel)
+	}
+
+	if level == "" {
+		if supported {
+			return database.CDCSlotLevelShared
+		}
+		return database.CDCSlotLevelStream
+	}
+
+	if level == database.CDCSlotLevelShared && !supported {
+		return database.CDCSlotLevelStream
+	}
+
+	return level
+}
+
 // ConfigOptions are configuration options
 type ConfigOptions struct {
 	Debug   bool `json:"debug,omitempty" yaml:"debug,omitempty"`
@@ -1660,6 +1683,9 @@ type CDCOptions struct {
 
 	// Backfill / Replay
 	ReplayFrom *string `json:"replay_from,omitempty" yaml:"replay_from,omitempty"`
+
+	// SlotLevel controls how the replication slot/reader is scoped for sources
+	SlotLevel *database.CDCSlotLevel `json:"slot_level,omitempty" yaml:"slot_level,omitempty"`
 }
 
 // SetDefaults sets default values for CDCOptions from a provided defaults CDCOptions
@@ -1694,6 +1720,9 @@ func (o *CDCOptions) SetDefaults(cdcOptions CDCOptions) {
 	}
 	if o.ReplayFrom == nil {
 		o.ReplayFrom = cdcOptions.ReplayFrom
+	}
+	if o.SlotLevel == nil {
+		o.SlotLevel = cdcOptions.SlotLevel
 	}
 }
 

--- a/core/sling/config.go
+++ b/core/sling/config.go
@@ -820,6 +820,17 @@ func (cfg *Config) Prepare() (err error) {
 			if cfg.ReplicationStream != nil {
 				cfg.ReplicationStream.SQL = cfg.Source.Stream
 			}
+		} else if sTable.Name != "" && sTable.Schema == "" {
+			if dbConn, err := cfg.SrcConn.AsDatabase(); err == nil {
+				if schema, _ := dbConn.CurrentSchema(); schema != "" {
+					// normalize the injected schema's casing for the dialect
+					if schemaTable, perr := database.ParseTableName(schema+"."+sTable.Name, cfg.SrcConn.Type); perr == nil && schemaTable.Name != "" {
+						schema = schemaTable.Schema
+					}
+					sTable.Schema = schema
+					cfg.Source.Stream = sTable.FullName()
+				}
+			}
 		}
 	}
 

--- a/core/sling/hooks.go
+++ b/core/sling/hooks.go
@@ -17,6 +17,17 @@ const (
 	HookKindStep HookKind = "step"
 )
 
+const (
+	OnFailAbort OnFailType = "abort"
+	OnFailError OnFailType = "error"
+	OnFailWarn  OnFailType = "warn"
+	OnFailSkip  OnFailType = "skip" // skip the stream
+	OnFailQuiet OnFailType = "quiet"
+	OnFailBreak OnFailType = "break" // break the hook
+	OnFailRetry OnFailType = "retry"
+	OnFailDefer OnFailType = "defer" // defer failure (in groups)
+)
+
 var HookRunReplication func(string, *Config, ...string) error
 
 type Hook interface {

--- a/core/sling/pipeline.go
+++ b/core/sling/pipeline.go
@@ -395,6 +395,13 @@ retry:
 		pse.Status = ExecStatusError
 		return g.Error(err, "error executing step: %s", pse.Step.ID())
 	}
+
+	// mark the step as warning so the status bubbles up to the overall pipeline
+	if onFail == OnFailWarn || pse.Step.Status().IsWarning() {
+		pse.Status = ExecStatusWarning
+		return nil
+	}
+
 	pse.Status = ExecStatusSuccess
 
 	return nil

--- a/core/sling/pipeline.go
+++ b/core/sling/pipeline.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/flarco/g"
@@ -233,9 +234,11 @@ func (pl *Pipeline) Execute() (err error) {
 			default:
 			}
 
-			// Add to output buffer
+			// Add to output buffer (lock since concurrent group steps may log)
+			pse.Pipeline.Context.Lock()
 			pse.Output.WriteString(ll.Line() + "\n")
 			pse.Pipeline.Output.WriteString(ll.Line() + "\n")
+			pse.Pipeline.Context.Unlock()
 		}
 
 		// Execute the step
@@ -432,6 +435,7 @@ func (pl *Pipeline) RuntimeState() (_ *PipelineState, err error) {
 			Store: map[string]any{},
 			Env:   pl.Env,
 			Runs:  map[string]*RunState{},
+			mu:    &sync.RWMutex{},
 		}
 	}
 
@@ -458,13 +462,35 @@ type PipelineState struct {
 	Timestamp DateTimeState             `json:"timestamp,omitempty"`
 	Runs      map[string]*RunState      `json:"runs,omitempty"`
 	Run       *RunState                 `json:"run,omitempty"`
+
+	mu *sync.RWMutex `json:"-" yaml:"-"`
 }
+
+func (ps *PipelineState) lock() {
+	if ps.mu == nil {
+		ps.mu = &sync.RWMutex{}
+	}
+	ps.mu.Lock()
+}
+
+func (ps *PipelineState) unlock() { ps.mu.Unlock() }
+
+func (ps *PipelineState) rlock() {
+	if ps.mu == nil {
+		ps.mu = &sync.RWMutex{}
+	}
+	ps.mu.RLock()
+}
+
+func (ps *PipelineState) runlock() { ps.mu.RUnlock() }
 
 func (ps *PipelineState) GetStore() map[string]any {
 	return ps.Store
 }
 
 func (ps *PipelineState) SetStoreData(key string, value any, del bool) {
+	ps.lock()
+	defer ps.unlock()
 	if del {
 		delete(ps.Store, key)
 	} else {
@@ -473,14 +499,23 @@ func (ps *PipelineState) SetStoreData(key string, value any, del bool) {
 }
 
 func (ps *PipelineState) SetStateData(id string, data map[string]any) {
+	ps.lock()
+	defer ps.unlock()
 	ps.State[id] = data
 }
 
 func (ps *PipelineState) SetStateKeyValue(id, key string, value any) {
+	ps.lock()
+	defer ps.unlock()
+	if ps.State[id] == nil {
+		ps.State[id] = map[string]any{}
+	}
 	ps.State[id][key] = value
 }
 
 func (ps *PipelineState) Marshall() string {
+	ps.rlock()
+	defer ps.runlock()
 	return g.Marshal(ps)
 }
 

--- a/core/sling/pipeline.go
+++ b/core/sling/pipeline.go
@@ -30,6 +30,7 @@ type Pipeline struct {
 	state         *PipelineState
 	steps         Hooks
 	execID        string
+	outputMux     sync.Mutex
 }
 
 func LoadPipelineConfigFromFile(cfgPath string) (pipeline *Pipeline, err error) {
@@ -234,11 +235,11 @@ func (pl *Pipeline) Execute() (err error) {
 			default:
 			}
 
-			// Add to output buffer (lock since concurrent group steps may log)
-			pse.Pipeline.Context.Lock()
+			// Add to output buffer. Use a dedicated mutex (not Context.Mux)
+			pse.Pipeline.outputMux.Lock()
 			pse.Output.WriteString(ll.Line() + "\n")
 			pse.Pipeline.Output.WriteString(ll.Line() + "\n")
-			pse.Pipeline.Context.Unlock()
+			pse.Pipeline.outputMux.Unlock()
 		}
 
 		// Execute the step

--- a/core/sling/replication.go
+++ b/core/sling/replication.go
@@ -430,6 +430,7 @@ func (rd *ReplicationConfig) ProcessWildcards() (err error) {
 
 						setEndpointProps := func(s *ReplicationStreamConfig) {
 							s.dependsOn = endpoint.DependsOn
+							s.queueStreaming = endpoint.ConsumesQueueImmediately()
 
 							if s.PrimaryKeyI == nil {
 								s.PrimaryKeyI = endpoint.Response.Records.PrimaryKey
@@ -478,6 +479,7 @@ func (rd *ReplicationConfig) ProcessWildcards() (err error) {
 							cfg.Description = ""
 							cfg.dependsOn = nil
 							cfg.overrides = nil
+							cfg.queueStreaming = false
 						}
 						setEndpointProps(cfg) // set endpoint props
 						rd.AddStream(endpoint.Name, cfg)
@@ -921,9 +923,10 @@ func (rd *ReplicationConfig) ProcessChunks() (err error) {
 
 func (rd *ReplicationConfig) AddStream(key string, cfg *ReplicationStreamConfig) {
 	newCfg := ReplicationStreamConfig{}
-	g.Unmarshal(g.Marshal(cfg), &newCfg)       // copy config over
-	newCfg.dependsOn = g.PtrVal(cfg).dependsOn // set dependsOn since not marshalled
-	newCfg.overrides = g.PtrVal(cfg).overrides // set overrides since not marshalled
+	g.Unmarshal(g.Marshal(cfg), &newCfg)                 // copy config over
+	newCfg.dependsOn = g.PtrVal(cfg).dependsOn           // set dependsOn since not marshalled
+	newCfg.overrides = g.PtrVal(cfg).overrides           // set overrides since not marshalled
+	newCfg.queueStreaming = g.PtrVal(cfg).queueStreaming // set since not marshalled
 	rd.Streams[key] = &newCfg
 	rd.streamsOrdered = append(rd.streamsOrdered, key)
 
@@ -1404,9 +1407,10 @@ type ReplicationStreamConfig struct {
 	Columns       any            `json:"columns,omitempty" yaml:"columns,omitempty"`
 	Hooks         HookMap        `json:"hooks,omitempty" yaml:"hooks,omitempty"`
 
-	overrides   *ReplicationStreamConfig `json:"-" yaml:"-"`
-	replication *ReplicationConfig       `json:"-" yaml:"-"`
-	dependsOn   []string                 `json:"-" yaml:"-"`
+	overrides      *ReplicationStreamConfig `json:"-" yaml:"-"`
+	replication    *ReplicationConfig       `json:"-" yaml:"-"`
+	dependsOn      []string                 `json:"-" yaml:"-"`
+	queueStreaming bool                     `json:"-" yaml:"-"`
 }
 
 // SelectColumnsToken, placed first in a stream's `select`, pins the column
@@ -1550,6 +1554,7 @@ func (rd *ReplicationConfig) StreamToTaskConfig(stream *ReplicationStreamConfig,
 		StreamName:        name,
 		ReplicationStream: stream,
 		DependsOn:         stream.dependsOn,
+		QueueStreaming:    stream.queueStreaming,
 		Env:               env,
 	}
 	// so that the next stream does not retain previous pointer values

--- a/core/sling/replication.go
+++ b/core/sling/replication.go
@@ -1350,8 +1350,8 @@ func (rd *ReplicationConfig) buildCDCRunner() {
 		}
 
 		switch {
-		case cfg.SrcConn.Type.IsMySQLLike():
-			return true
+		case cfg.SrcConn.Type.IsMySQLLike(), cfg.SrcConn.Type.IsPostgresLike():
+			return cfg.CDCSlotLevel() == database.CDCSlotLevelShared
 		}
 		return false
 	}
@@ -1362,8 +1362,11 @@ func (rd *ReplicationConfig) buildCDCRunner() {
 		}
 		if groupKey == "" {
 			groupKey = string(cfg.SrcConn.Type) + ":" + cfg.SrcConnMD5()
-			if cfg.SrcConn.Type.IsMySQLLike() {
+			switch {
+			case cfg.SrcConn.Type.IsMySQLLike():
 				groupKey = "mysql:" + cfg.SrcConnMD5()
+			case cfg.SrcConn.Type.IsPostgresLike():
+				groupKey = "postgres:" + cfg.SrcConnMD5()
 			}
 		}
 		groupTasks = append(groupTasks, cfg)

--- a/core/sling/replication.go
+++ b/core/sling/replication.go
@@ -1406,6 +1406,53 @@ type ReplicationStreamConfig struct {
 	dependsOn   []string                 `json:"-" yaml:"-"`
 }
 
+// SelectColumnsToken, placed first in a stream's `select`, pins the column
+// names declared under `columns` (in declared order). e.g. `['@columns', '*']`.
+const SelectColumnsToken = "@columns"
+
+// expandSelectColumns replaces a leading @columns sentinel with the given column
+// names (in declared order), deduping and preserving any tokens that follow.
+// Errors if @columns is not first or `columns` is undefined.
+func expandSelectColumns(selectList, columnNames []string) ([]string, error) {
+	tokenAt := -1
+	for i, f := range selectList {
+		if strings.TrimSpace(f) == SelectColumnsToken {
+			tokenAt = i
+			break
+		}
+	}
+
+	if tokenAt == -1 {
+		return selectList, nil // no sentinel, nothing to do
+	}
+	if tokenAt != 0 {
+		return selectList, g.Error("the '%s' select token must be the first item in `select`", SelectColumnsToken)
+	}
+	if len(columnNames) == 0 {
+		return selectList, g.Error("the '%s' select token requires `columns` to be defined on the stream", SelectColumnsToken)
+	}
+
+	expanded := make([]string, 0, len(selectList)-1+len(columnNames))
+	seen := map[string]bool{}
+	add := func(f string) {
+		key := strings.ToLower(strings.TrimSpace(f))
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		expanded = append(expanded, f)
+	}
+
+	// @columns is first: emit the declared column names, then the remaining tokens
+	for _, name := range columnNames {
+		add(name)
+	}
+	for _, f := range selectList[1:] {
+		add(f)
+	}
+	return expanded, nil
+}
+
 func (s *ReplicationStreamConfig) PrimaryKey() []string {
 	return castKeyArray(s.PrimaryKeyI)
 }
@@ -1472,12 +1519,19 @@ func (rd *ReplicationConfig) StreamToTaskConfig(stream *ReplicationStreamConfig,
 		stream.Hooks.PostMerge = append(stream.Hooks.PostMerge, overrides.Hooks.PostMerge...)
 	}
 
+	// Expand a leading @columns sentinel here, where both `select` and `columns`
+	// are fully resolved, before the select list reaches any source reader.
+	selectFields, err := expandSelectColumns(stream.Select, columnNamesInOrder(stream.Columns))
+	if err != nil {
+		return cfg, g.Error(err, "could not resolve `select` for stream: %s", name)
+	}
+
 	cfg = Config{
 		Source: Source{
 			Conn:        rd.Source,
 			Stream:      name,
 			Query:       stream.SQL,
-			Select:      stream.Select,
+			Select:      selectFields,
 			Where:       stream.Where,
 			Files:       stream.Files,
 			PrimaryKeyI: stream.PrimaryKey(),
@@ -1744,6 +1798,59 @@ func UnmarshalReplication(replicYAML string) (config ReplicationConfig, err erro
 	}
 
 	return
+}
+
+// columnNamesInOrder returns the column names from a stream's resolved `columns`
+// value, preserving declared order. The YAML parser stores it as an ordered
+// []any of {name, type} maps (see makeColumns); map shapes are a non-YAML
+// fallback. Returns nil if there are no columns.
+func columnNamesInOrder(cols any) []string {
+	if cols == nil {
+		return nil
+	}
+
+	extractName := func(item any) string {
+		switch v := item.(type) {
+		case map[string]any:
+			return cast.ToString(v["name"])
+		case map[any]any:
+			return cast.ToString(v["name"])
+		case iop.Column:
+			return v.Name
+		default:
+			return ""
+		}
+	}
+
+	var names []string
+	switch v := cols.(type) {
+	case []any:
+		for _, item := range v {
+			if name := extractName(item); name != "" {
+				names = append(names, name)
+			}
+		}
+	case []map[string]any:
+		for _, item := range v {
+			if name := cast.ToString(item["name"]); name != "" {
+				names = append(names, name)
+			}
+		}
+	case iop.Columns:
+		for _, c := range v {
+			names = append(names, c.Name)
+		}
+	case map[string]any:
+		for name := range v {
+			names = append(names, name)
+		}
+	case map[any]any:
+		for name := range v {
+			names = append(names, cast.ToString(name))
+		}
+	}
+
+	return names
 }
 
 // sets the columns correctly and keep the order

--- a/core/sling/replication.go
+++ b/core/sling/replication.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"runtime/debug"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/flarco/g"
@@ -100,6 +101,7 @@ func (rd *ReplicationConfig) initRuntimeState(selectStreams []string) {
 			Execution: ExecutionState{},
 			Source:    ConnState{Name: rd.Source},
 			Target:    ConnState{Name: rd.Target},
+			mu:        &sync.RWMutex{},
 		}
 
 		if env.IsThreadChild {

--- a/core/sling/replication_test.go
+++ b/core/sling/replication_test.go
@@ -818,3 +818,72 @@ streams:
 		})
 	}
 }
+
+func TestExpandSelectColumns(t *testing.T) {
+	cols := []string{"full_name", "id", "html_url"}
+
+	tests := []struct {
+		name       string
+		selectList []string
+		columns    []string
+		want       []string
+		wantErr    bool
+	}{
+		{
+			name:       "no token passes through unchanged",
+			selectList: []string{"id", "name"},
+			columns:    cols,
+			want:       []string{"id", "name"},
+		},
+		{
+			name:       "empty select passes through",
+			selectList: nil,
+			columns:    cols,
+			want:       nil,
+		},
+		{
+			name:       "token alone expands to columns in declared order",
+			selectList: []string{"@columns"},
+			columns:    cols,
+			want:       []string{"full_name", "id", "html_url"},
+		},
+		{
+			name:       "token then wildcard pins columns first",
+			selectList: []string{"@columns", "*"},
+			columns:    cols,
+			want:       []string{"full_name", "id", "html_url", "*"},
+		},
+		{
+			name:       "expansion dedupes a name listed again after the token",
+			selectList: []string{"@columns", "id", "extra"},
+			columns:    cols,
+			want:       []string{"full_name", "id", "html_url", "extra"},
+		},
+		{
+			name:       "token not first is an error",
+			selectList: []string{"id", "@columns"},
+			columns:    cols,
+			wantErr:    true,
+		},
+		{
+			name:       "token with no columns is an error",
+			selectList: []string{"@columns"},
+			columns:    nil,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := expandSelectColumns(tt.selectList, tt.columns)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/core/sling/task.go
+++ b/core/sling/task.go
@@ -528,7 +528,7 @@ func (t *TaskExecution) getSourceOptionsMap() (options map[string]any) {
 		options["decode"] = encoding.DecodeString()
 	}
 
-	if columns := t.Config.ColumnsPrepared(); len(columns) > 0 {
+	if columns, _ := t.Config.ColumnsPrepared(); len(columns) > 0 {
 		// set as string so that StreamProcessor parses it
 		options["columns"] = g.Marshal(columns)
 	}

--- a/core/sling/task_run_read.go
+++ b/core/sling/task_run_read.go
@@ -307,7 +307,8 @@ func (t *TaskExecution) ReadFromDB(cfg *Config, srcConn database.Connection) (df
 	}
 
 	// set constraints
-	for _, col := range cfg.ColumnsPrepared() {
+	cols, _ := cfg.ColumnsPrepared()
+	for _, col := range cols {
 		if c := sTable.Columns.GetColumn(col.Name); c != nil {
 			sTable.Columns[c.Position-1].Constraint = col.Constraint
 		}

--- a/core/sling/task_run_write.go
+++ b/core/sling/task_run_write.go
@@ -431,17 +431,17 @@ func (t *TaskExecution) WriteToDb(cfg *Config, df *iop.Dataflow, tgtConn databas
 
 	defer tgtConn.Rollback() // rollback in case of error
 
-	// pre-merge-hooks
-	if err = t.ExecuteHooks(HookStagePreMerge); err != nil {
-		err = g.Error(err, "error executing pre-merge hooks")
-		return 0, err
-	}
-
 	setStage("5 - prepare-final")
 
 	// Prepare final table operations
 	if err = prepareFinal(t, cfg, tgtConn, targetTable, df); err != nil {
 		err = g.Error(err, "error preparing final table")
+		return 0, err
+	}
+
+	// pre-merge-hooks
+	if err = t.ExecuteHooks(HookStagePreMerge); err != nil {
+		err = g.Error(err, "error executing pre-merge hooks")
 		return 0, err
 	}
 
@@ -547,15 +547,15 @@ func (t *TaskExecution) writeToDbDirectly(cfg *Config, df *iop.Dataflow, tgtConn
 
 	defer tgtConn.Rollback()
 
-	// pre-merge-hooks
-	if err = t.ExecuteHooks(HookStagePreMerge); err != nil {
-		err = g.Error(err, "error executing pre-merge hooks")
-		return 0, err
-	}
-
 	// Prepare final table operations & handlers
 	if err = prepareFinal(t, cfg, tgtConn, targetTable, df); err != nil {
 		err = g.Error(err, "error preparing final table")
+		return 0, err
+	}
+
+	// pre-merge-hooks
+	if err = t.ExecuteHooks(HookStagePreMerge); err != nil {
+		err = g.Error(err, "error executing pre-merge hooks")
 		return 0, err
 	}
 

--- a/core/sling/task_state.go
+++ b/core/sling/task_state.go
@@ -3,6 +3,7 @@ package sling
 import (
 	"os"
 	"path"
+	"sync"
 	"time"
 
 	"github.com/flarco/g"
@@ -35,13 +36,35 @@ type ReplicationState struct {
 	Object    *ObjectState              `json:"object,omitempty"`
 	Runs      map[string]*RunState      `json:"runs,omitempty"`
 	Run       *RunState                 `json:"run,omitempty"`
+
+	mu *sync.RWMutex `json:"-" yaml:"-"`
 }
+
+func (rs *ReplicationState) lock() {
+	if rs.mu == nil {
+		rs.mu = &sync.RWMutex{}
+	}
+	rs.mu.Lock()
+}
+
+func (rs *ReplicationState) unlock() { rs.mu.Unlock() }
+
+func (rs *ReplicationState) rlock() {
+	if rs.mu == nil {
+		rs.mu = &sync.RWMutex{}
+	}
+	rs.mu.RLock()
+}
+
+func (rs *ReplicationState) runlock() { rs.mu.RUnlock() }
 
 func (rs *ReplicationState) GetStore() map[string]any {
 	return rs.Store
 }
 
 func (rs *ReplicationState) SetStoreData(key string, value any, del bool) {
+	rs.lock()
+	defer rs.unlock()
 	if del {
 		delete(rs.Store, key)
 	} else {
@@ -50,14 +73,23 @@ func (rs *ReplicationState) SetStoreData(key string, value any, del bool) {
 }
 
 func (rs *ReplicationState) SetStateData(id string, data map[string]any) {
+	rs.lock()
+	defer rs.unlock()
 	rs.State[id] = data
 }
 
 func (rs *ReplicationState) SetStateKeyValue(id, key string, value any) {
+	rs.lock()
+	defer rs.unlock()
+	if rs.State[id] == nil {
+		rs.State[id] = map[string]any{}
+	}
 	rs.State[id][key] = value
 }
 
 func (rs *ReplicationState) Marshall() string {
+	rs.rlock()
+	defer rs.runlock()
 	return g.Marshal(rs)
 }
 
@@ -322,7 +354,7 @@ func (t *TaskExecution) StateSet() {
 		// write runtime state file if finished
 		if env.IsThreadChild && t.Status.IsFinished() {
 			stateFile := env.RuntimeFilePath(t.Config.StreamName)
-			if err := os.WriteFile(stateFile, []byte(g.Marshal(state)), 0755); err != nil {
+			if err := os.WriteFile(stateFile, []byte(state.Marshall()), 0755); err != nil {
 				g.Warn("could not write runtime state file (%s): %s", stateFile, err.Error())
 			}
 		}

--- a/core/sling/types.go
+++ b/core/sling/types.go
@@ -98,6 +98,8 @@ var AllExecStatus = []struct {
 	{ExecStatusError, "ExecStatusError"},
 	{ExecStatusSkipped, "ExecStatusSkipped"},
 	{ExecStatusStalled, "ExecStatusStalled"},
+	{ExecStatusCancelled, "ExecStatusCancelled"},
+	{ExecStatusWarning, "ExecStatusWarning"},
 }
 
 // IsRunning returns true if an execution is running
@@ -114,7 +116,8 @@ func (s ExecStatus) IsFinished() bool {
 	switch s {
 	case ExecStatusSuccess, ExecStatusError,
 		ExecStatusTerminated, ExecStatusStalled,
-		ExecStatusInterrupted, ExecStatusTimedOut:
+		ExecStatusInterrupted, ExecStatusTimedOut,
+		ExecStatusWarning:
 		return true
 	}
 	return false

--- a/core/version.go
+++ b/core/version.go
@@ -22,7 +22,7 @@ var TelProps = g.M(
 func init() {
 	// dev build version is in format => 1.2.2.dev/2024-08-20
 	parts := strings.Split(Version, "/")
-	if len(parts) != 2 || os.Getenv("SLING_AGENT_ID") != "" || os.Getenv("SLING_AGENT_KEY") != "" {
+	if len(parts) != 2 || os.Getenv("SLING_AGENT_ID") != "" || os.Getenv("SLING_AGENT_KEY") != "" || os.Getenv("SLING_RUNNER_ID") != "" || os.Getenv("SLING_RUNNER_KEY") != "" {
 		return
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/exasol/exasol-driver-go v1.0.14
 	github.com/fatih/color v1.18.0
 	github.com/flarco/bigquery v0.0.9
-	github.com/flarco/g v0.1.175
+	github.com/flarco/g v0.1.176
 	github.com/getsentry/sentry-go v0.27.0
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/gobwas/glob v0.2.3

--- a/justfile
+++ b/justfile
@@ -90,29 +90,29 @@ test-python-main:
     #!/usr/bin/env bash
     echo "TESTING Python"
     export SLING_BINARY="$PWD/cmd/sling/sling"
-    cd ../sling-python/sling && python -m pytest tests/tests.py -v && cd -
-    cd ../sling-python/sling && python -m pytest tests/test_api_spec.py -v && cd -
+    cd ../sling-python/sling && uv sync --group test && uv run python -m pytest tests/tests.py -v && cd -
+    cd ../sling-python/sling && uv run python -m pytest tests/test_api_spec.py -v && cd -
 
 # Test Python class without ARROW
 test-python-arrow-false:
     #!/usr/bin/env bash
     echo "TESTING Python class (ARROW=false)"
     export SLING_BINARY="$PWD/cmd/sling/sling"
-    cd ../sling-python/sling && SLING_USE_ARROW=false python -m pytest tests/test_sling_class.py -v && cd -
+    cd ../sling-python/sling && uv sync --group test && SLING_USE_ARROW=false uv run python -m pytest tests/test_sling_class.py -v && cd -
 
 # Test Python class with ARROW
 test-python-arrow-true:
     #!/usr/bin/env bash
     echo "TESTING Python class (ARROW=true)"
     export SLING_BINARY="$PWD/cmd/sling/sling"
-    cd ../sling-python/sling && SLING_USE_ARROW=true python -m pytest tests/test_sling_class.py -v && cd -
+    cd ../sling-python/sling && uv sync --group test && SLING_USE_ARROW=true uv run python -m pytest tests/test_sling_class.py -v && cd -
 
 # Test Python Connection class (sling conns exec/test, arrow IPC, CSV streaming, limit)
 test-python-conns:
     #!/usr/bin/env bash
     echo "TESTING Python Connection class"
     export SLING_BINARY="$PWD/cmd/sling/sling"
-    cd ../sling-python/sling && python -m pytest tests/test_connection.py -v && cd -
+    cd ../sling-python/sling && uv sync --group test && uv run python -m pytest tests/test_connection.py -v && cd -
 
 # Run all Python tests
 test-python: test-python-main test-python-arrow-false test-python-arrow-true test-python-conns

--- a/tests/pipelines/column_ddl/p.columns_ddl.00.master.yaml
+++ b/tests/pipelines/column_ddl/p.columns_ddl.00.master.yaml
@@ -1,0 +1,83 @@
+# Master pipeline for the per-engine column DDL test. Builds public.cddl_src
+# (varchar(255) cols, so Oracle maps to indexable VARCHAR2) then drives one child
+# pipeline per engine via command steps. Each child asserts only what it emits.
+# redshift/databricks are commented out (connections unavailable).
+
+env:
+  SOURCE: postgres
+
+steps:
+  # build the reusable source table
+  - connection: '{env.SOURCE}'
+    query: |
+      drop table if exists public.cddl_src;
+      create table public.cddl_src (
+        id bigint,
+        email varchar(255),
+        org_id varchar(255),
+        region varchar(255),
+        notes varchar(255)
+      );
+      insert into public.cddl_src (id, email, org_id, region, notes) values
+        (1, 'a@example.com', 'org-1', 'us-east', 'first note'),
+        (2, 'b@example.com', 'org-2', 'eu-west', 'second note');
+
+  - type: command
+    command: sling run -p tests/pipelines/column_ddl/p.columns_ddl.01.postgres.yaml
+    print: true
+
+  - type: command
+    command: sling run -p tests/pipelines/column_ddl/p.columns_ddl.02.mysql.yaml
+    print: true
+
+  - type: command
+    command: sling run -p tests/pipelines/column_ddl/p.columns_ddl.03.mariadb.yaml
+    print: true
+
+  - type: command
+    command: sling run -p tests/pipelines/column_ddl/p.columns_ddl.04.sqlserver.yaml
+    print: true
+
+  - type: command
+    command: sling run -p tests/pipelines/column_ddl/p.columns_ddl.05.sqlite.yaml
+    print: true
+
+  - type: command
+    command: sling run -p tests/pipelines/column_ddl/p.columns_ddl.06.oracle.yaml
+    print: true
+
+  - type: command
+    command: sling run -p tests/pipelines/column_ddl/p.columns_ddl.07.clickhouse.yaml
+    print: true
+
+  - type: command
+    command: sling run -p tests/pipelines/column_ddl/p.columns_ddl.08.snowflake.yaml
+    print: true
+
+  - type: command
+    command: sling run -p tests/pipelines/column_ddl/p.columns_ddl.09.duckdb.yaml
+    print: true
+
+  - type: command
+    command: sling run -p tests/pipelines/column_ddl/p.columns_ddl.10.motherduck.yaml
+    print: true
+
+  - type: command
+    command: sling run -p tests/pipelines/column_ddl/p.columns_ddl.11.bigquery.yaml
+    print: true
+
+  - type: command
+    command: sling run -p tests/pipelines/column_ddl/p.columns_ddl.12.starrocks.yaml
+    print: true
+
+  # redshift & databricks connections currently unavailable — uncomment to enable:
+  # - type: command
+  #   command: sling run -p tests/pipelines/column_ddl/p.columns_ddl.13.redshift.yaml
+  #   print: true
+  #
+  # - type: command
+  #   command: sling run -p tests/pipelines/column_ddl/p.columns_ddl.14.databricks.yaml
+  #   print: true
+
+  - type: log
+    message: 'SUCCESS: all column DDL engine pipelines passed'

--- a/tests/pipelines/column_ddl/p.columns_ddl.01.postgres.yaml
+++ b/tests/pipelines/column_ddl/p.columns_ddl.01.postgres.yaml
@@ -1,0 +1,86 @@
+# Column DDL constraints test: PostgreSQL target
+# Reads public.cddl_src (built by the master pipeline) and applies the column
+# modifier DSL (not_null, primary_key, unique_index, index, description), then
+# inspects the catalog to confirm each constraint landed on the right column.
+env:
+  SOURCE: postgres
+  TARGET: postgres
+  SCHEMA: public
+
+steps:
+  - connection: '{env.TARGET}'
+    query: drop table if exists {env.SCHEMA}.cddl_dst cascade
+
+  - type: replication
+    id: repl
+    replication:
+      source: '{env.SOURCE}'
+      target: '{env.TARGET}'
+      defaults:
+        mode: full-refresh
+      streams:
+        public.cddl_src:
+          object: '{env.SCHEMA}.cddl_dst'
+          columns:
+            id: bigint not_null primary_key
+            email: string(255) not_null unique_index
+            org_id: string(255) not_null
+            region: string(255) index
+            notes: string(255) description('user notes')
+
+  # nullability: id/email/org_id NOT NULL, region/notes nullable
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from information_schema.columns
+      where table_schema = '{env.SCHEMA}' and table_name = 'cddl_dst'
+        and is_nullable = 'NO' and column_name in ('id','email','org_id')
+    into: notnull_cnt
+  - type: check
+    check: int_parse(store.notnull_cnt[0].cnt) == 3
+    message: 'expected 3 NOT NULL columns, got {store.notnull_cnt[0].cnt}'
+
+  # primary key on id
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from information_schema.table_constraints
+      where table_schema = '{env.SCHEMA}' and table_name = 'cddl_dst'
+        and constraint_type = 'PRIMARY KEY'
+    into: pk_cnt
+  - type: check
+    check: int_parse(store.pk_cnt[0].cnt) == 1
+    message: 'expected 1 primary key, got {store.pk_cnt[0].cnt}'
+
+  # unique index on email, plain index on region
+  - connection: '{env.TARGET}'
+    query: |
+      select indexname, indexdef from pg_indexes
+      where schemaname = '{env.SCHEMA}' and tablename = 'cddl_dst'
+        and indexname = 'idx_cddl_dst_email'
+    into: uniq_idx
+  - type: check
+    check: contains(store.uniq_idx[0].indexdef, "UNIQUE")
+    message: 'expected unique index on email, got {store.uniq_idx[0].indexdef}'
+
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from pg_indexes
+      where schemaname = '{env.SCHEMA}' and tablename = 'cddl_dst'
+        and indexname = 'idx_cddl_dst_region'
+    into: plain_idx
+  - type: check
+    check: int_parse(store.plain_idx[0].cnt) == 1
+    message: 'expected index on region, got {store.plain_idx[0].cnt}'
+
+  # description / column comment on notes
+  - connection: '{env.TARGET}'
+    query: |
+      select col_description(('{env.SCHEMA}.cddl_dst')::regclass,
+        (select ordinal_position from information_schema.columns
+         where table_schema='{env.SCHEMA}' and table_name='cddl_dst' and column_name='notes')::int) comment
+    into: notes_comment
+  - type: check
+    check: store.notes_comment[0].comment == "user notes"
+    message: 'expected comment "user notes" on notes, got {store.notes_comment[0].comment}'
+
+  - type: log
+    message: 'SUCCESS: postgres column DDL verified'

--- a/tests/pipelines/column_ddl/p.columns_ddl.02.mysql.yaml
+++ b/tests/pipelines/column_ddl/p.columns_ddl.02.mysql.yaml
@@ -1,0 +1,85 @@
+# Column DDL constraints test: MySQL / MariaDB target
+# (same DDL emission path for both; the master pipeline passes TARGET).
+# Verifies not_null, primary_key, unique_index, index and description (comment).
+env:
+  SOURCE: postgres
+  TARGET: mysql
+  SCHEMA: mysql
+
+steps:
+  - connection: '{env.TARGET}'
+    query: drop table if exists {env.SCHEMA}.cddl_dst
+
+  - type: replication
+    id: repl
+    replication:
+      source: '{env.SOURCE}'
+      target: '{env.TARGET}'
+      defaults:
+        mode: full-refresh
+      streams:
+        public.cddl_src:
+          object: '{env.SCHEMA}.cddl_dst'
+          columns:
+            id: bigint not_null primary_key
+            email: string(255) not_null unique_index
+            org_id: string(255) not_null
+            region: string(255) index
+            notes: string(255) description('user notes')
+
+  # nullability
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from information_schema.columns
+      where table_schema = '{env.SCHEMA}' and table_name = 'cddl_dst'
+        and is_nullable = 'NO' and column_name in ('id','email','org_id')
+    into: notnull_cnt
+  - type: check
+    check: int_parse(store.notnull_cnt[0].cnt) == 3
+    message: 'expected 3 NOT NULL columns, got {store.notnull_cnt[0].cnt}'
+
+  # primary key
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from information_schema.statistics
+      where table_schema = '{env.SCHEMA}' and table_name = 'cddl_dst'
+        and index_name = 'PRIMARY'
+    into: pk_cnt
+  - type: check
+    check: int_parse(store.pk_cnt[0].cnt) >= 1
+    message: 'expected primary key, got {store.pk_cnt[0].cnt}'
+
+  # unique index on email (non_unique = 0)
+  - connection: '{env.TARGET}'
+    query: |
+      select non_unique from information_schema.statistics
+      where table_schema = '{env.SCHEMA}' and table_name = 'cddl_dst'
+        and index_name = 'idx_cddl_dst_email'
+    into: uniq_idx
+  - type: check
+    check: int_parse(store.uniq_idx[0].non_unique) == 0
+    message: 'expected unique index on email, got non_unique={store.uniq_idx[0].non_unique}'
+
+  # plain index on region (non_unique = 1)
+  - connection: '{env.TARGET}'
+    query: |
+      select non_unique from information_schema.statistics
+      where table_schema = '{env.SCHEMA}' and table_name = 'cddl_dst'
+        and index_name = 'idx_cddl_dst_region'
+    into: plain_idx
+  - type: check
+    check: int_parse(store.plain_idx[0].non_unique) == 1
+    message: 'expected non-unique index on region, got non_unique={store.plain_idx[0].non_unique}'
+
+  # description / column comment
+  - connection: '{env.TARGET}'
+    query: |
+      select column_comment from information_schema.columns
+      where table_schema = '{env.SCHEMA}' and table_name = 'cddl_dst' and column_name = 'notes'
+    into: notes_comment
+  - type: check
+    check: store.notes_comment[0].column_comment == "user notes"
+    message: 'expected comment "user notes" on notes, got {store.notes_comment[0].column_comment}'
+
+  - type: log
+    message: 'SUCCESS: {env.TARGET} column DDL verified'

--- a/tests/pipelines/column_ddl/p.columns_ddl.03.mariadb.yaml
+++ b/tests/pipelines/column_ddl/p.columns_ddl.03.mariadb.yaml
@@ -1,0 +1,85 @@
+# Column DDL constraints test: MariaDB target
+# (same DDL emission path for both; the master pipeline passes TARGET).
+# Verifies not_null, primary_key, unique_index, index and description (comment).
+env:
+  SOURCE: postgres
+  TARGET: mariadb
+  SCHEMA: mariadb
+
+steps:
+  - connection: '{env.TARGET}'
+    query: drop table if exists {env.SCHEMA}.cddl_dst
+
+  - type: replication
+    id: repl
+    replication:
+      source: '{env.SOURCE}'
+      target: '{env.TARGET}'
+      defaults:
+        mode: full-refresh
+      streams:
+        public.cddl_src:
+          object: '{env.SCHEMA}.cddl_dst'
+          columns:
+            id: bigint not_null primary_key
+            email: string(255) not_null unique_index
+            org_id: string(255) not_null
+            region: string(255) index
+            notes: string(255) description('user notes')
+
+  # nullability
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from information_schema.columns
+      where table_schema = '{env.SCHEMA}' and table_name = 'cddl_dst'
+        and is_nullable = 'NO' and column_name in ('id','email','org_id')
+    into: notnull_cnt
+  - type: check
+    check: int_parse(store.notnull_cnt[0].cnt) == 3
+    message: 'expected 3 NOT NULL columns, got {store.notnull_cnt[0].cnt}'
+
+  # primary key
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from information_schema.statistics
+      where table_schema = '{env.SCHEMA}' and table_name = 'cddl_dst'
+        and index_name = 'PRIMARY'
+    into: pk_cnt
+  - type: check
+    check: int_parse(store.pk_cnt[0].cnt) >= 1
+    message: 'expected primary key, got {store.pk_cnt[0].cnt}'
+
+  # unique index on email (non_unique = 0)
+  - connection: '{env.TARGET}'
+    query: |
+      select non_unique from information_schema.statistics
+      where table_schema = '{env.SCHEMA}' and table_name = 'cddl_dst'
+        and index_name = 'idx_cddl_dst_email'
+    into: uniq_idx
+  - type: check
+    check: int_parse(store.uniq_idx[0].non_unique) == 0
+    message: 'expected unique index on email, got non_unique={store.uniq_idx[0].non_unique}'
+
+  # plain index on region (non_unique = 1)
+  - connection: '{env.TARGET}'
+    query: |
+      select non_unique from information_schema.statistics
+      where table_schema = '{env.SCHEMA}' and table_name = 'cddl_dst'
+        and index_name = 'idx_cddl_dst_region'
+    into: plain_idx
+  - type: check
+    check: int_parse(store.plain_idx[0].non_unique) == 1
+    message: 'expected non-unique index on region, got non_unique={store.plain_idx[0].non_unique}'
+
+  # description / column comment
+  - connection: '{env.TARGET}'
+    query: |
+      select column_comment from information_schema.columns
+      where table_schema = '{env.SCHEMA}' and table_name = 'cddl_dst' and column_name = 'notes'
+    into: notes_comment
+  - type: check
+    check: store.notes_comment[0].column_comment == "user notes"
+    message: 'expected comment "user notes" on notes, got {store.notes_comment[0].column_comment}'
+
+  - type: log
+    message: 'SUCCESS: {env.TARGET} column DDL verified'

--- a/tests/pipelines/column_ddl/p.columns_ddl.04.sqlserver.yaml
+++ b/tests/pipelines/column_ddl/p.columns_ddl.04.sqlserver.yaml
@@ -1,0 +1,87 @@
+# Column DDL constraints test: SQL Server target
+# Verifies not_null, primary_key, unique_index, index and description
+# (column comment via sys.extended_properties MS_Description).
+env:
+  SOURCE: postgres
+  TARGET: mssql
+  SCHEMA: dbo
+
+steps:
+  - connection: '{env.TARGET}'
+    query: IF OBJECT_ID('{env.SCHEMA}.cddl_dst', 'U') IS NOT NULL DROP TABLE {env.SCHEMA}.cddl_dst
+
+  - type: replication
+    id: repl
+    replication:
+      source: '{env.SOURCE}'
+      target: '{env.TARGET}'
+      defaults:
+        mode: full-refresh
+      streams:
+        public.cddl_src:
+          object: '{env.SCHEMA}.cddl_dst'
+          columns:
+            id: bigint not_null primary_key
+            email: string(255) not_null unique_index
+            org_id: string(255) not_null
+            region: string(255) index
+            notes: string(255) description('user notes')
+
+  # nullability
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from information_schema.columns
+      where table_schema = '{env.SCHEMA}' and table_name = 'cddl_dst'
+        and is_nullable = 'NO' and column_name in ('id','email','org_id')
+    into: notnull_cnt
+  - type: check
+    check: int_parse(store.notnull_cnt[0].cnt) == 3
+    message: 'expected 3 NOT NULL columns, got {store.notnull_cnt[0].cnt}'
+
+  # primary key
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from information_schema.table_constraints
+      where table_schema = '{env.SCHEMA}' and table_name = 'cddl_dst'
+        and constraint_type = 'PRIMARY KEY'
+    into: pk_cnt
+  - type: check
+    check: int_parse(store.pk_cnt[0].cnt) == 1
+    message: 'expected 1 primary key, got {store.pk_cnt[0].cnt}'
+
+  # unique index on email
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from sys.indexes
+      where object_id = OBJECT_ID('{env.SCHEMA}.cddl_dst')
+        and name = 'idx_cddl_dst_email' and is_unique = 1
+    into: uniq_idx
+  - type: check
+    check: int_parse(store.uniq_idx[0].cnt) == 1
+    message: 'expected unique index on email, got {store.uniq_idx[0].cnt}'
+
+  # plain index on region
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from sys.indexes
+      where object_id = OBJECT_ID('{env.SCHEMA}.cddl_dst')
+        and name = 'idx_cddl_dst_region' and is_unique = 0
+    into: plain_idx
+  - type: check
+    check: int_parse(store.plain_idx[0].cnt) == 1
+    message: 'expected non-unique index on region, got {store.plain_idx[0].cnt}'
+
+  # description / column comment (extended property)
+  - connection: '{env.TARGET}'
+    query: |
+      select cast(value as varchar(200)) comment from sys.extended_properties
+      where major_id = OBJECT_ID('{env.SCHEMA}.cddl_dst') and name = 'MS_Description'
+        and minor_id = (select column_id from sys.columns
+                        where object_id = OBJECT_ID('{env.SCHEMA}.cddl_dst') and name = 'notes')
+    into: notes_comment
+  - type: check
+    check: store.notes_comment[0].comment == "user notes"
+    message: 'expected comment "user notes" on notes, got {store.notes_comment[0].comment}'
+
+  - type: log
+    message: 'SUCCESS: sqlserver column DDL verified'

--- a/tests/pipelines/column_ddl/p.columns_ddl.05.sqlite.yaml
+++ b/tests/pipelines/column_ddl/p.columns_ddl.05.sqlite.yaml
@@ -1,0 +1,65 @@
+# Column DDL constraints test: SQLite target
+# Verifies not_null, primary_key, unique_index, index.
+# SQLite has no column-comment concept, so description is not inspected.
+env:
+  SOURCE: postgres
+  TARGET: sqlite
+  SCHEMA: main
+
+steps:
+  - connection: '{env.TARGET}'
+    query: drop table if exists cddl_dst
+
+  - type: replication
+    id: repl
+    replication:
+      source: '{env.SOURCE}'
+      target: '{env.TARGET}'
+      defaults:
+        mode: full-refresh
+      streams:
+        public.cddl_src:
+          object: '{env.SCHEMA}.cddl_dst'
+          columns:
+            id: bigint not_null primary_key
+            email: string(255) not_null unique_index
+            org_id: string(255) not_null
+            region: string(255) index
+            notes: string(255) description('user notes')
+
+  # nullability: 3 NOT NULL columns (notnull flag = 1)
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from pragma_table_info('cddl_dst')
+      where "notnull" = 1 and name in ('id','email','org_id')
+    into: notnull_cnt
+  - type: check
+    check: int_parse(store.notnull_cnt[0].cnt) == 3
+    message: 'expected 3 NOT NULL columns, got {store.notnull_cnt[0].cnt}'
+
+  # primary key on id (pk flag > 0)
+  - connection: '{env.TARGET}'
+    query: select count(*) cnt from pragma_table_info('cddl_dst') where pk > 0 and name = 'id'
+    into: pk_cnt
+  - type: check
+    check: int_parse(store.pk_cnt[0].cnt) == 1
+    message: 'expected primary key on id, got {store.pk_cnt[0].cnt}'
+
+  # unique index on email ("unique" = 1)
+  - connection: '{env.TARGET}'
+    query: select "unique" uniq from pragma_index_list('cddl_dst') where name = 'idx_cddl_dst_email'
+    into: uniq_idx
+  - type: check
+    check: int_parse(store.uniq_idx[0].uniq) == 1
+    message: 'expected unique index on email, got unique={store.uniq_idx[0].uniq}'
+
+  # plain index on region ("unique" = 0)
+  - connection: '{env.TARGET}'
+    query: select "unique" uniq from pragma_index_list('cddl_dst') where name = 'idx_cddl_dst_region'
+    into: plain_idx
+  - type: check
+    check: int_parse(store.plain_idx[0].uniq) == 0
+    message: 'expected non-unique index on region, got unique={store.plain_idx[0].uniq}'
+
+  - type: log
+    message: 'SUCCESS: sqlite column DDL verified'

--- a/tests/pipelines/column_ddl/p.columns_ddl.06.oracle.yaml
+++ b/tests/pipelines/column_ddl/p.columns_ddl.06.oracle.yaml
@@ -1,0 +1,80 @@
+# Column DDL constraints test: Oracle target
+# Verifies not_null, primary_key, unique_index, index.
+# Oracle column comments are not emitted by Sling, so description is not inspected.
+# Source columns are varchar(255) -> Oracle VARCHAR2(255) so they remain indexable
+# (TEXT -> CLOB would fail with ORA-02327).
+env:
+  SOURCE: postgres
+  TARGET: oracle
+  SCHEMA: ORACLE
+
+steps:
+  - connection: '{env.TARGET}'
+    query: |
+      begin
+        execute immediate 'drop table {env.SCHEMA}.cddl_dst';
+      exception when others then if sqlcode != -942 then raise; end if;
+      end;
+
+  - type: replication
+    id: repl
+    replication:
+      source: '{env.SOURCE}'
+      target: '{env.TARGET}'
+      defaults:
+        mode: full-refresh
+      streams:
+        public.cddl_src:
+          object: '{env.SCHEMA}.cddl_dst'
+          columns:
+            id: bigint not_null primary_key
+            email: string(255) not_null unique_index
+            org_id: string(255) not_null
+            region: string(255) index
+            notes: string(255) description('user notes')
+
+  # nullability: id/email/org_id = N (not null)
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from all_tab_columns
+      where owner = '{env.SCHEMA}' and table_name = 'CDDL_DST'
+        and nullable = 'N' and column_name in ('ID','EMAIL','ORG_ID')
+    into: notnull_cnt
+  - type: check
+    check: int_parse(store.notnull_cnt[0].cnt) == 3
+    message: 'expected 3 NOT NULL columns, got {store.notnull_cnt[0].cnt}'
+
+  # primary key
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from all_constraints
+      where owner = '{env.SCHEMA}' and table_name = 'CDDL_DST' and constraint_type = 'P'
+    into: pk_cnt
+  - type: check
+    check: int_parse(store.pk_cnt[0].cnt) == 1
+    message: 'expected 1 primary key, got {store.pk_cnt[0].cnt}'
+
+  # unique index on email
+  - connection: '{env.TARGET}'
+    query: |
+      select uniqueness from all_indexes
+      where table_owner = '{env.SCHEMA}' and table_name = 'CDDL_DST'
+        and index_name = 'idx_cddl_dst_email'
+    into: uniq_idx
+  - type: check
+    check: store.uniq_idx[0].uniqueness == "UNIQUE"
+    message: 'expected unique index on email, got {store.uniq_idx[0].uniqueness}'
+
+  # plain index on region
+  - connection: '{env.TARGET}'
+    query: |
+      select uniqueness from all_indexes
+      where table_owner = '{env.SCHEMA}' and table_name = 'CDDL_DST'
+        and index_name = 'idx_cddl_dst_region'
+    into: plain_idx
+  - type: check
+    check: store.plain_idx[0].uniqueness == "NONUNIQUE"
+    message: 'expected non-unique index on region, got {store.plain_idx[0].uniqueness}'
+
+  - type: log
+    message: 'SUCCESS: oracle column DDL verified'

--- a/tests/pipelines/column_ddl/p.columns_ddl.07.clickhouse.yaml
+++ b/tests/pipelines/column_ddl/p.columns_ddl.07.clickhouse.yaml
@@ -1,0 +1,55 @@
+# Column DDL constraints test: ClickHouse target
+# ClickHouse (MergeTree) does not have RDBMS-style PRIMARY KEY / UNIQUE / secondary
+# index semantics that map to the column DSL, and emits no column comments. The one
+# constraint it does honor is not_null, encoded as the ABSENCE of Nullable(T).
+# So this test only sets/verifies not_null (and that nullable columns stay Nullable).
+env:
+  SOURCE: postgres
+  TARGET: clickhouse
+  SCHEMA: default
+
+steps:
+  - connection: '{env.TARGET}'
+    query: drop table if exists {env.SCHEMA}.cddl_dst
+
+  - type: replication
+    id: repl
+    replication:
+      source: '{env.SOURCE}'
+      target: '{env.TARGET}'
+      defaults:
+        mode: full-refresh
+      streams:
+        public.cddl_src:
+          object: '{env.SCHEMA}.cddl_dst'
+          columns:
+            id: bigint not_null
+            email: string(255) not_null
+            org_id: string(255) not_null
+            region: string(255)
+            notes: string(255)
+
+  # not_null columns must NOT be Nullable(...)
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from system.columns
+      where database = '{env.SCHEMA}' and table = 'cddl_dst'
+        and name in ('id','email','org_id') and type not like 'Nullable(%'
+    into: notnull_cnt
+  - type: check
+    check: int_parse(store.notnull_cnt[0].cnt) == 3
+    message: 'expected 3 non-Nullable columns, got {store.notnull_cnt[0].cnt}'
+
+  # nullable columns must be Nullable(...)
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from system.columns
+      where database = '{env.SCHEMA}' and table = 'cddl_dst'
+        and name in ('region','notes') and type like 'Nullable(%'
+    into: nullable_cnt
+  - type: check
+    check: int_parse(store.nullable_cnt[0].cnt) == 2
+    message: 'expected 2 Nullable columns, got {store.nullable_cnt[0].cnt}'
+
+  - type: log
+    message: 'SUCCESS: clickhouse column DDL verified'

--- a/tests/pipelines/column_ddl/p.columns_ddl.08.snowflake.yaml
+++ b/tests/pipelines/column_ddl/p.columns_ddl.08.snowflake.yaml
@@ -1,0 +1,53 @@
+# Column DDL constraints test: Snowflake target
+# Snowflake emits not_null / primary_key / unique (inline) and column COMMENTs.
+# It has no secondary indexes (the index modifier is dropped with a warning),
+# so index presence is not inspected here.
+env:
+  SOURCE: postgres
+  TARGET: snowflake
+  SCHEMA: PUBLIC
+
+steps:
+  - connection: '{env.TARGET}'
+    query: drop table if exists {env.SCHEMA}.cddl_dst
+
+  - type: replication
+    id: repl
+    replication:
+      source: '{env.SOURCE}'
+      target: '{env.TARGET}'
+      defaults:
+        mode: full-refresh
+      streams:
+        public.cddl_src:
+          object: '{env.SCHEMA}.cddl_dst'
+          columns:
+            id: bigint not_null primary_key
+            email: string(255) not_null unique
+            org_id: string(255) not_null
+            region: string(255)
+            notes: string(255) description('user notes')
+
+  # nullability (Snowflake upper-cases identifiers)
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from information_schema.columns
+      where table_schema = '{env.SCHEMA}' and table_name = 'CDDL_DST'
+        and is_nullable = 'NO' and column_name in ('ID','EMAIL','ORG_ID')
+    into: notnull_cnt
+  - type: check
+    check: int_parse(store.notnull_cnt[0].cnt) == 3
+    message: 'expected 3 NOT NULL columns, got {store.notnull_cnt[0].cnt}'
+
+  # description / column comment on notes
+  - connection: '{env.TARGET}'
+    query: |
+      select comment from information_schema.columns
+      where table_schema = '{env.SCHEMA}' and table_name = 'CDDL_DST' and column_name = 'NOTES'
+    into: notes_comment
+  - type: check
+    check: store.notes_comment[0].comment == "user notes"
+    message: 'expected comment "user notes" on notes, got {store.notes_comment[0].comment}'
+
+  - type: log
+    message: 'SUCCESS: snowflake column DDL verified'

--- a/tests/pipelines/column_ddl/p.columns_ddl.09.duckdb.yaml
+++ b/tests/pipelines/column_ddl/p.columns_ddl.09.duckdb.yaml
@@ -1,0 +1,63 @@
+# Column DDL constraints test: DuckDB target
+# Verifies not_null, primary_key, unique_index, index and description (comment).
+env:
+  SOURCE: postgres
+  TARGET: duckdb
+  SCHEMA: main
+
+steps:
+  # no pre-drop on the target: DuckDB is single-writer per file, and holding a
+  # connection open here would block the replication step. full-refresh recreates.
+  - type: replication
+    id: repl
+    replication:
+      source: '{env.SOURCE}'
+      target: '{env.TARGET}'
+      defaults:
+        mode: full-refresh
+      streams:
+        public.cddl_src:
+          object: '{env.SCHEMA}.cddl_dst'
+          columns:
+            id: bigint not_null primary_key
+            email: string(255) not_null unique_index
+            org_id: string(255) not_null
+            region: string(255) index
+            notes: string(255) description('user notes')
+
+  # nullability
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from duckdb_columns()
+      where table_name = 'cddl_dst' and not is_nullable and column_name in ('id','email','org_id')
+    into: notnull_cnt
+  - type: check
+    check: int_parse(store.notnull_cnt[0].cnt) == 3
+    message: 'expected 3 NOT NULL columns, got {store.notnull_cnt[0].cnt}'
+
+  # unique index on email (cast bool -> int for a stable check comparison)
+  - connection: '{env.TARGET}'
+    query: select cast(is_unique as int) uniq from duckdb_indexes() where table_name = 'cddl_dst' and index_name = 'idx_cddl_dst_email'
+    into: uniq_idx
+  - type: check
+    check: int_parse(store.uniq_idx[0].uniq) == 1
+    message: 'expected unique index on email, got {store.uniq_idx[0].uniq}'
+
+  # plain index on region
+  - connection: '{env.TARGET}'
+    query: select cast(is_unique as int) uniq from duckdb_indexes() where table_name = 'cddl_dst' and index_name = 'idx_cddl_dst_region'
+    into: plain_idx
+  - type: check
+    check: int_parse(store.plain_idx[0].uniq) == 0
+    message: 'expected non-unique index on region, got {store.plain_idx[0].uniq}'
+
+  # description / column comment
+  - connection: '{env.TARGET}'
+    query: select comment from duckdb_columns() where table_name = 'cddl_dst' and column_name = 'notes'
+    into: notes_comment
+  - type: check
+    check: store.notes_comment[0].comment == "user notes"
+    message: 'expected comment "user notes" on notes, got {store.notes_comment[0].comment}'
+
+  - type: log
+    message: 'SUCCESS: duckdb column DDL verified'

--- a/tests/pipelines/column_ddl/p.columns_ddl.10.motherduck.yaml
+++ b/tests/pipelines/column_ddl/p.columns_ddl.10.motherduck.yaml
@@ -1,0 +1,63 @@
+# Column DDL constraints test: MotherDuck target
+# Verifies not_null, primary_key, unique_index, index and description (comment).
+env:
+  SOURCE: postgres
+  TARGET: motherduck
+  SCHEMA: main
+
+steps:
+  # no pre-drop on the target: DuckDB is single-writer per file, and holding a
+  # connection open here would block the replication step. full-refresh recreates.
+  - type: replication
+    id: repl
+    replication:
+      source: '{env.SOURCE}'
+      target: '{env.TARGET}'
+      defaults:
+        mode: full-refresh
+      streams:
+        public.cddl_src:
+          object: '{env.SCHEMA}.cddl_dst'
+          columns:
+            id: bigint not_null primary_key
+            email: string(255) not_null unique_index
+            org_id: string(255) not_null
+            region: string(255) index
+            notes: string(255) description('user notes')
+
+  # nullability
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from duckdb_columns()
+      where table_name = 'cddl_dst' and not is_nullable and column_name in ('id','email','org_id')
+    into: notnull_cnt
+  - type: check
+    check: int_parse(store.notnull_cnt[0].cnt) == 3
+    message: 'expected 3 NOT NULL columns, got {store.notnull_cnt[0].cnt}'
+
+  # unique index on email (cast bool -> int for a stable check comparison)
+  - connection: '{env.TARGET}'
+    query: select cast(is_unique as int) uniq from duckdb_indexes() where table_name = 'cddl_dst' and index_name = 'idx_cddl_dst_email'
+    into: uniq_idx
+  - type: check
+    check: int_parse(store.uniq_idx[0].uniq) == 1
+    message: 'expected unique index on email, got {store.uniq_idx[0].uniq}'
+
+  # plain index on region
+  - connection: '{env.TARGET}'
+    query: select cast(is_unique as int) uniq from duckdb_indexes() where table_name = 'cddl_dst' and index_name = 'idx_cddl_dst_region'
+    into: plain_idx
+  - type: check
+    check: int_parse(store.plain_idx[0].uniq) == 0
+    message: 'expected non-unique index on region, got {store.plain_idx[0].uniq}'
+
+  # description / column comment
+  - connection: '{env.TARGET}'
+    query: select comment from duckdb_columns() where table_name = 'cddl_dst' and column_name = 'notes'
+    into: notes_comment
+  - type: check
+    check: store.notes_comment[0].comment == "user notes"
+    message: 'expected comment "user notes" on notes, got {store.notes_comment[0].comment}'
+
+  - type: log
+    message: 'SUCCESS: motherduck column DDL verified'

--- a/tests/pipelines/column_ddl/p.columns_ddl.11.bigquery.yaml
+++ b/tests/pipelines/column_ddl/p.columns_ddl.11.bigquery.yaml
@@ -1,0 +1,53 @@
+# Column DDL constraints test: BigQuery target
+# BigQuery emits not_null and column descriptions (via ALTER COLUMN SET OPTIONS).
+# It has no general CREATE INDEX (only search indexes on STRING/JSON), so the
+# index modifier is not emitted and index presence is not inspected here.
+# (BigQuery primary keys are advisory / NOT ENFORCED, so PK is not asserted.)
+env:
+  SOURCE: postgres
+  TARGET: bigquery
+  SCHEMA: public
+
+steps:
+  - connection: '{env.TARGET}'
+    query: drop table if exists {env.SCHEMA}.cddl_dst
+
+  - type: replication
+    id: repl
+    replication:
+      source: '{env.SOURCE}'
+      target: '{env.TARGET}'
+      defaults:
+        mode: full-refresh
+      streams:
+        public.cddl_src:
+          object: '{env.SCHEMA}.cddl_dst'
+          columns:
+            id: bigint not_null
+            email: string(255) not_null
+            org_id: string(255) not_null
+            region: string(255)
+            notes: string(255) description('user notes')
+
+  # nullability
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from {env.SCHEMA}.INFORMATION_SCHEMA.COLUMNS
+      where table_name = 'cddl_dst' and is_nullable = 'NO' and column_name in ('id','email','org_id')
+    into: notnull_cnt
+  - type: check
+    check: int_parse(store.notnull_cnt[0].cnt) == 3
+    message: 'expected 3 NOT NULL columns, got {store.notnull_cnt[0].cnt}'
+
+  # description on notes
+  - connection: '{env.TARGET}'
+    query: |
+      select description from {env.SCHEMA}.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS
+      where table_name = 'cddl_dst' and column_name = 'notes'
+    into: notes_comment
+  - type: check
+    check: store.notes_comment[0].description == "user notes"
+    message: 'expected description "user notes" on notes, got {store.notes_comment[0].description}'
+
+  - type: log
+    message: 'SUCCESS: bigquery column DDL verified'

--- a/tests/pipelines/column_ddl/p.columns_ddl.12.starrocks.yaml
+++ b/tests/pipelines/column_ddl/p.columns_ddl.12.starrocks.yaml
@@ -1,0 +1,56 @@
+# Column DDL constraints test: StarRocks target
+# StarRocks emits not_null and inline column comments (description). Its
+# PRIMARY KEY / UNIQUE / index concepts are tied to the table distribution model
+# (primary/duplicate/hash keys, bitmap/bloomfilter indexes) and do not map to the
+# generic column DSL, so only not_null + description are exercised here.
+# Comments are emitted INLINE in the column definition (post-CREATE
+# ALTER ... MODIFY COLUMN COMMENT is an async schema-change on StarRocks).
+env:
+  SOURCE: postgres
+  TARGET: starrocks
+  SCHEMA: sling_test
+
+steps:
+  - connection: '{env.TARGET}'
+    query: drop table if exists {env.SCHEMA}.cddl_dst
+
+  - type: replication
+    id: repl
+    replication:
+      source: '{env.SOURCE}'
+      target: '{env.TARGET}'
+      defaults:
+        mode: full-refresh
+      streams:
+        public.cddl_src:
+          object: '{env.SCHEMA}.cddl_dst'
+          columns:
+            id: bigint not_null
+            email: string(255) not_null
+            org_id: string(255) not_null
+            region: string(255)
+            notes: string(255) description('user notes')
+
+  # nullability: id/email/org_id NOT NULL, region/notes nullable
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from information_schema.columns
+      where table_schema = '{env.SCHEMA}' and table_name = 'cddl_dst'
+        and is_nullable = 'NO' and column_name in ('id','email','org_id')
+    into: notnull_cnt
+  - type: check
+    check: int_parse(store.notnull_cnt[0].cnt) == 3
+    message: 'expected 3 NOT NULL columns, got {store.notnull_cnt[0].cnt}'
+
+  # description / inline column comment on notes
+  - connection: '{env.TARGET}'
+    query: |
+      select column_comment from information_schema.columns
+      where table_schema = '{env.SCHEMA}' and table_name = 'cddl_dst' and column_name = 'notes'
+    into: notes_comment
+  - type: check
+    check: store.notes_comment[0].column_comment == "user notes"
+    message: 'expected comment "user notes" on notes, got {store.notes_comment[0].column_comment}'
+
+  - type: log
+    message: 'SUCCESS: starrocks column DDL verified'

--- a/tests/pipelines/column_ddl/p.columns_ddl.13.redshift.yaml
+++ b/tests/pipelines/column_ddl/p.columns_ddl.13.redshift.yaml
@@ -1,0 +1,66 @@
+# Column DDL constraints test: Redshift target
+# Redshift emits not_null / primary_key / unique (inline) and column COMMENTs.
+# It has no secondary indexes (matrix noIndexes), so index is not inspected.
+# NOTE: not wired into the master pipeline / suite — the Redshift test connection
+# is currently unavailable. Kept here so it runs once a connection exists.
+env:
+  SOURCE: postgres
+  TARGET: redshift
+  SCHEMA: public
+
+steps:
+  - connection: '{env.TARGET}'
+    query: drop table if exists {env.SCHEMA}.cddl_dst
+
+  - type: replication
+    id: repl
+    replication:
+      source: '{env.SOURCE}'
+      target: '{env.TARGET}'
+      defaults:
+        mode: full-refresh
+      streams:
+        public.cddl_src:
+          object: '{env.SCHEMA}.cddl_dst'
+          columns:
+            id: bigint not_null primary_key
+            email: string(255) not_null unique
+            org_id: string(255) not_null
+            region: string(255)
+            notes: string(255) description('user notes')
+
+  # nullability
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from information_schema.columns
+      where table_schema = '{env.SCHEMA}' and table_name = 'cddl_dst'
+        and is_nullable = 'NO' and column_name in ('id','email','org_id')
+    into: notnull_cnt
+  - type: check
+    check: int_parse(store.notnull_cnt[0].cnt) == 3
+    message: 'expected 3 NOT NULL columns, got {store.notnull_cnt[0].cnt}'
+
+  # primary key
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from information_schema.table_constraints
+      where table_schema = '{env.SCHEMA}' and table_name = 'cddl_dst'
+        and constraint_type = 'PRIMARY KEY'
+    into: pk_cnt
+  - type: check
+    check: int_parse(store.pk_cnt[0].cnt) == 1
+    message: 'expected 1 primary key, got {store.pk_cnt[0].cnt}'
+
+  # description / column comment on notes
+  - connection: '{env.TARGET}'
+    query: |
+      select col_description(('{env.SCHEMA}.cddl_dst')::regclass,
+        (select ordinal_position from information_schema.columns
+         where table_schema='{env.SCHEMA}' and table_name='cddl_dst' and column_name='notes')::int) comment
+    into: notes_comment
+  - type: check
+    check: store.notes_comment[0].comment == "user notes"
+    message: 'expected comment "user notes" on notes, got {store.notes_comment[0].comment}'
+
+  - type: log
+    message: 'SUCCESS: redshift column DDL verified'

--- a/tests/pipelines/column_ddl/p.columns_ddl.14.databricks.yaml
+++ b/tests/pipelines/column_ddl/p.columns_ddl.14.databricks.yaml
@@ -1,0 +1,55 @@
+# Column DDL constraints test: Databricks target
+# Databricks (Delta) emits not_null and column COMMENTs (ALTER COLUMN ... COMMENT).
+# Delta has no general CREATE INDEX, so index is not inspected. Delta primary keys
+# are informational, so PK is not asserted here.
+# NOTE: not wired into the master pipeline / suite — the Databricks test
+# connection is currently unavailable. Kept here so it runs once a connection exists.
+env:
+  SOURCE: postgres
+  TARGET: databricks
+  SCHEMA: default
+
+steps:
+  - connection: '{env.TARGET}'
+    query: drop table if exists {env.SCHEMA}.cddl_dst
+
+  - type: replication
+    id: repl
+    replication:
+      source: '{env.SOURCE}'
+      target: '{env.TARGET}'
+      defaults:
+        mode: full-refresh
+      streams:
+        public.cddl_src:
+          object: '{env.SCHEMA}.cddl_dst'
+          columns:
+            id: bigint not_null
+            email: string(255) not_null
+            org_id: string(255) not_null
+            region: string(255)
+            notes: string(255) description('user notes')
+
+  # nullability
+  - connection: '{env.TARGET}'
+    query: |
+      select count(*) cnt from information_schema.columns
+      where table_schema = '{env.SCHEMA}' and table_name = 'cddl_dst'
+        and is_nullable = 'NO' and column_name in ('id','email','org_id')
+    into: notnull_cnt
+  - type: check
+    check: int_parse(store.notnull_cnt[0].cnt) == 3
+    message: 'expected 3 NOT NULL columns, got {store.notnull_cnt[0].cnt}'
+
+  # description / column comment on notes
+  - connection: '{env.TARGET}'
+    query: |
+      select comment from information_schema.columns
+      where table_schema = '{env.SCHEMA}' and table_name = 'cddl_dst' and column_name = 'notes'
+    into: notes_comment
+  - type: check
+    check: store.notes_comment[0].comment == "user notes"
+    message: 'expected comment "user notes" on notes, got {store.notes_comment[0].comment}'
+
+  - type: log
+    message: 'SUCCESS: databricks column DDL verified'

--- a/tests/pipelines/p.29.agent_service_cli.yaml
+++ b/tests/pipelines/p.29.agent_service_cli.yaml
@@ -4,7 +4,7 @@ steps:
   - id: svc_help
     command: sling agent service --help
 
-  - check: 'contains(state.svc_help.output.combined, "manage the sling agent as an OS service")'
+  - check: 'contains(state.svc_help.output.combined, "manage the sling runner as an OS service")'
     failure_message: 'service --help missing description'
 
   - check: 'contains(state.svc_help.output.combined, "install") && contains(state.svc_help.output.combined, "uninstall") && contains(state.svc_help.output.combined, "start") && contains(state.svc_help.output.combined, "stop") && contains(state.svc_help.output.combined, "restart") && contains(state.svc_help.output.combined, "status") && contains(state.svc_help.output.combined, "log")'
@@ -15,7 +15,7 @@ steps:
   - id: svc_install_help
     command: sling agent service install --help
 
-  - check: 'contains(state.svc_install_help.output.combined, "register the agent with the OS service manager")'
+  - check: 'contains(state.svc_install_help.output.combined, "register the runner with the OS service manager")'
     failure_message: 'install --help missing description'
 
   - check: 'contains(state.svc_install_help.output.combined, "--user") && contains(state.svc_install_help.output.combined, "--key") && contains(state.svc_install_help.output.combined, "-k")'
@@ -26,7 +26,7 @@ steps:
   - id: svc_log_help
     command: sling agent service log --help
 
-  - check: 'contains(state.svc_log_help.output.combined, "print the agent service log")'
+  - check: 'contains(state.svc_log_help.output.combined, "print the runner service log")'
     failure_message: 'log --help missing description'
 
   - check: 'contains(state.svc_log_help.output.combined, "--follow") && contains(state.svc_log_help.output.combined, "-f") && contains(state.svc_log_help.output.combined, "--lines") && contains(state.svc_log_help.output.combined, "-l")'

--- a/tests/pipelines/p.34.column_ddl_constraints_and_indexes.yaml
+++ b/tests/pipelines/p.34.column_ddl_constraints_and_indexes.yaml
@@ -1,0 +1,431 @@
+# Column DDL constraints & index improvements — self-contained pipeline.
+# Covers the columns: modifier DSL, the ClickHouse not_null fix, the
+# table_keys.index list form, and the reserved-but-unsupported error path.
+
+steps:
+  # 1. Column modifier DSL — not_null / primary_key / unique / description
+  - type: query
+    connection: postgres
+    query: |
+      DROP TABLE IF EXISTS public.col_ddl_src;
+      CREATE TABLE public.col_ddl_src (id bigint, email text, org_id text, notes text);
+      INSERT INTO public.col_ddl_src (id, email, org_id, notes) VALUES
+      (1, 'a@x.com', 'org1', 'hello'),
+      (2, 'b@x.com', 'org2', NULL);
+
+  - type: query
+    connection: postgres
+    query: DROP TABLE IF EXISTS public.col_ddl_dest
+
+  - type: replication
+    id: repl_constraints
+    replication:
+      source: postgres
+      target: postgres
+      defaults:
+        mode: full-refresh
+      streams:
+        public.col_ddl_src:
+          object: public.col_ddl_dest
+          columns:
+            id: bigint not_null primary_key
+            email: text not_null unique
+            org_id: text not_null
+            notes: text description('user-supplied notes')
+
+  - type: check
+    check: state.repl_constraints.status == "success"
+    failure_message: "constraints replication failed: {state.repl_constraints.error}"
+
+  - type: query
+    connection: postgres
+    query: |
+      SELECT is_nullable as is_nullable FROM information_schema.columns
+      WHERE table_name = 'col_ddl_dest' AND column_name = 'id'
+    into: id_null
+
+  - type: check
+    check: store.id_null[0].is_nullable == "NO"
+    failure_message: "expected id NOT NULL, got nullable={store.id_null[0].is_nullable}"
+
+  - type: query
+    connection: postgres
+    query: |
+      SELECT count(*) as cnt FROM information_schema.table_constraints
+      WHERE table_name = 'col_ddl_dest' AND constraint_type = 'PRIMARY KEY'
+    into: pk
+
+  - type: check
+    check: int_parse(store.pk[0].cnt) == 1
+    failure_message: "expected a PRIMARY KEY on col_ddl_dest"
+
+  - type: query
+    connection: postgres
+    query: |
+      SELECT count(*) as cnt FROM information_schema.table_constraints
+      WHERE table_name = 'col_ddl_dest' AND constraint_type = 'UNIQUE'
+    into: uniq
+
+  - type: check
+    check: int_parse(store.uniq[0].cnt) >= 1
+    failure_message: "expected a UNIQUE constraint on col_ddl_dest"
+
+  - type: query
+    connection: postgres
+    query: |
+      SELECT col_description('public.col_ddl_dest'::regclass, ordinal_position) as comment
+      FROM information_schema.columns
+      WHERE table_name = 'col_ddl_dest' AND column_name = 'notes'
+    into: comment
+
+  - type: check
+    check: store.comment[0].comment == "user-supplied notes"
+    failure_message: "expected notes description, got {store.comment[0].comment}"
+
+  # 2. ClickHouse not_null fix — explicit not_null must NOT be Nullable(T)
+  - type: query
+    connection: postgres
+    query: |
+      DROP TABLE IF EXISTS public.ch_ddl_src;
+      CREATE TABLE public.ch_ddl_src (id bigint, name text, notes text);
+      INSERT INTO public.ch_ddl_src (id, name, notes) VALUES
+      (1, 'alice', 'hello'),
+      (2, 'bob', NULL);
+
+  - type: query
+    connection: clickhouse
+    query: DROP TABLE IF EXISTS default.ch_ddl_dest
+
+  - type: replication
+    id: repl_clickhouse
+    replication:
+      source: postgres
+      target: clickhouse
+      defaults:
+        mode: full-refresh
+      streams:
+        public.ch_ddl_src:
+          object: default.ch_ddl_dest
+          primary_key: id
+          columns:
+            id: bigint not_null
+            name: string not_null
+            notes: string
+
+  - type: check
+    check: state.repl_clickhouse.status == "success"
+    failure_message: "clickhouse replication failed: {state.repl_clickhouse.error}"
+
+  - type: query
+    connection: clickhouse
+    query: |
+      SELECT type FROM system.columns
+      WHERE database = 'default' AND table = 'ch_ddl_dest' AND name = 'id'
+    into: id_type
+
+  - type: check
+    check: '!contains(store.id_type[0].type, "Nullable")'
+    failure_message: "expected id NOT Nullable, got {store.id_type[0].type}"
+
+  - type: query
+    connection: clickhouse
+    query: |
+      SELECT type FROM system.columns
+      WHERE database = 'default' AND table = 'ch_ddl_dest' AND name = 'name'
+    into: name_type
+
+  - type: check
+    check: '!contains(store.name_type[0].type, "Nullable")'
+    failure_message: "expected name NOT Nullable, got {store.name_type[0].type}"
+
+  - type: query
+    connection: clickhouse
+    query: |
+      SELECT type FROM system.columns
+      WHERE database = 'default' AND table = 'ch_ddl_dest' AND name = 'notes'
+    into: notes_type
+
+  - type: check
+    check: contains(store.notes_type[0].type, "Nullable")
+    failure_message: "expected notes Nullable, got {store.notes_type[0].type}"
+
+  # 3. Inline column index modifiers — index / unique_index
+  - type: query
+    connection: postgres
+    query: |
+      DROP TABLE IF EXISTS public.idx_ddl_src;
+      CREATE TABLE public.idx_ddl_src (id bigint, email text, region text);
+      INSERT INTO public.idx_ddl_src (id, email, region) VALUES
+      (1, 'a@x.com', 'us'),
+      (2, 'b@x.com', 'eu'),
+      (3, 'c@x.com', 'us');
+
+  - type: query
+    connection: postgres
+    query: DROP TABLE IF EXISTS public.idx_ddl_dest
+
+  - type: replication
+    id: repl_inline_index
+    replication:
+      source: postgres
+      target: postgres
+      defaults:
+        mode: full-refresh
+      streams:
+        public.idx_ddl_src:
+          object: public.idx_ddl_dest
+          columns:
+            id: bigint not_null
+            email: text unique_index
+            region: text index
+
+  - type: check
+    check: state.repl_inline_index.status == "success"
+    failure_message: "inline-index replication failed: {state.repl_inline_index.error}"
+
+  - type: query
+    connection: postgres
+    query: |
+      SELECT count(*) as cnt FROM pg_indexes
+      WHERE tablename = 'idx_ddl_dest' AND indexdef ILIKE '%region%'
+      AND indexdef NOT ILIKE '%UNIQUE%'
+    into: region_idx
+
+  - type: check
+    check: int_parse(store.region_idx[0].cnt) >= 1
+    failure_message: "expected a plain index on region"
+
+  - type: query
+    connection: postgres
+    query: |
+      SELECT count(*) as cnt FROM pg_indexes
+      WHERE tablename = 'idx_ddl_dest' AND indexdef ILIKE '%email%'
+      AND indexdef ILIKE '%UNIQUE%'
+    into: email_idx
+
+  - type: check
+    check: int_parse(store.email_idx[0].cnt) >= 1
+    failure_message: "expected a UNIQUE index on email"
+
+  # 4. table_keys.index list form — composite + expression + partial-unique
+  - type: query
+    connection: postgres
+    query: |
+      DROP TABLE IF EXISTS public.tk_idx_src;
+      CREATE TABLE public.tk_idx_src (id bigint, org_id text, name text, deleted_at timestamp);
+      INSERT INTO public.tk_idx_src (id, org_id, name, deleted_at) VALUES
+      (1, 'org1', 'Alice', NULL),
+      (2, 'org1', 'Bob', NULL),
+      (3, 'org2', 'Carol', now());
+
+  - type: query
+    connection: postgres
+    query: DROP TABLE IF EXISTS public.tk_idx_dest
+
+  - type: replication
+    id: repl_table_keys
+    replication:
+      source: postgres
+      target: postgres
+      defaults:
+        mode: full-refresh
+      streams:
+        public.tk_idx_src:
+          object: public.tk_idx_dest
+          target_options:
+            table_keys:
+              index:
+                - idx_org_name: [org_id, name]
+                - idx_lower_name:
+                    expression: LOWER(name)
+                - idx_active:
+                    columns: [id]
+                    unique: true
+                    where: deleted_at IS NULL
+
+  - type: check
+    check: state.repl_table_keys.status == "success"
+    failure_message: "table_keys replication failed: {state.repl_table_keys.error}"
+
+  - type: query
+    connection: postgres
+    query: |
+      SELECT count(*) as cnt FROM pg_indexes
+      WHERE tablename = 'tk_idx_dest' AND indexname = 'idx_org_name'
+    into: comp_idx
+
+  - type: check
+    check: int_parse(store.comp_idx[0].cnt) == 1
+    failure_message: "expected composite index idx_org_name"
+
+  - type: query
+    connection: postgres
+    query: |
+      SELECT count(*) as cnt FROM pg_indexes
+      WHERE tablename = 'tk_idx_dest' AND indexname = 'idx_lower_name'
+      AND indexdef ILIKE '%lower%'
+    into: expr_idx
+
+  - type: check
+    check: int_parse(store.expr_idx[0].cnt) == 1
+    failure_message: "expected expression index idx_lower_name on LOWER(name)"
+
+  - type: query
+    connection: postgres
+    query: |
+      SELECT count(*) as cnt FROM pg_indexes
+      WHERE tablename = 'tk_idx_dest' AND indexname = 'idx_active'
+      AND indexdef ILIKE '%UNIQUE%' AND indexdef ILIKE '%deleted_at%'
+    into: partial_idx
+
+  - type: check
+    check: int_parse(store.partial_idx[0].cnt) == 1
+    failure_message: "expected partial unique index idx_active"
+
+  # 4b. table_keys.index anonymous shapes — single column, composite list, and
+  # a composite mixing a plain column with a raw SQL expression (LOWER(col2)).
+  - type: query
+    connection: postgres
+    query: |
+      DROP TABLE IF EXISTS public.anon_idx_src;
+      CREATE TABLE public.anon_idx_src (search_col text, col1 text, col2 text);
+      INSERT INTO public.anon_idx_src (search_col, col1, col2) VALUES
+      ('a', 'x', 'Foo'),
+      ('b', 'y', 'BAR'),
+      ('c', 'z', 'baz');
+
+  - type: query
+    connection: postgres
+    query: DROP TABLE IF EXISTS public.anon_idx_dest
+
+  - type: replication
+    id: repl_anon_index
+    replication:
+      source: postgres
+      target: postgres
+      defaults:
+        mode: full-refresh
+      streams:
+        public.anon_idx_src:
+          object: public.anon_idx_dest
+          target_options:
+            table_keys:
+              index:
+                - search_col
+                - [col1, col2]
+                - [col1, "LOWER(col2)"]
+
+  - type: check
+    check: state.repl_anon_index.status == "success"
+    failure_message: "anonymous-index replication failed: {state.repl_anon_index.error}"
+
+  # exactly 3 indexes were created on the fresh table
+  - type: query
+    connection: postgres
+    query: |
+      SELECT count(*) as cnt FROM pg_indexes WHERE tablename = 'anon_idx_dest'
+    into: anon_cnt
+
+  - type: check
+    check: int_parse(store.anon_cnt[0].cnt) == 3
+    failure_message: "expected 3 anonymous indexes on anon_idx_dest, got {store.anon_cnt[0].cnt}"
+
+  # 1. single-column index on search_col
+  - type: query
+    connection: postgres
+    query: |
+      SELECT count(*) as cnt FROM pg_indexes
+      WHERE tablename = 'anon_idx_dest' AND indexdef ILIKE '%(search_col)%'
+    into: anon_single
+
+  - type: check
+    check: int_parse(store.anon_single[0].cnt) == 1
+    failure_message: "expected single-column index on search_col"
+
+  # 2. plain composite index on (col1, col2)
+  - type: query
+    connection: postgres
+    query: |
+      SELECT count(*) as cnt FROM pg_indexes
+      WHERE tablename = 'anon_idx_dest'
+      AND indexdef ILIKE '%(col1, col2)%'
+    into: anon_comp
+
+  - type: check
+    check: int_parse(store.anon_comp[0].cnt) == 1
+    failure_message: "expected composite index on (col1, col2)"
+
+  # 3. composite index mixing a column with a LOWER(col2) expression
+  - type: query
+    connection: postgres
+    query: |
+      SELECT count(*) as cnt FROM pg_indexes
+      WHERE tablename = 'anon_idx_dest'
+      AND indexdef ILIKE '%col1%' AND indexdef ILIKE '%lower(col2)%'
+    into: anon_expr
+
+  - type: check
+    check: int_parse(store.anon_expr[0].cnt) == 1
+    failure_message: "expected composite index mixing col1 and LOWER(col2)"
+
+  # 5. Reserved-but-unsupported modifier — auto_increment must fail fast at
+  # config prep with a clear "not yet supported" error. on_failure: warn lets
+  # the pipeline continue so the failure (status + message) can be asserted.
+  - type: query
+    connection: postgres
+    query: |
+      DROP TABLE IF EXISTS public.col_unsupp_src;
+      CREATE TABLE public.col_unsupp_src (id bigint, name text);
+      INSERT INTO public.col_unsupp_src (id, name) VALUES (1, 'a');
+
+  - type: query
+    connection: postgres
+    query: DROP TABLE IF EXISTS public.col_unsupp_dest
+
+  - type: replication
+    id: repl_unsupported
+    on_failure: warn
+    replication:
+      source: postgres
+      target: postgres
+      defaults:
+        mode: full-refresh
+      streams:
+        public.col_unsupp_src:
+          object: public.col_unsupp_dest
+          columns:
+            id: bigint not_null auto_increment
+            name: text
+
+  - type: check
+    check: state.repl_unsupported.status != "success"
+    failure_message: "expected unsupported modifier to fail, got status={state.repl_unsupported.status}"
+
+  - type: check
+    check: contains(state.repl_unsupported.error, "not yet supported")
+    failure_message: "expected 'not yet supported' error, got {state.repl_unsupported.error}"
+
+  # 6. Cleanup
+  - type: log
+    message: "SUCCESS: column DDL constraints & indexes pipeline passed"
+
+  - type: query
+    connection: postgres
+    query: |
+      DROP TABLE IF EXISTS public.col_ddl_src;
+      DROP TABLE IF EXISTS public.col_ddl_dest;
+      DROP TABLE IF EXISTS public.ch_ddl_src;
+      DROP TABLE IF EXISTS public.idx_ddl_src;
+      DROP TABLE IF EXISTS public.idx_ddl_dest;
+      DROP TABLE IF EXISTS public.tk_idx_src;
+      DROP TABLE IF EXISTS public.tk_idx_dest;
+      DROP TABLE IF EXISTS public.anon_idx_src;
+      DROP TABLE IF EXISTS public.anon_idx_dest;
+      DROP TABLE IF EXISTS public.col_unsupp_src;
+      DROP TABLE IF EXISTS public.col_unsupp_dest;
+    on_failure: warn
+
+  - type: query
+    connection: clickhouse
+    query: DROP TABLE IF EXISTS default.ch_ddl_dest
+    on_failure: warn

--- a/tests/pipelines/p.35.on_failure_warn_status.yaml
+++ b/tests/pipelines/p.35.on_failure_warn_status.yaml
@@ -1,0 +1,70 @@
+# Verifies that on_failure: warn sets the step status to "warning" (not success),
+# and that the warning propagates up through groups and nested groups so it can
+# bubble up to the overall execution and be reported to the platform as warning.
+steps:
+  # 1. a direct step that fails with on_failure: warn => status becomes "warning"
+  - type: check
+    id: direct_warn
+    check: 1 == 2
+    on_failure: warn
+
+  - type: check
+    check: state.direct_warn.status == "warning"
+    message: 'expected direct_warn status "warning", got "{state.direct_warn.status}"'
+
+  # 2. a group containing a warned sub-step => the group becomes "warning"
+  - type: group
+    id: warn_group
+    steps:
+      - type: log
+        message: "group substep 1 ok"
+      - type: check
+        id: group_inner_warn
+        check: 1 == 2
+        on_failure: warn
+      - type: log
+        message: "group substep 3 still ran"
+
+  - type: check
+    check: state.group_inner_warn.status == "warning"
+    message: 'expected group_inner_warn "warning", got "{state.group_inner_warn.status}"'
+
+  - type: check
+    check: state.warn_group.status == "warning"
+    message: 'expected warn_group "warning", got "{state.warn_group.status}"'
+
+  # 3. nested groups => warning propagates from the deepest step to every parent
+  - type: group
+    id: outer_group
+    steps:
+      - type: log
+        message: "outer ok"
+      - type: group
+        id: inner_group
+        steps:
+          - type: check
+            id: deep_warn
+            check: 1 == 2
+            on_failure: warn
+
+  - type: check
+    check: state.inner_group.status == "warning"
+    message: 'expected inner_group "warning", got "{state.inner_group.status}"'
+
+  - type: check
+    check: state.outer_group.status == "warning"
+    message: 'expected outer_group "warning", got "{state.outer_group.status}"'
+
+  # 4. a group whose sub-steps all succeed stays "success" (no false warnings)
+  - type: group
+    id: clean_group
+    steps:
+      - type: log
+        message: "clean substep"
+
+  - type: check
+    check: state.clean_group.status == "success"
+    message: 'expected clean_group "success", got "{state.clean_group.status}"'
+
+  - type: log
+    message: "all on_failure:warn status checks passed"

--- a/tests/pipelines/p.36.group_concurrency.yaml
+++ b/tests/pipelines/p.36.group_concurrency.yaml
@@ -1,0 +1,60 @@
+# Verifies group `concurrency`: a group looping over N values with concurrency C
+# runs iterations in parallel. Each iteration sleeps, so the wall-clock time
+# proves parallelism (parallel ~= sleep duration, sequential ~= N * sleep).
+# Also verifies {loop.value} still resolves correctly under concurrency.
+steps:
+  # ---- concurrent group: 4 iterations x ~2s sleep, concurrency 4 ----
+  - type: store
+    key: t_start_concurrent
+    value: "{now()}"
+
+  - type: group
+    id: concurrent_group
+    concurrency: 4
+    loop: [1, 2, 3, 4]
+    steps:
+      - type: command
+        command: [sleep, "2"]
+      - type: log
+        message: "concurrent iteration value={loop.value} index={loop.index}"
+
+  - type: store
+    key: t_end_concurrent
+    value: "{now()}"
+
+  # with concurrency 4, total wall-clock should be ~2s (one sleep), well under
+  # the ~8s a sequential run would take. Assert < 6s to allow generous margin.
+  - type: check
+    check: date_diff(store.t_end_concurrent, store.t_start_concurrent, "s") < 6
+    message: 'concurrent group took too long ({date_diff(store.t_end_concurrent, store.t_start_concurrent, "s")}s), parallelism not working'
+
+  - type: check
+    check: state.concurrent_group.status == "success"
+    message: 'expected concurrent_group "success", got "{state.concurrent_group.status}"'
+
+  # ---- sequential group (concurrency 1): same loop, sleeps ~1s x 3 ----
+  - type: store
+    key: t_start_sequential
+    value: "{now()}"
+
+  - type: group
+    id: sequential_group
+    concurrency: 1
+    loop: [1, 2, 3]
+    steps:
+      - type: command
+        command: [sleep, "1"]
+      - type: log
+        message: "sequential iteration value={loop.value}"
+
+  - type: store
+    key: t_end_sequential
+    value: "{now()}"
+
+  # sequential 3 x ~1s => should take at least ~3s (proves it did NOT parallelize)
+  - type: check
+    check: date_diff(store.t_end_sequential, store.t_start_sequential, "s") >= 3
+    message: 'sequential group finished too fast ({date_diff(store.t_end_sequential, store.t_start_sequential, "s")}s), should run serially'
+
+  - type: log
+    message: "group concurrency checks passed"

--- a/tests/replications/r.100.merge_strategy.yaml
+++ b/tests/replications/r.100.merge_strategy.yaml
@@ -32,6 +32,18 @@ hooks:
         CREATE TABLE public.test_merge_strategy_upd (id int PRIMARY KEY, val text);
         INSERT INTO public.test_merge_strategy_upd VALUES (1, 'initial_a'), (2, 'initial_b');
 
+        -- Source for skip-existing insert test (issue #755): the TARGET below is
+        -- pre-populated with overlapping ids so a second incremental insert must
+        -- skip rows that already exist instead of erroring on duplicate key.
+        DROP TABLE IF EXISTS public.test_merge_strategy_ins_skip_src;
+        CREATE TABLE public.test_merge_strategy_ins_skip_src (id int PRIMARY KEY, val text);
+        INSERT INTO public.test_merge_strategy_ins_skip_src VALUES (1, 'src_a'), (2, 'src_b'), (3, 'src_c');
+
+        -- Target pre-populated with ids 1,2 (so 1,2 must be skipped, 3 inserted)
+        DROP TABLE IF EXISTS public.test_merge_strategy_ins_skip;
+        CREATE TABLE public.test_merge_strategy_ins_skip (id int PRIMARY KEY, val text);
+        INSERT INTO public.test_merge_strategy_ins_skip VALUES (1, 'existing_a'), (2, 'existing_b');
+
   end:
     # if errored, do not proceed
     - type: check
@@ -134,6 +146,45 @@ hooks:
       check: int_parse(store.result_upd_new[0].cnt) == 0
       message: "update should NOT insert new row id=3"
 
+    # Verify insert strategy skip-existing (issue #755): incremental + primary_key
+    # into a target that already has ids 1,2. Must NOT error on duplicate key,
+    # must keep existing rows (first-wins) and only insert the new id=3.
+    - type: query
+      connection: '{target.name}'
+      query: SELECT count(*) as cnt FROM public.test_merge_strategy_ins_skip
+      into: count_ins_skip
+
+    - type: query
+      connection: '{target.name}'
+      query: SELECT val FROM public.test_merge_strategy_ins_skip WHERE id = 1
+      into: result_ins_skip
+
+    - type: query
+      connection: '{target.name}'
+      query: SELECT val FROM public.test_merge_strategy_ins_skip WHERE id = 3
+      into: result_ins_skip_new
+
+    - type: log
+      message: |
+        insert skip-existing count => {store.count_ins_skip}
+        insert skip-existing row 1 => {store.result_ins_skip}
+        insert skip-existing row 3 => {store.result_ins_skip_new}
+
+    - type: check
+      check: int_parse(store.count_ins_skip[0].cnt) == 3
+      message: "insert skip-existing should have 3 rows (1,2 kept + 3 inserted)"
+
+    - type: check
+      check: store.result_ins_skip[0].val == "existing_a"
+      message: "insert skip-existing must keep existing row id=1 (first-wins, not overwritten)"
+
+    - type: check
+      check: store.result_ins_skip_new[0].val == "src_c"
+      message: "insert skip-existing must insert new row id=3"
+
+    - type: log
+      message: "SUCCESS: merge_strategy insert skips existing rows (issue #755)"
+
     # Cleanup
     - type: query
       connection: '{source.name}'
@@ -142,6 +193,8 @@ hooks:
         DROP TABLE IF EXISTS public.test_merge_strategy_di;
         DROP TABLE IF EXISTS public.test_merge_strategy_ins;
         DROP TABLE IF EXISTS public.test_merge_strategy_upd;
+        DROP TABLE IF EXISTS public.test_merge_strategy_ins_skip;
+        DROP TABLE IF EXISTS public.test_merge_strategy_ins_skip_src;
 
 streams:
   # Test update_insert strategy
@@ -185,3 +238,10 @@ streams:
     object: public.test_merge_strategy_upd
     target_options:
       merge_strategy: update
+
+  # Test insert strategy skip-existing (issue #755): incremental + primary_key,
+  # target already has ids 1,2 -> must skip them and insert only id=3 (no dup-key error)
+  test_merge_strategy_ins_skip_src:
+    object: public.test_merge_strategy_ins_skip
+    target_options:
+      merge_strategy: insert

--- a/tests/replications/r.111.mysql_binary_blob_fidelity.yaml
+++ b/tests/replications/r.111.mysql_binary_blob_fidelity.yaml
@@ -1,0 +1,114 @@
+# Test MySQL binary/blob fidelity (mediumblob -> mediumblob)
+# Bug: mysql blob types mapped to generic `text`, so binary PDFs were stored as
+# mediumtext and invalid UTF-8 bytes got replaced with the U+FFFD replacement
+# char, corrupting the data. Fix: map blob types to `binary`, hex-encode binary
+# in the LOAD DATA CSV and decode via UNHEX on load.
+
+source: mysql
+target: mysql
+
+defaults:
+  mode: full-refresh
+
+hooks:
+  start:
+    - type: query
+      connection: '{source.name}'
+      query: |
+        DROP TABLE IF EXISTS mysql.binary_blob_src;
+        CREATE TABLE mysql.binary_blob_src (
+          id int PRIMARY KEY,
+          cert_blob mediumblob
+        );
+
+    - type: query
+      connection: '{source.name}'
+      query: |
+        INSERT INTO mysql.binary_blob_src (id, cert_blob) VALUES
+        (1, UNHEX('25504446312D312E340AE2E3CFD30A312030206F626A0A00FF00FE0A2554697465')),
+        (2, REPEAT(RANDOM_BYTES(64), 4096)),
+        (3, UNHEX('000102030405060708090A0B0C0D0E0FFEFFFDFC2C220A0D5C4E')),
+        (4, NULL);
+
+    - type: query
+      connection: '{target.name}'
+      query: DROP TABLE IF EXISTS mysql.binary_blob_dest
+
+  end:
+    - type: check
+      check: execution.status.error == 0
+      on_failure: break
+
+    # destination column type must be a blob, not text
+    - type: query
+      connection: '{target.name}'
+      query: |
+        SELECT DATA_TYPE as data_type FROM information_schema.columns
+        WHERE table_schema = 'mysql' AND table_name = 'binary_blob_dest'
+          AND column_name = 'cert_blob'
+      into: coltype
+
+    - type: log
+      message: "dest cert_blob data_type: {store.coltype[0].data_type}"
+
+    - type: check
+      check: store.coltype[0].data_type == "longblob"
+      failure_message: "expected longblob, got {store.coltype[0].data_type} (binary mapped to text?)"
+
+    # byte-for-byte fidelity per row (MD5 + length)
+    - type: query
+      connection: '{source.name}'
+      query: |
+        SELECT id, MD5(cert_blob) as m, LENGTH(cert_blob) as l
+        FROM mysql.binary_blob_src ORDER BY id
+      into: src
+
+    - type: query
+      connection: '{target.name}'
+      query: |
+        SELECT id, MD5(cert_blob) as m, LENGTH(cert_blob) as l
+        FROM mysql.binary_blob_dest ORDER BY id
+      into: dst
+
+    - type: log
+      message: |
+        row1 md5_match={store.src[0].m == store.dst[0].m} len {store.src[0].l}/{store.dst[0].l}
+        row2 md5_match={store.src[1].m == store.dst[1].m} len {store.src[1].l}/{store.dst[1].l}
+        row3 md5_match={store.src[2].m == store.dst[2].m} len {store.src[2].l}/{store.dst[2].l}
+
+    - type: check
+      check: store.src[0].m == store.dst[0].m
+      failure_message: "row 1 (PDF) blob corrupted"
+
+    - type: check
+      check: store.src[1].m == store.dst[1].m
+      failure_message: "row 2 (256KB) blob corrupted"
+
+    - type: check
+      check: store.src[2].m == store.dst[2].m
+      failure_message: "row 3 (full byte range) blob corrupted"
+
+    # NULL must remain NULL
+    - type: query
+      connection: '{target.name}'
+      query: SELECT COUNT(*) as cnt FROM mysql.binary_blob_dest WHERE cert_blob IS NULL
+      into: null_count
+
+    - type: check
+      check: int_parse(store.null_count[0].cnt) == 1
+      failure_message: "NULL blob not preserved (got {store.null_count[0].cnt} nulls)"
+
+    - type: log
+      message: "SUCCESS: MySQL binary blob fidelity test passed"
+
+    - type: query
+      connection: '{source.name}'
+      query: DROP TABLE IF EXISTS mysql.binary_blob_src
+
+    - type: query
+      connection: '{target.name}'
+      query: DROP TABLE IF EXISTS mysql.binary_blob_dest
+
+streams:
+  mysql.binary_blob_src:
+    object: mysql.binary_blob_dest

--- a/tests/replications/r.112.sqlserver_binary_fidelity.yaml
+++ b/tests/replications/r.112.sqlserver_binary_fidelity.yaml
@@ -1,0 +1,149 @@
+# Test SQL Server binary fidelity (varbinary(max) -> varbinary(max))
+# Bug: binary values were serialized as text (BCP CSV / nvarchar bind), corrupting
+# or truncating the data. Fix: hex-encode binary so bcp -w decodes into varbinary,
+# and coerce binary to []byte for the cursor path (processSQLServerInsertRow).
+# Two streams cover both write paths: bcp (use_bulk default) and cursor (use_bulk false).
+
+source: MSSQL
+target: MSSQL
+
+defaults:
+  mode: full-refresh
+
+hooks:
+  start:
+    - type: query
+      connection: '{source.name}'
+      query: |
+        IF OBJECT_ID('dbo.binary_src','U') IS NOT NULL DROP TABLE dbo.binary_src;
+        CREATE TABLE dbo.binary_src (id int PRIMARY KEY, cert_blob varbinary(max));
+
+    - type: query
+      connection: '{source.name}'
+      query: |
+        INSERT INTO dbo.binary_src (id, cert_blob) VALUES
+        (1, 0x25504446312D312E340AE2E3CFD30A312030206F626A0A00FF00FE0A2554697465),
+        (2, 0x000102030405060708090A0B0C0D0E0FFEFFFDFC2C220A0D5C4E),
+        (3, NULL);
+
+    - type: query
+      connection: '{target.name}'
+      query: |
+        IF OBJECT_ID('dbo.binary_dest','U') IS NOT NULL DROP TABLE dbo.binary_dest;
+        IF OBJECT_ID('dbo.binary_dest_cursor','U') IS NOT NULL DROP TABLE dbo.binary_dest_cursor;
+
+  end:
+    - type: check
+      check: execution.status.error == 0
+      on_failure: break
+
+    - type: query
+      connection: '{source.name}'
+      query: |
+        SELECT id, lower(convert(varchar(max), cert_blob, 2)) as h
+        FROM dbo.binary_src WHERE cert_blob IS NOT NULL ORDER BY id
+      into: src
+
+    # --- bcp path: dbo.binary_dest ---
+    - type: query
+      connection: '{target.name}'
+      query: |
+        SELECT data_type as data_type FROM information_schema.columns
+        WHERE table_name = 'binary_dest' AND column_name = 'cert_blob'
+      into: bcp_coltype
+
+    - type: query
+      connection: '{target.name}'
+      query: |
+        SELECT id, lower(convert(varchar(max), cert_blob, 2)) as h
+        FROM dbo.binary_dest WHERE cert_blob IS NOT NULL ORDER BY id
+      into: bcp_dst
+
+    - type: query
+      connection: '{target.name}'
+      query: SELECT COUNT(*) as cnt FROM dbo.binary_dest WHERE cert_blob IS NULL
+      into: bcp_null
+
+    # --- cursor path: dbo.binary_dest_cursor ---
+    - type: query
+      connection: '{target.name}'
+      query: |
+        SELECT data_type as data_type FROM information_schema.columns
+        WHERE table_name = 'binary_dest_cursor' AND column_name = 'cert_blob'
+      into: cur_coltype
+
+    - type: query
+      connection: '{target.name}'
+      query: |
+        SELECT id, lower(convert(varchar(max), cert_blob, 2)) as h
+        FROM dbo.binary_dest_cursor WHERE cert_blob IS NOT NULL ORDER BY id
+      into: cur_dst
+
+    - type: query
+      connection: '{target.name}'
+      query: SELECT COUNT(*) as cnt FROM dbo.binary_dest_cursor WHERE cert_blob IS NULL
+      into: cur_null
+
+    - type: log
+      message: |
+        bcp    data_type={store.bcp_coltype[0].data_type} row1={store.src[0].h == store.bcp_dst[0].h} row2={store.src[1].h == store.bcp_dst[1].h} nulls={store.bcp_null[0].cnt}
+        cursor data_type={store.cur_coltype[0].data_type} row1={store.src[0].h == store.cur_dst[0].h} row2={store.src[1].h == store.cur_dst[1].h} nulls={store.cur_null[0].cnt}
+
+    # bcp path checks
+    - type: check
+      check: store.bcp_coltype[0].data_type == "varbinary"
+      failure_message: "[bcp] expected varbinary, got {store.bcp_coltype[0].data_type}"
+
+    - type: check
+      check: store.src[0].h == store.bcp_dst[0].h
+      failure_message: "[bcp] row 1 (PDF) binary corrupted"
+
+    - type: check
+      check: store.src[1].h == store.bcp_dst[1].h
+      failure_message: "[bcp] row 2 (full byte range) binary corrupted"
+
+    - type: check
+      check: int_parse(store.bcp_null[0].cnt) == 1
+      failure_message: "[bcp] NULL binary not preserved (got {store.bcp_null[0].cnt} nulls)"
+
+    # cursor path checks
+    - type: check
+      check: store.cur_coltype[0].data_type == "varbinary"
+      failure_message: "[cursor] expected varbinary, got {store.cur_coltype[0].data_type}"
+
+    - type: check
+      check: store.src[0].h == store.cur_dst[0].h
+      failure_message: "[cursor] row 1 (PDF) binary corrupted"
+
+    - type: check
+      check: store.src[1].h == store.cur_dst[1].h
+      failure_message: "[cursor] row 2 (full byte range) binary corrupted"
+
+    - type: check
+      check: int_parse(store.cur_null[0].cnt) == 1
+      failure_message: "[cursor] NULL binary not preserved (got {store.cur_null[0].cnt} nulls)"
+
+    - type: log
+      message: "SUCCESS: SQL Server binary fidelity test passed (bcp + cursor)"
+
+    - type: query
+      connection: '{source.name}'
+      query: "IF OBJECT_ID('dbo.binary_src','U') IS NOT NULL DROP TABLE dbo.binary_src"
+
+    - type: query
+      connection: '{target.name}'
+      query: |
+        IF OBJECT_ID('dbo.binary_dest','U') IS NOT NULL DROP TABLE dbo.binary_dest;
+        IF OBJECT_ID('dbo.binary_dest_cursor','U') IS NOT NULL DROP TABLE dbo.binary_dest_cursor;
+
+streams:
+  # bcp path (use_bulk default true -> fast bcp -w hex load)
+  dbo.binary_src:
+    object: dbo.binary_dest
+
+  # cursor path (use_bulk false -> InsertBatchStream / processSQLServerInsertRow)
+  binary_src_cursor:
+    sql: select * from dbo.binary_src
+    object: dbo.binary_dest_cursor
+    target_options:
+      use_bulk: false

--- a/tests/replications/r.113.postgres_binary_fidelity.yaml
+++ b/tests/replications/r.113.postgres_binary_fidelity.yaml
@@ -1,0 +1,105 @@
+# Test Postgres binary fidelity (bytea -> bytea)
+# Ensures binary values (PDF bytes, full byte range, large payloads, NULL) survive
+# replication byte-for-byte and the destination column stays bytea.
+
+source: POSTGRES
+target: POSTGRES
+
+defaults:
+  mode: full-refresh
+
+hooks:
+  start:
+    - type: query
+      connection: '{source.name}'
+      query: |
+        DROP TABLE IF EXISTS public.binary_src;
+        CREATE TABLE public.binary_src (id int PRIMARY KEY, cert_blob bytea);
+
+    - type: query
+      connection: '{source.name}'
+      query: |
+        INSERT INTO public.binary_src (id, cert_blob) VALUES
+        (1, decode('25504446312D312E340AE2E3CFD30A312030206F626A0A00FF00FE0A2554697465','hex')),
+        (2, decode('000102030405060708090A0B0C0D0E0FFEFFFDFC2C220A0D5C4E','hex')),
+        (3, decode(repeat('DEADBEEF', 32768), 'hex')),
+        (4, NULL);
+
+    - type: query
+      connection: '{target.name}'
+      query: DROP TABLE IF EXISTS public.binary_dest
+
+  end:
+    - type: check
+      check: execution.status.error == 0
+      on_failure: break
+
+    - type: query
+      connection: '{target.name}'
+      query: |
+        SELECT data_type as data_type FROM information_schema.columns
+        WHERE table_name = 'binary_dest' AND column_name = 'cert_blob'
+      into: coltype
+
+    - type: log
+      message: "dest cert_blob data_type: {store.coltype[0].data_type}"
+
+    - type: check
+      check: store.coltype[0].data_type == "bytea"
+      failure_message: "expected bytea, got {store.coltype[0].data_type}"
+
+    - type: query
+      connection: '{source.name}'
+      query: |
+        SELECT id, md5(cert_blob) as m, length(cert_blob) as l
+        FROM public.binary_src WHERE cert_blob IS NOT NULL ORDER BY id
+      into: src
+
+    - type: query
+      connection: '{target.name}'
+      query: |
+        SELECT id, md5(cert_blob) as m, length(cert_blob) as l
+        FROM public.binary_dest WHERE cert_blob IS NOT NULL ORDER BY id
+      into: dst
+
+    - type: log
+      message: |
+        row1 md5_match={store.src[0].m == store.dst[0].m} len {store.src[0].l}/{store.dst[0].l}
+        row2 md5_match={store.src[1].m == store.dst[1].m} len {store.src[1].l}/{store.dst[1].l}
+        row3 md5_match={store.src[2].m == store.dst[2].m} len {store.src[2].l}/{store.dst[2].l}
+
+    - type: check
+      check: store.src[0].m == store.dst[0].m
+      failure_message: "row 1 (PDF) bytea corrupted"
+
+    - type: check
+      check: store.src[1].m == store.dst[1].m
+      failure_message: "row 2 (full byte range) bytea corrupted"
+
+    - type: check
+      check: store.src[2].m == store.dst[2].m
+      failure_message: "row 3 (128KB) bytea corrupted"
+
+    - type: query
+      connection: '{target.name}'
+      query: SELECT COUNT(*) as cnt FROM public.binary_dest WHERE cert_blob IS NULL
+      into: null_count
+
+    - type: check
+      check: int_parse(store.null_count[0].cnt) == 1
+      failure_message: "NULL bytea not preserved (got {store.null_count[0].cnt} nulls)"
+
+    - type: log
+      message: "SUCCESS: Postgres binary fidelity test passed"
+
+    - type: query
+      connection: '{source.name}'
+      query: DROP TABLE IF EXISTS public.binary_src
+
+    - type: query
+      connection: '{target.name}'
+      query: DROP TABLE IF EXISTS public.binary_dest
+
+streams:
+  public.binary_src:
+    object: public.binary_dest

--- a/tests/replications/r.114.oracle_no_schema_columns.yaml
+++ b/tests/replications/r.114.oracle_no_schema_columns.yaml
@@ -1,0 +1,87 @@
+source: '{my_source}'
+target: '{my_target}'
+
+defaults:
+  mode: full-refresh
+
+hooks:
+  start:
+    - type: query
+      connection: '{source.name}'
+      query: |
+        BEGIN
+          EXECUTE IMMEDIATE 'DROP TABLE {env.schema}.CUSTOMERS_NOSCHEMA PURGE';
+        EXCEPTION
+          WHEN OTHERS THEN
+            IF SQLCODE != -942 THEN
+              RAISE;
+            END IF;
+        END;
+
+    - type: query
+      connection: '{source.name}'
+      query: |
+        CREATE TABLE {env.schema}.CUSTOMERS_NOSCHEMA (
+          id NUMBER,
+          name VARCHAR2(50)
+        )
+
+    - type: query
+      connection: '{source.name}'
+      query: |
+        INSERT INTO {env.schema}.CUSTOMERS_NOSCHEMA (id, name) VALUES (1, 'Alice');
+        INSERT INTO {env.schema}.CUSTOMERS_NOSCHEMA (id, name) VALUES (2, 'Bob');
+        INSERT INTO {env.schema}.CUSTOMERS_NOSCHEMA (id, name) VALUES (3, 'Carol');
+
+    - type: query
+      connection: '{target.name}'
+      query: drop table if exists public.customers_noschema
+
+  end:
+    - type: query
+      connection: '{target.name}'
+      query: select * from public.customers_noschema order by id
+      into: result
+
+    - type: log
+      message: |
+        store.result => { pretty_table(store.result) }
+
+    # ensure all rows replicated with the bare (no-schema) stream name
+    - type: check
+      check: length(store.result) == 3
+
+    - type: check
+      check: store.result[0].name == "Alice"
+
+    - type: check
+      check: store.result[2].name == "Carol"
+
+    - type: query
+      connection: '{source.name}'
+      query: |
+        BEGIN
+          EXECUTE IMMEDIATE 'DROP TABLE {env.schema}.CUSTOMERS_NOSCHEMA PURGE';
+        EXCEPTION
+          WHEN OTHERS THEN
+            IF SQLCODE != -942 THEN
+              RAISE;
+            END IF;
+        END;
+
+    - type: query
+      connection: '{target.name}'
+      query: drop table if exists public.customers_noschema
+
+# bare table name (no schema qualifier) — exercises the schema-injection path.
+# Sling must inject & case-normalize the connection's default schema so Oracle's
+# owner-qualified metadata lookup resolves the columns.
+# https://github.com/slingdata-io/sling-cli/issues/749
+streams:
+  CUSTOMERS_NOSCHEMA:
+    object: public.customers_noschema
+
+env:
+  schema: ${SCHEMA}
+  my_source: ${SOURCE}
+  my_target: ${TARGET}

--- a/tests/replications/r.115.iceberg_time_uuid.yaml
+++ b/tests/replications/r.115.iceberg_time_uuid.yaml
@@ -1,0 +1,34 @@
+# Regression test for https://github.com/slingdata-io/sling-cli/issues/751
+source: postgres
+target: iceberg_s3
+
+defaults:
+  mode: full-refresh
+
+streams:
+  repro_751_time_uuid:
+    sql: |
+      select
+        1                       as id,
+        '08:30:00'::time        as t,
+        gen_random_uuid()       as u
+    object: public.repro_751_time_uuid
+
+hooks:
+  end:
+    - type: check
+      check: execution.status.error == 0
+      on_failure: break
+
+    # read back from iceberg and verify the time value round-tripped (not 00:00:00)
+    - type: query
+      connection: iceberg_s3
+      query: select t::text as t from iceberg_catalog.public.repro_751_time_uuid
+      into: result
+
+    - type: log
+      message: 'result => { store.result[0] }'
+
+    - type: check
+      check: store.result[0].t == "08:30:00"
+      failure_message: 'expected time 08:30:00, got {store.result[0].t}'

--- a/tests/replications/r.73.duckdb_large_parquet.yaml
+++ b/tests/replications/r.73.duckdb_large_parquet.yaml
@@ -20,7 +20,7 @@ hooks:
   start:
     # Generate test Parquet file with very large strings (>65,330 chars)
     - type: command
-      command: python3 tests/scripts/generate_large_parquet.py
+      command: uv run tests/scripts/generate_large_parquet.py
 
     # Copy the generated file to S3
     - type: copy

--- a/tests/replications/r.75.fields_placeholder_select.yaml
+++ b/tests/replications/r.75.fields_placeholder_select.yaml
@@ -30,7 +30,7 @@ hooks:
     # verify the target table has the correct data
     - type: query
       connection: '{target.name}'
-      query: SELECT id, name FROM public.test_table_fields_output ORDER BY id
+      query: SELECT * FROM public.test_table_fields_output ORDER BY id
       into: result
 
     - type: log
@@ -51,6 +51,57 @@ hooks:
     - type: check
       check: store.result[2].name == "Charlie"
 
+    # verify the placeholder columns (null, 0, true literals)
+    - type: check
+      check: is_null(store.result[0].null_col)
+
+    - type: check
+      check: store.result[0].num_col == 0
+
+    - type: check
+      check: bool_parse(store.result[0].bool_col) == true
+
+    - type: check
+      check: is_null(store.result[2].null_col)
+
+    - type: check
+      check: store.result[2].num_col == 0
+
+    - type: check
+      check: bool_parse(store.result[2].bool_col) == true
+
+    # verify the expression columns (string literal, keyword, CASE, cast, quoted)
+    - type: check
+      check: store.result[0].str_col == "N/A"
+
+    - type: check
+      check: store.result[2].str_col == "N/A"
+
+    # current_date should be populated (non-null)
+    - type: check
+      check: is_null(store.result[0].date_col) == false
+
+    # CASE: id=1 -> "small", id=3 -> "big"
+    - type: check
+      check: store.result[0].case_col == "small"
+
+    - type: check
+      check: store.result[2].case_col == "big"
+
+    # id::text cast -> string value of id
+    - type: check
+      check: store.result[0].cast_col == "1"
+
+    - type: check
+      check: store.result[2].cast_col == "3"
+
+    # "email" quoted identifier -> original email value
+    - type: check
+      check: store.result[0].quoted_email == "alice@example.com"
+
+    - type: check
+      check: store.result[2].quoted_email == "charlie@example.com"
+
     # cleanup
     - type: query
       connection: '{source.name}'
@@ -62,7 +113,17 @@ hooks:
 
 streams:
   test_table_fields:
-    select: [id, name]
+    select:
+      - id
+      - name
+      - null as null_col
+      - 0 as num_col
+      - true as bool_col
+      - "'N/A' as str_col"                                          # string literal
+      - current_date as date_col                                    # bare keyword expression
+      - "case when id > 1 then 'big' else 'small' end as case_col"  # CASE expression
+      - "id::text as cast_col"                                      # cast shorthand
+      - '"email" as quoted_email'                                   # already-quoted identifier
     sql: |
       SELECT {fields}
       FROM public.test_table_fields

--- a/tests/scripts/generate_large_parquet.py
+++ b/tests/scripts/generate_large_parquet.py
@@ -1,4 +1,10 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "pyarrow",
+# ]
+# ///
 """
 Generate a Parquet file with very large string values to test DuckDB scanner handling.
 This reproduces issue #668 where DuckDB hangs when reading Parquet files with large strings.

--- a/tests/specs/api_select_columns/pipeline.yaml
+++ b/tests/specs/api_select_columns/pipeline.yaml
@@ -101,7 +101,9 @@ steps:
     failure_message: "exclude-only `select` produced too few columns"
 
   # Case 4: reordering via `select` — `[front, "*", back]` places pins
-  # at the ends and lets `*` fill the middle in source order.
+  # at the ends; the `*` remainder fills the middle ALPHABETICALLY (the API's
+  # original field order is NOT preserved — pins go where listed, everything
+  # else is alphabetized).
   - replication:
       source: API_SELECT_TEST
       target: local
@@ -141,6 +143,304 @@ steps:
   - type: check
     check: 'length(keys(json_parse(store.reorder_body)[0])) >= 80'
     failure_message: "reorder: expected ~85 columns; got {length(keys(json_parse(store.reorder_body)[0]))}"
+
+  # The `*` remainder is ALPHABETICAL. The column right after the `id` pin must
+  # be `allow_forking` — the alphabetically-first non-pinned GitHub repo field.
+  # (Under the old source-order behavior this slot held `node_id`/`owner`/etc.)
+  - type: check
+    check: 'regex_match(store.reorder_body, "^\\[\\{\"full_name\":[^,]*,\"id\":[^,]*,\"allow_forking\":")'
+    failure_message: "reorder: `*` remainder not alphabetical — expected `allow_forking` first in the middle"
+
+  # Spot-check alphabetical ordering deeper in the middle: `archive_url` must
+  # precede `archived`, which must precede `assignees_url`.
+  - type: check
+    check: 'regex_match(store.reorder_body, "\"archive_url\":[^,]*,\"archived\":[^,]*,\"assignees_url\":")'
+    failure_message: "reorder: `*` remainder not alphabetical (archive_url < archived < assignees_url)"
+
+  - replication:
+      source: API_SELECT_TEST
+      target: local
+      defaults:
+        mode: full-refresh
+        object: "file://{env.OUT_DIR}/{stream_name}_nested.json"
+      streams:
+        search:
+          select:
+            - id
+            - name
+            - full_name
+            - description
+            - language
+            - stargazers_count
+
+  - type: read
+    from: local/{env.OUT_DIR}/search_nested.json
+    into: nested_body
+
+  - type: log
+    message: "nested-envelope output columns: {keys(json_parse(store.nested_body)[0])}"
+
+  # Multiple records came through (envelope was unwrapped, not treated as 1 row).
+  - type: check
+    check: 'length(json_parse(store.nested_body)) > 1'
+    failure_message: "nested-envelope: expected multiple records from `items`, got {length(json_parse(store.nested_body))}"
+
+  # Exactly the 6 selected columns reach the target — no leakage, no drops.
+  - type: check
+    check: 'length(keys(json_parse(store.nested_body)[0])) == 6'
+    failure_message: "nested-envelope: expected exactly 6 selected columns, got {length(keys(json_parse(store.nested_body)[0]))}"
+
+  - type: check
+    check: '!contains(keys(json_parse(store.nested_body)[0]), "owner") && !contains(keys(json_parse(store.nested_body)[0]), "html_url")'
+    failure_message: "nested-envelope: non-selected column leaked into the target"
+
+  # Column ORDER matches the `select` list exactly. Validated against raw
+  # bytes (json_parse → Go map loses order). The keys must appear in the
+  # order: id, name, full_name, description, language, stargazers_count.
+  - type: check
+    check: 'regex_match(store.nested_body, "^\\[\\{\"id\":[^}]*,\"name\":[^}]*,\"full_name\":[^}]*,\"description\":[^}]*,\"language\":[^}]*,\"stargazers_count\":")'
+    failure_message: "nested-envelope: `select` column order not preserved (expected id, name, full_name, description, language, stargazers_count)"
+
+  # Case 6: select a FLATTENED nested field (`owner__login`) alongside
+  # top-level fields, with a deeper flatten level. Regression for the bug
+  # where the record filter ran on raw top-level keys before flattening, so
+  # `owner` was stripped and `owner__login` could never be produced — the
+  # nested field silently vanished from the output.
+  - replication:
+      source: API_SELECT_TEST
+      target: local
+      defaults:
+        mode: full-refresh
+        object: "file://{env.OUT_DIR}/{stream_name}_flatsel.json"
+        source_options:
+          flatten: 2
+      streams:
+        search:
+          select:
+            - id
+            - owner__login
+            - name
+
+  - type: read
+    from: local/{env.OUT_DIR}/search_flatsel.json
+    into: flatsel_body
+
+  - type: log
+    message: "flattened-select output columns: {keys(json_parse(store.flatsel_body)[0])}"
+
+  # The flattened nested field actually made it through.
+  - type: check
+    check: 'contains(keys(json_parse(store.flatsel_body)[0]), "owner__login")'
+    failure_message: "flattened-select: nested field `owner__login` was dropped"
+
+  # Exactly the 3 selected columns — no leakage, no extra owner__* fields.
+  - type: check
+    check: 'length(keys(json_parse(store.flatsel_body)[0])) == 3'
+    failure_message: "flattened-select: expected exactly 3 columns, got {length(keys(json_parse(store.flatsel_body)[0]))}"
+
+  # No leakage: neither the un-flattened `owner` object nor sibling
+  # `owner__*` fields should appear. Checked against raw bytes since
+  # `contains` on a key list does substring matching (owner__login would
+  # false-match a bare "owner" probe).
+  - type: check
+    check: '!regex_match(store.flatsel_body, "\"owner\":") && !regex_match(store.flatsel_body, "\"owner__id\":")'
+    failure_message: "flattened-select: unselected nested fields leaked into the target"
+
+  # Order matches the select list: id, owner__login, name (raw-bytes check).
+  - type: check
+    check: 'regex_match(store.flatsel_body, "^\\[\\{\"id\":[^}]*,\"owner__login\":[^}]*,\"name\":")'
+    failure_message: "flattened-select: column order not preserved (expected id, owner__login, name)"
+
+  # Case 7: `select` referencing a key PRODUCED BY A PROCESSOR. The
+  # `search_proc_rename` endpoint renames `full_name` -> `slug` via an
+  # object_rename processor that runs AFTER the records are fetched. The
+  # stream selects [id, slug, name, stargazers_count]. Regression for the
+  # bug where select/order ran BEFORE processors: at order time `slug`
+  # didn't exist yet (only `full_name` did) and `full_name` was dropped by
+  # the select, so the processor had nothing to rename and `slug` vanished.
+  # Now select/order run after processors and see the final `slug` key.
+  - replication:
+      source: API_SELECT_TEST
+      target: local
+      defaults:
+        mode: full-refresh
+        object: "file://{env.OUT_DIR}/{stream_name}_procsel.json"
+      streams:
+        search_proc_rename:
+          select:
+            - id
+            - slug
+            - name
+            - stargazers_count
+
+  - type: read
+    from: local/{env.OUT_DIR}/search_proc_rename_procsel.json
+    into: procsel_body
+
+  - type: log
+    message: "processor-rename select output columns: {keys(json_parse(store.procsel_body)[0])}"
+
+  - type: check
+    check: 'length(json_parse(store.procsel_body)) > 1'
+    failure_message: "processor-rename: expected multiple records, got {length(json_parse(store.procsel_body))}"
+
+  # The processor-produced key `slug` survived select (it wasn't dropped
+  # before the rename had a chance to run).
+  - type: check
+    check: 'contains(keys(json_parse(store.procsel_body)[0]), "slug")'
+    failure_message: "processor-rename: `slug` (produced by object_rename) was dropped by select"
+
+  - type: check
+    check: 'length(keys(json_parse(store.procsel_body)[0])) == 4'
+    failure_message: "processor-rename: expected exactly 4 selected columns, got {length(keys(json_parse(store.procsel_body)[0]))}"
+
+  # Neither the pre-rename `full_name` nor unselected fields leak.
+  - type: check
+    check: '!regex_match(store.procsel_body, "\"full_name\":") && !regex_match(store.procsel_body, "\"owner\":")'
+    failure_message: "processor-rename: unselected/pre-rename column leaked into the target"
+
+  # Order matches the select list: id, slug, name, stargazers_count.
+  - type: check
+    check: 'regex_match(store.procsel_body, "^\\[\\{\"id\":[^}]*,\"slug\":[^}]*,\"name\":[^}]*,\"stargazers_count\":")'
+    failure_message: "processor-rename: column order not preserved (expected id, slug, name, stargazers_count)"
+
+  # Case 8: `select` referencing keys produced by a jq RESHAPE of the
+  # records. The `search_jq_reshape` endpoint rebuilds each record as
+  # {id, label, title, stars} via a jq records expression. The stream
+  # selects [id, label, title, stars] — none of which appear in the raw
+  # response bytes (the source keys are full_name/name/stargazers_count).
+  # Regression for the bug where column order was recovered from raw bytes
+  # before reshaping, so reshaped keys ordered alphabetically (stars before
+  # title) instead of by select-list order. Now order is computed on the
+  # final reshaped records.
+  - replication:
+      source: API_SELECT_TEST
+      target: local
+      defaults:
+        mode: full-refresh
+        object: "file://{env.OUT_DIR}/{stream_name}_jqsel.json"
+      streams:
+        search_jq_reshape:
+          select:
+            - id
+            - label
+            - title
+            - stars
+
+  - type: read
+    from: local/{env.OUT_DIR}/search_jq_reshape_jqsel.json
+    into: jqsel_body
+
+  - type: log
+    message: "jq-reshape select output columns: {keys(json_parse(store.jqsel_body)[0])}"
+
+  - type: check
+    check: 'length(json_parse(store.jqsel_body)) > 1'
+    failure_message: "jq-reshape: expected multiple records, got {length(json_parse(store.jqsel_body))}"
+
+  - type: check
+    check: 'length(keys(json_parse(store.jqsel_body)[0])) == 4'
+    failure_message: "jq-reshape: expected exactly 4 selected columns, got {length(keys(json_parse(store.jqsel_body)[0]))}"
+
+  # Order matches the select list exactly: id, label, title, stars. The
+  # critical assertion — `title` must precede `stars` (select order), not
+  # `stars` before `title` (alphabetical, the pre-fix behavior).
+  - type: check
+    check: 'regex_match(store.jqsel_body, "^\\[\\{\"id\":[^}]*,\"label\":[^}]*,\"title\":[^}]*,\"stars\":")'
+    failure_message: "jq-reshape: column order not preserved (expected id, label, title, stars)"
+
+  # Case 9: the `@columns` sentinel as the sole `select` item
+  # (`select: ['@columns']`). It expands to the column names listed under
+  # `columns`, IN DECLARED ORDER, and narrows the output to exactly those
+  # columns. The `columns` order here is deliberately NON-alphabetical
+  # (full_name, id, html_url, stargazers_count) so the test proves the order
+  # comes from `columns`, not from alphabetizing (alphabetical would be
+  # full_name, html_url, id, stargazers_count).
+  - replication:
+      source: API_SELECT_TEST
+      target: local
+      defaults:
+        mode: full-refresh
+        object: "file://{env.OUT_DIR}/{stream_name}_atcols.json"
+      streams:
+        repo:
+          columns:
+            full_name: string
+            id: integer
+            html_url: string
+            stargazers_count: integer
+          select:
+            - "@columns"
+
+  - type: read
+    from: local/{env.OUT_DIR}/repo_atcols.json
+    into: atcols_body
+
+  - type: log
+    message: "@columns scalar output columns: {keys(json_parse(store.atcols_body)[0])}"
+
+  # Exactly the 4 columns from `columns` — no more, no less.
+  - type: check
+    check: 'length(keys(json_parse(store.atcols_body)[0])) == 4'
+    failure_message: "@columns scalar: expected exactly 4 columns from `columns`, got {length(keys(json_parse(store.atcols_body)[0]))}"
+
+  - type: check
+    check: '!contains(keys(json_parse(store.atcols_body)[0]), "owner") && !regex_match(store.atcols_body, "\"node_id\":")'
+    failure_message: "@columns scalar: a column not in `columns` leaked into the target"
+
+  # Order is the `columns` DECLARATION order (raw-bytes check; json_parse loses
+  # order). Must be full_name, id, html_url, stargazers_count — not alphabetical.
+  - type: check
+    check: 'regex_match(store.atcols_body, "^\\[\\{\"full_name\":[^}]*,\"id\":[^}]*,\"html_url\":[^}]*,\"stargazers_count\":")'
+    failure_message: "@columns scalar: order is not the `columns` declaration order (expected full_name, id, html_url, stargazers_count)"
+
+  # Case 10: the `@columns` sentinel MIXED with `*` (`select: ['@columns', '*']`).
+  # The `columns` names pin first in declared order; the `*` remainder then fills
+  # the rest ALPHABETICALLY, with no duplication of the already-pinned columns.
+  - replication:
+      source: API_SELECT_TEST
+      target: local
+      defaults:
+        mode: full-refresh
+        object: "file://{env.OUT_DIR}/{stream_name}_atcolsmix.json"
+      streams:
+        repo:
+          columns:
+            full_name: string
+            id: integer
+            html_url: string
+          select:
+            - "@columns"
+            - "*"
+
+  - type: read
+    from: local/{env.OUT_DIR}/repo_atcolsmix.json
+    into: atcolsmix_body
+
+  - type: log
+    message: "@columns + * output columns: {keys(json_parse(store.atcolsmix_body)[0])}"
+
+  # The `*` remainder brings the full record through (~85 fields), not just the 3 pins.
+  - type: check
+    check: 'length(keys(json_parse(store.atcolsmix_body)[0])) >= 80'
+    failure_message: "@columns + *: expected the full record (~85 cols); got {length(keys(json_parse(store.atcolsmix_body)[0]))}"
+
+  # The 3 `columns` pins lead, in declared order: full_name, id, html_url.
+  - type: check
+    check: 'regex_match(store.atcolsmix_body, "^\\[\\{\"full_name\":[^}]*,\"id\":[^}]*,\"html_url\":")'
+    failure_message: "@columns + *: pins not first in `columns` order (expected full_name, id, html_url)"
+
+  # The column right after the pins is `allow_forking` — the alphabetically-first
+  # non-pinned GitHub repo field — confirming the `*` remainder is alphabetical.
+  - type: check
+    check: 'regex_match(store.atcolsmix_body, "^\\[\\{\"full_name\":[^,]*,\"id\":[^,]*,\"html_url\":[^,]*,\"allow_forking\":")'
+    failure_message: "@columns + *: remainder not alphabetical — expected `allow_forking` right after the pins"
+
+  # No duplication: a pinned column (id) must appear exactly once even though it
+  # is also part of the `*` set.
+  - type: check
+    check: 'length(json_parse(store.atcolsmix_body)[0]) == length(keys(json_parse(store.atcolsmix_body)[0]))'
+    failure_message: "@columns + *: a pinned column was duplicated in the `*` remainder"
 
   - type: log
     message: "=== API select-columns pipeline passed ==="

--- a/tests/specs/api_select_columns/spec.yaml
+++ b/tests/specs/api_select_columns/spec.yaml
@@ -37,3 +37,49 @@ endpoints:
         - id
         - name
         - full_name
+  search:
+    request:
+      url: "{state.base_url}/search/repositories"
+      method: GET
+      parameters:
+        q: "sling language:go"
+        per_page: 5
+    response:
+      records:
+        jmespath: "items"
+        primary_key: ["id"]
+
+  # PROBE A: a processor that renames a key AFTER select/order runs.
+  # `full_name` is renamed to `slug` by an object_rename processor. The
+  # `select` lists [id, slug, name, stargazers_count]. If ordering is
+  # computed before processors, `slug` won't exist yet at order time.
+  search_proc_rename:
+    request:
+      url: "{state.base_url}/search/repositories"
+      method: GET
+      parameters:
+        q: "sling language:go"
+        per_page: 5
+    response:
+      records:
+        jmespath: "items"
+        primary_key: ["id"]
+      processors:
+        - expression: 'object_rename(record, "full_name", "slug")'
+          output: record
+
+  # PROBE B: a jq records expression that RESHAPES each record into a new
+  # object with reordered/renamed keys. The select lists the post-jq names.
+  # The raw response bytes no longer match these keys, so order recovery
+  # from respBytes cannot find them.
+  search_jq_reshape:
+    request:
+      url: "{state.base_url}/search/repositories"
+      method: GET
+      parameters:
+        q: "sling language:go"
+        per_page: 5
+    response:
+      records:
+        jq: '.items[] | {id: .id, label: .full_name, title: .name, stars: .stargazers_count}'
+        primary_key: ["id"]

--- a/tests/specs/queue_streaming_failfast/.env.sling
+++ b/tests/specs/queue_streaming_failfast/.env.sling
@@ -1,0 +1,6 @@
+ENV_YAML="
+connections:
+  QUEUE_STREAM_TEST:
+    type: api
+    spec: file://./spec.yaml
+"

--- a/tests/specs/queue_streaming_failfast/replication.failfast.yaml
+++ b/tests/specs/queue_streaming_failfast/replication.failfast.yaml
@@ -1,0 +1,21 @@
+# Fail-fast: two independent streaming-queue groups. The server fails one item
+# for group 1 only (grp=1). Group 1 (search + details_a/b) must fail/terminate
+# fast, while the independent group 2 (search2 + details2_a/b) finishes OK.
+source: QUEUE_STREAM_TEST
+target: local
+
+env:
+  SLING_THREADS: "6"
+  OUT_DIR: ${OUT_DIR}
+
+defaults:
+  mode: full-refresh
+  object: "file://{env.OUT_DIR}/{stream_name}.json"
+
+streams:
+  search: {}
+  details_a: {}
+  details_b: {}
+  search2: {}
+  details2_a: {}
+  details2_b: {}

--- a/tests/specs/queue_streaming_failfast/replication.success.yaml
+++ b/tests/specs/queue_streaming_failfast/replication.success.yaml
@@ -1,0 +1,20 @@
+# Success path: two independent streaming-queue groups, all streams succeed.
+# Each child writes one JSON file; the script asserts each has NUM_ITEMS records.
+source: QUEUE_STREAM_TEST
+target: local
+
+env:
+  SLING_THREADS: "6" # both producers + 4 children run concurrently
+  OUT_DIR: ${OUT_DIR}
+
+defaults:
+  mode: full-refresh
+  object: "file://{env.OUT_DIR}/{stream_name}.json"
+
+streams:
+  search: {}
+  details_a: {}
+  details_b: {}
+  search2: {}
+  details2_a: {}
+  details2_b: {}

--- a/tests/specs/queue_streaming_failfast/replication.success.yaml
+++ b/tests/specs/queue_streaming_failfast/replication.success.yaml
@@ -4,7 +4,7 @@ source: QUEUE_STREAM_TEST
 target: local
 
 env:
-  SLING_THREADS: "6" # both producers + 4 children run concurrently
+  SLING_THREADS: "8" # all producers + children run concurrently
   OUT_DIR: ${OUT_DIR}
 
 defaults:
@@ -18,3 +18,5 @@ streams:
   search2: {}
   details2_a: {}
   details2_b: {}
+  list_c: {}      # regular (non-queue_only) producer that also feeds queue.item_ids3
+  details_c: {}   # consume: immediate child of list_c (regression for queue done-sentinel)

--- a/tests/specs/queue_streaming_failfast/run_test.sh
+++ b/tests/specs/queue_streaming_failfast/run_test.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Self-contained streaming-queue fail-fast test (two independent groups).
+#
+# Group 1: search  -> details_a, details_b   (queue.item_ids)
+# Group 2: search2 -> details2_a, details2_b  (queue.item_ids2)
+#
+#   1. Success path: all 6 streams succeed. Assert each child produced exactly
+#      NUM_ITEMS records (broadcast + count match).
+#   2. Fail-fast path: the server fails one item for group 1 only (grp=1). Assert
+#      the run exits non-zero AND fast, that group 1 was terminated (incomplete),
+#      and that the independent group 2 still finished successfully.
+#
+# Prints "QUEUE STREAMING TEST PASSED" on success (asserted by the suite).
+
+set -uo pipefail
+cd "$(dirname "$0")"
+
+NUM_ITEMS=30
+OUT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/queue_stream_test.XXXXXX")"
+PORT_FILE="$OUT_DIR/port"
+PORT=""
+SERVER_PID=""
+
+cleanup() {
+  [[ -n "$SERVER_PID" ]] && kill "$SERVER_PID" >/dev/null 2>&1
+  rm -rf "$OUT_DIR"
+}
+trap cleanup EXIT
+
+fail() { echo "TEST FAILURE: $*" >&2; exit 1; }
+
+# locate the sling binary (built by the suite into cmd/sling)
+SLING_BIN="$(cd ../../../cmd/sling && pwd)/sling"
+[[ -x "$SLING_BIN" ]] || SLING_BIN="sling"
+
+run_sling() {
+  "$SLING_BIN" "$@"
+}
+
+count_records() {
+  # count JSON objects (one record per {...}) in the child output file
+  local f="$1"
+  [[ -f "$f" ]] || { echo 0; return; }
+  grep -o '"id"' "$f" | wc -l | tr -d ' '
+}
+
+# start_server [FAIL_ON_ID] [FAIL_ON_GROUP]
+start_server() {
+  rm -f "$PORT_FILE"
+  NUM_ITEMS="$NUM_ITEMS" PORT=0 PORT_FILE="$PORT_FILE" \
+    FAIL_ON_ID="${1:-}" FAIL_ON_GROUP="${2:-}" \
+    go run server.go &
+  SERVER_PID=$!
+  # wait for the server to publish its chosen port, then probe readiness
+  for _ in $(seq 1 100); do
+    if [[ -s "$PORT_FILE" ]]; then
+      PORT="$(cat "$PORT_FILE")"
+      if curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
+        export TEST_BASE_URL="http://127.0.0.1:$PORT"
+        return 0
+      fi
+    fi
+    sleep 0.2
+  done
+  fail "test server did not become ready"
+}
+
+stop_server() {
+  if [[ -n "$SERVER_PID" ]]; then
+    kill "$SERVER_PID" >/dev/null 2>&1
+    wait "$SERVER_PID" 2>/dev/null
+    SERVER_PID=""
+  fi
+}
+
+export OUT_DIR
+
+# ---------------------------------------------------------------------------
+echo "=== [1/2] success path: 2 groups, 4 children, expect $NUM_ITEMS each ==="
+start_server "" ""
+
+if ! run_sling run -d -r replication.success.yaml; then
+  fail "success-path replication failed unexpectedly (exit $?)"
+fi
+stop_server
+
+for child in details_a details_b details2_a details2_b; do
+  n=$(count_records "$OUT_DIR/$child.json")
+  echo "  $child => $n records"
+  [[ "$n" == "$NUM_ITEMS" ]] || fail "$child produced $n records, expected $NUM_ITEMS (broadcast/count mismatch)"
+done
+echo "SUCCESS PATH OK: all 4 children produced $NUM_ITEMS records each"
+
+# ---------------------------------------------------------------------------
+echo "=== [2/2] fail-fast path: fail group 1 only; group 2 must survive ==="
+rm -rf "$OUT_DIR"/*.json
+start_server "item-005" "1"
+
+LOG="$OUT_DIR/failfast.log"
+start_ts=$(date +%s)
+run_sling run -d -r replication.failfast.yaml >"$LOG" 2>&1
+rc=$?
+end_ts=$(date +%s)
+stop_server
+
+cat "$LOG"
+
+# the run as a whole must fail (group 1 failed)
+[[ "$rc" == "0" ]] && fail "fail-fast replication unexpectedly succeeded (group 1 should have failed the run)"
+
+# must fail fast (not hang waiting on a terminated group)
+elapsed=$(( end_ts - start_ts ))
+echo "  fail-fast run exited non-zero in ${elapsed}s"
+[[ "$elapsed" -le 60 ]] || fail "fail-fast run took ${elapsed}s — expected to fail fast"
+
+# the independent group 2 must have finished successfully with full output
+for child in details2_a details2_b; do
+  n=$(count_records "$OUT_DIR/$child.json")
+  echo "  group2 $child => $n records"
+  [[ "$n" == "$NUM_ITEMS" ]] || fail "independent $child produced $n records, expected $NUM_ITEMS (group 2 should NOT be terminated)"
+done
+
+# group 1 must NOT have completed (terminated): its children should not have a
+# full output file. (A terminated stream writes no file or a partial one.)
+for child in details_a details_b; do
+  n=$(count_records "$OUT_DIR/$child.json")
+  echo "  group1 $child => $n records"
+  [[ "$n" == "$NUM_ITEMS" ]] && fail "group1 $child produced full output ($n) — it should have been terminated"
+done
+
+echo "FAIL-FAST PATH OK: group 1 failed/terminated, independent group 2 succeeded"
+
+echo "QUEUE STREAMING TEST PASSED"

--- a/tests/specs/queue_streaming_failfast/run_test.sh
+++ b/tests/specs/queue_streaming_failfast/run_test.sh
@@ -84,12 +84,13 @@ if ! run_sling run -d -r replication.success.yaml; then
 fi
 stop_server
 
-for child in details_a details_b details2_a details2_b; do
+# details_c tails a non-queue_only producer (list_c); it must not hang
+for child in details_a details_b details2_a details2_b details_c; do
   n=$(count_records "$OUT_DIR/$child.json")
   echo "  $child => $n records"
   [[ "$n" == "$NUM_ITEMS" ]] || fail "$child produced $n records, expected $NUM_ITEMS (broadcast/count mismatch)"
 done
-echo "SUCCESS PATH OK: all 4 children produced $NUM_ITEMS records each"
+echo "SUCCESS PATH OK: all 5 children produced $NUM_ITEMS records each"
 
 # ---------------------------------------------------------------------------
 echo "=== [2/2] fail-fast path: fail group 1 only; group 2 must survive ==="

--- a/tests/specs/queue_streaming_failfast/server.go
+++ b/tests/specs/queue_streaming_failfast/server.go
@@ -1,0 +1,93 @@
+//go:build ignore
+
+// Test HTTP server: /search (queue producer) + /detail (queue consumers).
+// Env: PORT, NUM_ITEMS (default 30), FAIL_ON_ID (422s that id), FAIL_DELAY_MS (default 150).
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+)
+
+func main() {
+	// Bind to a free port (PORT=0) and write it to PORT_FILE to avoid port races.
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "0"
+	}
+
+	numItems := 30
+	if v := os.Getenv("NUM_ITEMS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			numItems = n
+		}
+	}
+
+	failOnID := os.Getenv("FAIL_ON_ID")
+	failOnGroup := os.Getenv("FAIL_ON_GROUP") // only fail when ?grp= matches (empty = any)
+	failDelay := 150 * time.Millisecond
+	if v := os.Getenv("FAIL_DELAY_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			failDelay = time.Duration(n) * time.Millisecond
+		}
+	}
+
+	mux := http.NewServeMux()
+
+	// /search returns {"results":[{id}...]} for the producer to enqueue.
+	mux.HandleFunc("/search", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"results":[`)
+		for i := 1; i <= numItems; i++ {
+			if i > 1 {
+				fmt.Fprint(w, ",")
+			}
+			fmt.Fprintf(w, `{"id":"item-%03d"}`, i)
+		}
+		fmt.Fprint(w, `]}`)
+	})
+
+	// /detail returns one id's record; FAIL_ON_ID (+ optional FAIL_ON_GROUP via
+	// ?grp=) returns a non-retryable 422.
+	mux.HandleFunc("/detail", func(w http.ResponseWriter, r *http.Request) {
+		id := r.URL.Query().Get("id")
+		grp := r.URL.Query().Get("grp")
+		if failOnID != "" && id == failOnID && (failOnGroup == "" || grp == failOnGroup) {
+			time.Sleep(failDelay)
+			http.Error(w, `{"error":"injected failure for `+id+` grp=`+grp+`"}`, http.StatusUnprocessableEntity)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"id":%q,"name":"Name for %s","value":%d}`, id, id, len(id))
+	})
+
+	// readiness probe
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "ok")
+	})
+
+	addr := "127.0.0.1:" + port
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "listen error:", err)
+		os.Exit(1)
+	}
+
+	chosen := ln.Addr().(*net.TCPAddr).Port
+	if pf := os.Getenv("PORT_FILE"); pf != "" {
+		if err := os.WriteFile(pf, []byte(strconv.Itoa(chosen)), 0644); err != nil {
+			fmt.Fprintln(os.Stderr, "could not write PORT_FILE:", err)
+			os.Exit(1)
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "test server listening on 127.0.0.1:%d (num_items=%d fail_on_id=%q)\n", chosen, numItems, failOnID)
+	if err := http.Serve(ln, mux); err != nil {
+		fmt.Fprintln(os.Stderr, "server error:", err)
+		os.Exit(1)
+	}
+}

--- a/tests/specs/queue_streaming_failfast/spec.yaml
+++ b/tests/specs/queue_streaming_failfast/spec.yaml
@@ -104,3 +104,35 @@ endpoints:
       records:
         jmespath: "@"
         primary_key: ["id"]
+
+  # ---- Group 3: list_c is a REGULAR record-emitting producer (NOT queue_only)
+  # that also populates queue.item_ids3; details_c tails it with consume:
+  # immediate. Regression for: non-queue_only producers must signal queue done. ----
+  list_c:
+    request:
+      url: "{state.base_url}/search"
+      method: GET
+    response:
+      records:
+        jmespath: "results"
+        primary_key: ["id"]
+      processors:
+        - expression: "record.id"
+          output: "queue.item_ids3"
+
+  details_c:
+    iterate:
+      over: "queue.item_ids3"
+      into: "state.item_id"
+      consume: immediate
+      concurrency: 3
+    request:
+      url: "{state.base_url}/detail"
+      method: GET
+      parameters:
+        id: "{state.item_id}"
+        grp: "3"
+    response:
+      records:
+        jmespath: "@"
+        primary_key: ["id"]

--- a/tests/specs/queue_streaming_failfast/spec.yaml
+++ b/tests/specs/queue_streaming_failfast/spec.yaml
@@ -1,0 +1,106 @@
+name: "Queue Streaming Fail-Fast Test"
+description: >
+  Self-contained spec with TWO independent streaming-queue groups. Each group has
+  a queue_only producer (search) feeding its own queue, and children that tail it
+  with consume: immediate. Used to verify (a) broadcast + count match, and (b) when
+  a child in group 1 fails, only group 1 (its producer + children) is terminated,
+  while the independent group 2 finishes successfully.
+
+defaults:
+  state:
+    base_url: "{env.TEST_BASE_URL}"
+
+endpoints:
+  # ---- Group 1: search -> details_a, details_b (queue.item_ids) ----
+  search:
+    queue_only: true
+    request:
+      url: "{state.base_url}/search"
+      method: GET
+    response:
+      records:
+        jmespath: "results"
+      processors:
+        - expression: "record.id"
+          output: "queue.item_ids"
+
+  details_a:
+    iterate:
+      over: "queue.item_ids"
+      into: "state.item_id"
+      consume: immediate
+      concurrency: 3
+    request:
+      url: "{state.base_url}/detail"
+      method: GET
+      parameters:
+        id: "{state.item_id}"
+        grp: "1"
+    response:
+      records:
+        jmespath: "@"
+        primary_key: ["id"]
+
+  details_b:
+    iterate:
+      over: "queue.item_ids"
+      into: "state.item_id"
+      consume: immediate
+      concurrency: 3
+    request:
+      url: "{state.base_url}/detail"
+      method: GET
+      parameters:
+        id: "{state.item_id}"
+        grp: "1"
+    response:
+      records:
+        jmespath: "@"
+        primary_key: ["id"]
+
+  # ---- Group 2 (independent): search2 -> details2_a, details2_b (queue.item_ids2) ----
+  search2:
+    queue_only: true
+    request:
+      url: "{state.base_url}/search"
+      method: GET
+    response:
+      records:
+        jmespath: "results"
+      processors:
+        - expression: "record.id"
+          output: "queue.item_ids2"
+
+  details2_a:
+    iterate:
+      over: "queue.item_ids2"
+      into: "state.item_id"
+      consume: immediate
+      concurrency: 3
+    request:
+      url: "{state.base_url}/detail"
+      method: GET
+      parameters:
+        id: "{state.item_id}"
+        grp: "2"
+    response:
+      records:
+        jmespath: "@"
+        primary_key: ["id"]
+
+  details2_b:
+    iterate:
+      over: "queue.item_ids2"
+      into: "state.item_id"
+      consume: immediate
+      concurrency: 3
+    request:
+      url: "{state.base_url}/detail"
+      method: GET
+      parameters:
+        id: "{state.item_id}"
+        grp: "2"
+    response:
+      records:
+        jmespath: "@"
+        primary_key: ["id"]

--- a/tests/suite.cli.yaml
+++ b/tests/suite.cli.yaml
@@ -2300,3 +2300,14 @@
   run: 'sling run -d -p tests/pipelines/p.33.select_json_file_source.yaml'
   output_contains:
     - 'select on JSON file source: SUCCESS'
+
+- id: 241
+  name: 'API streaming queue: broadcast count match, group-scoped fail-fast'
+  group: api
+  run: |
+    cd tests/specs/queue_streaming_failfast
+    bash run_test.sh
+  output_contains:
+    - 'SUCCESS PATH OK: all 4 children produced 30 records each'
+    - 'FAIL-FAST PATH OK: group 1 failed/terminated, independent group 2 succeeded'
+    - 'QUEUE STREAMING TEST PASSED'

--- a/tests/suite.cli.yaml
+++ b/tests/suite.cli.yaml
@@ -1250,7 +1250,7 @@
   name: 'Test {fields} placeholder with select parameter (issue #669)'
   run: 'sling run -d -r tests/replications/r.75.fields_placeholder_select.yaml'
   output_contains:
-    - SELECT "id", "name"
+    - SELECT "id", "name", null as null_col, 0 as num_col, true as bool_col
 
 - id: 142
   name: 'Test columns casting to string for DDL (issue #651)'

--- a/tests/suite.cli.yaml
+++ b/tests/suite.cli.yaml
@@ -2405,3 +2405,12 @@
     TARGET: POSTGRES
   output_contains:
     - 'execution succeeded'
+
+- id: 250
+  name: Run sling iceberg time/uuid write (issue #751)
+  run: |
+    sling run -d -r tests/replications/r.115.iceberg_time_uuid.yaml
+  output_contains:
+    - committed iceberg snapshot
+    - inserted 1 rows
+    - 'result => {"t":"08:30:00"}'

--- a/tests/suite.cli.yaml
+++ b/tests/suite.cli.yaml
@@ -2345,3 +2345,37 @@
   output_contains:
     - 'execution succeeded'
     - 'SUCCESS: Postgres binary fidelity test passed'
+
+# Column DDL constraints & index improvements — single self-contained pipeline
+# covering the columns: modifier DSL (not_null / primary_key / unique /
+# description / inline index), the ClickHouse not_null fix, the
+# table_keys.index list form, and the reserved-but-unsupported error path.
+- id: 245
+  name: 'Test column DDL constraints & indexes (pipeline)'
+  run: 'sling run -d -p tests/pipelines/p.34.column_ddl_constraints_and_indexes.yaml'
+  output_contains:
+    - 'is not yet supported'
+    - 'SUCCESS: column DDL constraints & indexes pipeline passed'
+
+# Column DDL per-engine validation — master pipeline builds a Postgres source
+# table then drives one child pipeline per emission-capable engine. Each child
+# applies the columns: modifier DSL and inspects the target catalog /
+# information_schema to confirm not_null / primary_key / unique / index /
+# description landed correctly (each engine asserts only what it natively emits).
+- id: 246
+  name: 'Test column DDL per-engine (master pipeline)'
+  run: 'sling run -p tests/pipelines/column_ddl/p.columns_ddl.00.master.yaml'
+  output_contains:
+    - 'SUCCESS: postgres column DDL verified'
+    - 'SUCCESS: mysql column DDL verified'
+    - 'SUCCESS: mariadb column DDL verified'
+    - 'SUCCESS: sqlserver column DDL verified'
+    - 'SUCCESS: sqlite column DDL verified'
+    - 'SUCCESS: oracle column DDL verified'
+    - 'SUCCESS: clickhouse column DDL verified'
+    - 'SUCCESS: snowflake column DDL verified'
+    - 'SUCCESS: duckdb column DDL verified'
+    - 'SUCCESS: motherduck column DDL verified'
+    - 'SUCCESS: bigquery column DDL verified'
+    - 'SUCCESS: starrocks column DDL verified'
+    - 'SUCCESS: all column DDL engine pipelines passed'

--- a/tests/suite.cli.yaml
+++ b/tests/suite.cli.yaml
@@ -2395,3 +2395,13 @@
     - 'group substep 3 still ran'
     - 'step (deep_warn) failed'
     - 'all on_failure:warn status checks passed'
+
+- id: 249
+  name: Oracle bare table name injects schema for column lookup (https://github.com/slingdata-io/sling-cli/issues/749)
+  run: sling run -r tests/replications/r.114.oracle_no_schema_columns.yaml
+  env:
+    SCHEMA: ORACLE
+    SOURCE: ORACLE
+    TARGET: POSTGRES
+  output_contains:
+    - 'execution succeeded'

--- a/tests/suite.cli.yaml
+++ b/tests/suite.cli.yaml
@@ -2311,3 +2311,37 @@
     - 'SUCCESS PATH OK: all 4 children produced 30 records each'
     - 'FAIL-FAST PATH OK: group 1 failed/terminated, independent group 2 succeeded'
     - 'QUEUE STREAMING TEST PASSED'
+
+# Test MySQL binary/blob fidelity (mediumblob -> mediumblob)
+# Issue: blob types mapped to generic `text`, storing binary as mediumtext and
+# corrupting invalid UTF-8 bytes with the U+FFFD replacement char.
+# Fix: map blob types to `binary`, hex-encode binary in CSV, decode via UNHEX.
+- id: 242
+  name: 'Test MySQL binary blob fidelity'
+  run: 'sling run -d -r tests/replications/r.111.mysql_binary_blob_fidelity.yaml'
+  streams: 1
+  rows: 4
+  output_contains:
+    - 'execution succeeded'
+    - 'SUCCESS: MySQL binary blob fidelity test passed'
+
+# Test SQL Server binary fidelity (varbinary(max) round-trip)
+# Issue: binary serialized as text (BCP CSV / nvarchar bind) corrupted/truncated data.
+- id: 243
+  name: 'Test SQL Server binary fidelity'
+  run: 'sling run -d -r tests/replications/r.112.sqlserver_binary_fidelity.yaml'
+  streams: 2
+  rows: 6
+  output_contains:
+    - 'execution succeeded'
+    - 'SUCCESS: SQL Server binary fidelity test passed (bcp + cursor)'
+
+# Test Postgres binary fidelity (bytea round-trip)
+- id: 244
+  name: 'Test Postgres binary fidelity'
+  run: 'sling run -d -r tests/replications/r.113.postgres_binary_fidelity.yaml'
+  streams: 1
+  rows: 4
+  output_contains:
+    - 'execution succeeded'
+    - 'SUCCESS: Postgres binary fidelity test passed'

--- a/tests/suite.cli.yaml
+++ b/tests/suite.cli.yaml
@@ -2379,3 +2379,9 @@
     - 'SUCCESS: bigquery column DDL verified'
     - 'SUCCESS: starrocks column DDL verified'
     - 'SUCCESS: all column DDL engine pipelines passed'
+
+- id: 247
+  name: 'Test group concurrency runs loop iterations in parallel'
+  run: 'sling run -p tests/pipelines/p.36.group_concurrency.yaml'
+  output_contains:
+    - 'group concurrency checks passed'

--- a/tests/suite.cli.yaml
+++ b/tests/suite.cli.yaml
@@ -1580,13 +1580,14 @@
 - id: 171
   name: 'Test merge_strategy target option'
   run: 'sling run -d -r tests/replications/r.100.merge_strategy.yaml'
-  streams: 4
+  streams: 5
   output_contains:
     - 'execution succeeded'
     - 'update_insert count'
     - 'delete_insert count'
     - 'update count'
     - 'insert count'
+    - 'SUCCESS: merge_strategy insert skips existing rows (issue #755)'
 
 # Test constraint validation with value IN expressions
 # Bug: Constraints fail to abort replication when invalid data is present

--- a/tests/suite.cli.yaml
+++ b/tests/suite.cli.yaml
@@ -2385,3 +2385,13 @@
   run: 'sling run -p tests/pipelines/p.36.group_concurrency.yaml'
   output_contains:
     - 'group concurrency checks passed'
+
+- id: 248
+  name: 'Test on_failure:warn sets warning status & propagates through groups'
+  run: 'sling run -p tests/pipelines/p.35.on_failure_warn_status.yaml'
+  output_contains:
+    - 'step (direct_warn) failed'
+    - 'step (group_inner_warn) failed'
+    - 'group substep 3 still ran'
+    - 'step (deep_warn) failed'
+    - 'all on_failure:warn status checks passed'

--- a/tests/suite.cli.yaml
+++ b/tests/suite.cli.yaml
@@ -2309,7 +2309,7 @@
     cd tests/specs/queue_streaming_failfast
     bash run_test.sh
   output_contains:
-    - 'SUCCESS PATH OK: all 4 children produced 30 records each'
+    - 'SUCCESS PATH OK: all 5 children produced 30 records each'
     - 'FAIL-FAST PATH OK: group 1 failed/terminated, independent group 2 succeeded'
     - 'QUEUE STREAMING TEST PASSED'
 


### PR DESCRIPTION
### New Features

- **SQL expressions in `select`**: Allow raw SQL expressions, literals, casts, `CASE`, and keywords in select configurations, bypassing identifier quoting and passing unmatched rename expressions through as raw SQL aliases.
- **`@columns` select token**: Pin declared columns in their defined order, with remaining unpinned columns output alphabetically. Adds `FlattenRecord` to support selecting flattened nested fields, and runs select/order after processors and `jq` expressions.
- **JSON Lines file extensions**: Recognize `.jsonl`, `.ndjson`, and `.jsonlines` extensions for JSON Lines files.
- **CDC slot level config**: New `slot_level` field (`stream` or `shared`) on CDC options to control slot scoping, with shared CDC runner grouping for Postgres/MySQL sources. Includes PostgreSQL shared-reader support.
- **Live queue streaming**: New `QueueReader` for tailing queue files via polling, `consume: immediate` config for live consumption, file-based done sentinels, and fail-fast termination via context cancellation.
- **Explicit DDL constraints via columns DSL**: Declare `NOT NULL`, `UNIQUE`, `PRIMARY KEY`, and column comments through the `columns:` modifier DSL at CREATE time, independent of schema-migration settings. Adds ClickHouse data-skipping index injection and column comments across multiple backends (BigQuery, ClickHouse, Postgres, Snowflake, etc.).
- **Unique constraints & advanced index options**: Added unique constraints and advanced index options to schema migration.
- **`on_failure: warn` warning status**: New `ExecStatusWarning` so steps with `on_failure: warn` are marked "warning" instead of "success"/"error", bubbling up through nested groups to the overall pipeline.
- **Concurrency for hook group loops**: Added concurrency support for `HookGroup` loops with warning propagation.
- **Auto-inject current schema for bare table names**: New `CurrentSchema()` on the Connection interface (with Oracle override via `SYS_CONTEXT`) resolves and injects the current schema when a source stream uses an unqualified table name.
- **Snowflake key-pair auth: multiple key formats**: `getEncodedPrivateKey` now accepts PEM, base64-encoded DER, or raw DER PKCS#8 private keys.
- **Render state before setup/teardown**: API spec state templates are now rendered before setup and teardown sequences execute, preventing raw template strings in setup payloads.
- **Rename agent mode to runner mode**: "agent" terminology renamed to "runner" throughout (`sling runner`), with backward compatibility for the `sling agent` command and `SLING_AGENT_ID` env var.

### Bug Fixes

- **Binary/blob fidelity on load**: Map native blob types to binary (not text) to prevent UTF-8 replacement corruption; hex-encode binary in CSV and decode via `UNHEX` for MySQL/MariaDB loads.
- **Binary columns across connectors**: Hex-encode binary in BigQuery CSV exports, set `BinaryAsHex` for Snowflake CSV/Parquet stage writes, detect binary in SQL Server BCP imports, and bind binary values as `[]byte` (varbinary) instead of nvarchar.
- **Iceberg time/timez/uuid types**: Map these to native Arrow types in `ColumnsToArrowSchema` and fix bare time-of-day parsing that silently zeroed values to `00:00:00`; broaden time layouts to handle nanosecond precision and timezone suffixes.
- **API sync variables in setup/teardown**: Propagate `{sync.X}` variables into setup and teardown sequences by inheriting the parent endpoint's `syncMap`.
- **API state vars in setup/teardown**: Render state templates so `{state.X}` placeholders resolve during setup and teardown sequences.
- **State race conditions**: Added `sync.RWMutex` to `PipelineState` and `ReplicationState` for safe concurrent group-step access, plus a nil-map panic fix in `SetStateKeyValue`. Pipeline output buffering uses a dedicated mutex to avoid context-lock contention.
- **CDC WAL ack**: Freeze WAL ack during shared reads and flush the slot after write.
- **Queue done signal for record-emitting producers**: Non-`queue_only` producers that also populate a queue now properly signal queue done, preventing immediate consumers from hanging.
- **DuckDB deadlock on cancel/exit**: Added a watcher goroutine and dedicated `kill()` method so context cancellation, process exit, or scanner errors unblock the reader instead of hanging indefinitely.
- **Temp table DDL**: Match `CREATE [TEMP|TEMPORARY] TABLE` variants when injecting primary key constraints, and resolve index column names against known columns to preserve database casing (e.g. Oracle uppercase folding).
- **Pre-merge hook ordering**: Execute pre-merge hooks after `prepareFinal` so hooks have access to the configured target table.
- **`merge_insert` duplicates**: Add `WHERE NOT EXISTS` / `WHERE NOT IN` existence checks to `merge_insert` templates across many connectors (Athena, AzureSQL, BigQuery, ClickHouse, D1, Databricks, DuckDB, Exasol, etc.) to prevent duplicate inserts; mark DuckLake as not supporting indexes.
- **Cloudflare D1**: Buffer request body for retries, properly drain/close response bodies to fix leaks, and fix an incorrect JSON tag on the exec response duration field.
