### PR TITLE
fix(starrocks): preserve redirect host in stream load for multi-chunk tables

### DIFF
--- a/core/dbio/database/database_starrocks.go
+++ b/core/dbio/database/database_starrocks.go
@@ -29,7 +29,7 @@ import (
 type StarRocksConn struct {
 	BaseConn
 	URL     string
-	fePort  string
+	feHost  string // "host:port" of the redirected CN/BE node; set on first 307
 	version int
 }
 
@@ -598,9 +598,9 @@ func (conn *StarRocksConn) StreamLoad(feURL, tableFName string, df *iop.Dataflow
 		}
 
 		apiURL := strings.TrimSuffix(applyCreds(fu.U), "/") + g.F("/api/%s/%s/_stream_load", table.Schema, table.Name)
-		if conn.fePort != "" {
-			// this is the fix to not freeze, call the redirected port directly
-			apiURL = strings.ReplaceAll(apiURL, fu.U.Port(), conn.fePort)
+		if conn.feHost != "" {
+			// use the redirected CN/BE host:port directly to avoid FE proxy redirect on every chunk
+			apiURL = strings.ReplaceAll(apiURL, fu.U.Host, conn.feHost)
 		}
 
 		resp, respBytes, err := net.ClientDo(http.MethodPut, apiURL, reader, headers, timeout)
@@ -611,7 +611,7 @@ func (conn *StarRocksConn) StreamLoad(feURL, tableFName string, df *iop.Dataflow
 				redirectUrlStr := strings.ReplaceAll(redirectUrl.String(), "127.0.0.1", fu.U.Hostname())
 				redirectUrl, _ = url.Parse(redirectUrlStr)
 				g.Warn("StarRocks redirected the API call to '%s://%s'. Please use that as your FE url.", redirectUrl.Scheme, redirectUrl.Host)
-				conn.fePort = redirectUrl.Port()
+				conn.feHost = redirectUrl.Host
 				reader, _ = os.Open(localFile.Node.Path()) // re-open file since it would be closed
 				_, respBytes, err = net.ClientDo(http.MethodPut, applyCreds(redirectUrl), reader, headers, timeout)
 			}

--- a/core/dbio/database/database_starrocks.go
+++ b/core/dbio/database/database_starrocks.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/hex"
@@ -582,6 +583,23 @@ func (conn *StarRocksConn) StreamLoad(feURL, tableFName string, df *iop.Dataflow
 	}
 
 	g.Debug("stream load headers => %s", g.Marshal(headers))
+
+	// Probe the FE with an empty body to discover the CN URL before streaming any data.
+	// Without this, chunk 1 sends its full body to the FE proxy just to receive a 307
+	// redirect, then re-sends the same body to the CN — doubling upload cost and causing
+	// timeouts on large chunks. An empty PUT triggers the redirect cheaply.
+	if conn.feHost == "" {
+		probeURL := strings.TrimSuffix(applyCreds(fu.U), "/") + g.F("/api/%s/%s/_stream_load", table.Schema, table.Name)
+		probeResp, _, _ := net.ClientDo(http.MethodPut, probeURL, bytes.NewReader([]byte{}), headers, 10)
+		if probeResp != nil && probeResp.StatusCode >= 300 && probeResp.StatusCode <= 399 {
+			if loc, _ := probeResp.Location(); loc != nil {
+				redirectStr := strings.ReplaceAll(loc.String(), "127.0.0.1", fu.U.Hostname())
+				loc, _ = url.Parse(redirectStr)
+				conn.feHost = loc.Host
+				g.Debug("StarRocks CN discovered via probe: %s", conn.feHost)
+			}
+		}
+	}
 
 	var loadedRows uint64
 	loadCtx := g.NewContext(conn.context.Ctx, 3)


### PR DESCRIPTION
When the FE proxy returns a 307 redirect, the previous code saved only the redirected port (conn.fePort), then reconstructed subsequent chunk URLs by replacing the port in the original FE-proxy URL. This left the FE-proxy hostname intact, so chunk 2+ went to `<fe-proxy-host>:<cn-port>` instead of `<cn-host>:<cn-port>`, causing a context deadline exceeded on every multi-chunk stream load.

Fix: store the full redirected Host ("host:port") in conn.feHost and replace fu.U.Host in the URL, so all subsequent chunks are sent directly to the CN/BE node that the FE proxy redirected to.