### PR TITLE
Implemented the credential-chain fallback for Redshift

### DIFF
--- a/core/dbio/database/database_aws.go
+++ b/core/dbio/database/database_aws.go
@@ -1,0 +1,49 @@
+package database
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/flarco/g"
+)
+
+// loadAWSCredentialsFromChain loads AWS credentials from the default credential chain
+// (environment variables, shared config profiles, IAM roles, etc.) and populates the
+// connection properties so they can be used by the database or filesystem clients.
+func loadAWSCredentialsFromChain(conn Connection) error {
+	g.Debug("Loading AWS credentials from default credential chain")
+
+	ctx := context.Background()
+	if conn.Context() != nil && conn.Context().Ctx != nil {
+		ctx = conn.Context().Ctx
+	}
+
+	configOptions := []func(*config.LoadOptions) error{}
+	if profile := conn.GetProp("AWS_PROFILE", "PROFILE"); profile != "" {
+		configOptions = append(configOptions, config.WithSharedConfigProfile(profile))
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx, configOptions...)
+	if err != nil {
+		return g.Error(err, "Failed to load AWS configuration from credential chain")
+	}
+
+	creds, err := cfg.Credentials.Retrieve(ctx)
+	if err != nil {
+		return g.Error(err, "Failed to retrieve AWS credentials from credential chain")
+	}
+
+	conn.SetProp("AWS_ACCESS_KEY_ID", creds.AccessKeyID)
+	conn.SetProp("AWS_SECRET_ACCESS_KEY", creds.SecretAccessKey)
+	if creds.SessionToken != "" {
+		conn.SetProp("AWS_SESSION_TOKEN", creds.SessionToken)
+	}
+
+	// Set region if not already set
+	if conn.GetProp("AWS_REGION", "AWS_DEFAULT_REGION", "REGION", "DEFAULT_REGION") == "" && cfg.Region != "" {
+		conn.SetProp("AWS_REGION", cfg.Region)
+	}
+
+	g.Debug("Successfully loaded AWS credentials from credential chain")
+	return nil
+}

--- a/core/dbio/database/database_databricks.go
+++ b/core/dbio/database/database_databricks.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/databricks/databricks-sql-go/driverctx"
@@ -267,34 +266,7 @@ func (conn *DatabricksConn) generateSessionToken() error {
 
 // loadAWSCredentialsFromChain attempts to load credentials using the default AWS credential chain
 func (conn *DatabricksConn) loadAWSCredentialsFromChain() error {
-	g.Debug("Loading AWS credentials from default credential chain")
-
-	// Load default AWS config (will use IAM roles, profiles, env vars, etc.)
-	cfg, err := config.LoadDefaultConfig(context.Background())
-	if err != nil {
-		return g.Error(err, "Failed to load AWS configuration from credential chain")
-	}
-
-	// Get credentials
-	creds, err := cfg.Credentials.Retrieve(context.Background())
-	if err != nil {
-		return g.Error(err, "Failed to retrieve AWS credentials from credential chain")
-	}
-
-	// Set the credentials
-	conn.SetProp("AWS_ACCESS_KEY_ID", creds.AccessKeyID)
-	conn.SetProp("AWS_SECRET_ACCESS_KEY", creds.SecretAccessKey)
-	if creds.SessionToken != "" {
-		conn.SetProp("AWS_SESSION_TOKEN", creds.SessionToken)
-	}
-
-	// Set region if not already set
-	if conn.GetProp("AWS_REGION") == "" && cfg.Region != "" {
-		conn.SetProp("AWS_REGION", cfg.Region)
-	}
-
-	g.Debug("Successfully loaded AWS credentials from credential chain")
-	return nil
+	return loadAWSCredentialsFromChain(conn)
 }
 
 // CopyViaS3 uses the Databricks COPY INTO command from AWS S3

--- a/core/dbio/database/database_redshift.go
+++ b/core/dbio/database/database_redshift.go
@@ -92,6 +92,8 @@ func (conn *RedshiftConn) GenerateDDL(table Table, data iop.Dataset, temporary b
 // adding fallbacks for credentials for wider compatibility.
 // See: https://github.com/slingdata-io/sling-cli/issues/571
 func (conn *RedshiftConn) getS3Props() []string {
+	conn.ensureAWSCredentials()
+
 	s3Props := conn.PropArr()
 
 	awsID := conn.GetProp("AWS_ACCESS_KEY_ID")
@@ -119,10 +121,46 @@ func (conn *RedshiftConn) getS3Props() []string {
 	if awsProfile != "" {
 		s3Props = append(s3Props, "PROFILE="+awsProfile)
 	}
+	if awsRegion := conn.GetProp("AWS_REGION", "AWS_DEFAULT_REGION", "REGION", "DEFAULT_REGION"); awsRegion != "" {
+		s3Props = append(s3Props, "REGION="+awsRegion)
+	}
 	return s3Props
 }
 
+// ensureAWSCredentials ensures AWS credentials are available for Redshift's COPY/UNLOAD
+// commands and the S3 filesystem. When no explicit credentials or role are provided, it
+// falls back to the default AWS credential chain (environment variables, shared config
+// profiles, IAM roles), similar to the USE_ENVIRONMENT option for S3. This allows
+// Redshift clusters in private subnets to avoid STS-based role assumption and instead use
+// static credentials resolved from the environment.
+func (conn *RedshiftConn) ensureAWSCredentials() (ok bool, err error) {
+	awsID := conn.GetProp("AWS_ACCESS_KEY_ID")
+	awsKey := conn.GetProp("AWS_SECRET_ACCESS_KEY")
+	awsToken := conn.GetProp("AWS_SESSION_TOKEN")
+	awsRole := conn.GetProp("AWS_ROLE_ARN")
+
+	// explicit credentials or role already provided, nothing to do
+	if (awsID != "" && awsKey != "") || awsToken != "" || awsRole != "" {
+		return true, nil
+	}
+
+	// explicitly opted out of using the environment credential chain
+	if strings.EqualFold(conn.GetProp("USE_ENVIRONMENT"), "false") {
+		return false, nil
+	}
+
+	// fall back to the default AWS credential chain
+	err = loadAWSCredentialsFromChain(conn)
+	if err != nil {
+		return false, g.Error(err, "Could not load AWS credentials. Set 'AWS_ACCESS_KEY_ID'/'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN', 'AWS_ROLE_ARN', or set 'USE_ENVIRONMENT=true' to use the AWS credential chain")
+	}
+
+	return true, nil
+}
+
 func (conn *RedshiftConn) makeCopyCredentialString() (cred string) {
+
+	conn.ensureAWSCredentials()
 
 	AwsID := conn.GetProp("AWS_ACCESS_KEY_ID")
 	AwsAccessKey := conn.GetProp("AWS_SECRET_ACCESS_KEY")
@@ -163,6 +201,13 @@ func (conn *RedshiftConn) Unload(ctx *g.Context, fileFormat dbio.FileType, table
 
 	if conn.GetProp("AWS_BUCKET") == "" {
 		return "", g.Error("need to set AWS_BUCKET")
+	}
+
+	ok, err := conn.ensureAWSCredentials()
+	if err != nil {
+		return "", g.Error(err, "Could not load AWS credentials for Redshift")
+	} else if !ok {
+		return "", g.Error("Need to set 'AWS_ACCESS_KEY_ID' and 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN', 'AWS_ROLE_ARN' (use 'default' for the cluster's default IAM role), or set 'USE_ENVIRONMENT=true' to use the AWS credential chain to unload from redshift to S3")
 	}
 
 	AwsID := conn.GetProp("AWS_ACCESS_KEY_ID")
@@ -449,15 +494,14 @@ func (conn *RedshiftConn) GenerateMergeSQLWithStrategy(srcTable string, tgtTable
 
 // CopyFromS3 uses the COPY INTO Table command from AWS S3
 func (conn *RedshiftConn) CopyFromS3(tableFName, s3Path string, columns iop.Columns) (count uint64, err error) {
-	AwsID := conn.GetProp("AWS_ACCESS_KEY_ID")
-	AwsAccessKey := conn.GetProp("AWS_SECRET_ACCESS_KEY")
-	AwsSessionToken := conn.GetProp("AWS_SESSION_TOKEN")
-	AwsRole := conn.GetProp("AWS_ROLE_ARN")
-
-	if (AwsID == "" || AwsAccessKey == "") && AwsSessionToken == "" && AwsRole == "" {
-		err = g.Error("Need to set 'AWS_ACCESS_KEY_ID' and 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN', or 'AWS_ROLE_ARN' (use 'default' for the cluster's default IAM role) to copy to redshift from S3")
+	ok, err := conn.ensureAWSCredentials()
+	if err != nil {
+		return 0, g.Error(err, "Could not load AWS credentials for Redshift")
+	} else if !ok {
+		err = g.Error("Need to set 'AWS_ACCESS_KEY_ID' and 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN', 'AWS_ROLE_ARN' (use 'default' for the cluster's default IAM role), or set 'USE_ENVIRONMENT=true' to use the AWS credential chain to copy to redshift from S3")
 		return
 	}
+
 	credentialExpr := conn.makeCopyCredentialString()
 
 	tgtColumns := conn.Template().QuoteNames(columns.Names()...)

--- a/core/dbio/database/database_redshift_test.go
+++ b/core/dbio/database/database_redshift_test.go
@@ -1,0 +1,96 @@
+package database
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestRedshiftConn(t *testing.T) *RedshiftConn {
+	t.Helper()
+	conn, err := NewConnContext(
+		context.Background(),
+		"redshift://testuser:testpass@testhost.example.com:5439/testdb",
+	)
+	if err != nil {
+		t.Fatalf("could not create redshift conn: %s", err)
+	}
+	rs, ok := conn.(*RedshiftConn)
+	if !ok {
+		t.Fatalf("expected *RedshiftConn, got %T", conn)
+	}
+	return rs
+}
+
+// ensureAWSCredentials should short-circuit when explicit credentials are provided,
+// without attempting to load from the AWS credential chain.
+func TestRedshiftEnsureAWSCredentialsExplicit(t *testing.T) {
+	conn := newTestRedshiftConn(t)
+	conn.SetProp("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE")
+	conn.SetProp("AWS_SECRET_ACCESS_KEY", "secretkey")
+
+	ok, err := conn.ensureAWSCredentials()
+	assert.NoError(t, err)
+	assert.True(t, ok)
+}
+
+// ensureAWSCredentials should honor USE_ENVIRONMENT=false and not attempt the chain.
+func TestRedshiftEnsureAWSCredentialsOptedOut(t *testing.T) {
+	conn := newTestRedshiftConn(t)
+	conn.SetProp("USE_ENVIRONMENT", "false")
+
+	ok, err := conn.ensureAWSCredentials()
+	assert.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestRedshiftMakeCopyCredentialString(t *testing.T) {
+	t.Run("static credentials with session token", func(t *testing.T) {
+		conn := newTestRedshiftConn(t)
+		conn.SetProp("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE")
+		conn.SetProp("AWS_SECRET_ACCESS_KEY", "secretkey")
+		conn.SetProp("AWS_SESSION_TOKEN", "sessiontoken")
+
+		cred := conn.makeCopyCredentialString()
+		assert.Equal(t,
+			"credentials 'aws_access_key_id=AKIAEXAMPLE;aws_secret_access_key=secretkey;token=sessiontoken'",
+			cred,
+		)
+	})
+
+	t.Run("iam role arn", func(t *testing.T) {
+		conn := newTestRedshiftConn(t)
+		conn.SetProp("AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/MyRole")
+
+		cred := conn.makeCopyCredentialString()
+		assert.Equal(t,
+			"iam_role 'arn:aws:iam::123456789012:role/MyRole'",
+			cred,
+		)
+	})
+
+	t.Run("iam role default", func(t *testing.T) {
+		conn := newTestRedshiftConn(t)
+		conn.SetProp("AWS_ROLE_ARN", "default")
+
+		cred := conn.makeCopyCredentialString()
+		assert.Equal(t, "iam_role default", cred)
+	})
+}
+
+// getS3Props should include the region and propagate explicit credentials.
+func TestRedshiftGetS3Props(t *testing.T) {
+	conn := newTestRedshiftConn(t)
+	conn.SetProp("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE")
+	conn.SetProp("AWS_SECRET_ACCESS_KEY", "secretkey")
+	conn.SetProp("AWS_REGION", "eu-west-1")
+
+	props := conn.getS3Props()
+	joined := strings.Join(props, " ")
+
+	assert.Contains(t, joined, "ACCESS_KEY_ID=AKIAEXAMPLE")
+	assert.Contains(t, joined, "SECRET_ACCESS_KEY=secretkey")
+	assert.Contains(t, joined, "REGION=eu-west-1")
+}


### PR DESCRIPTION
Possible fix for #776

I used DeepseekV4.

I built the binary with these changes and the same replication that was previously failing now succeeds.

- core/dbio/database/database_aws.go (new):
  - shared loadAWSCredentialsFromChain(conn) that loads the default AWS credential chain (env vars, profile via AWS_PROFILE, IAM role) and populates AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, AWS_REGION on the connection.

- core/dbio/database/database_databricks.go (refactor):
  - refactored to use the shared helper now in core/dbio/database/database_aws.go (above).

- core/dbio/database/database_redshift.go:
  - ensureAWSCredentials()
    - no-ops if explicit creds/role exist; skips if USE_ENVIRONMENT=false; otherwise falls back to the credential chain. This produces static creds for COPY/UNLOAD, so Redshift only needs S3 reachability (your working case), never STS.
  - Wired into getS3Props (also now passes REGION), makeCopyCredentialString, CopyFromS3, and Unload with clearer error messages mentioning USE_ENVIRONMENT=true.

- core/dbio/database/database_redshift_test.go (new):
  -  unit tests for the fast-paths and credential-string generation.
  - Usage: with AWS_BUCKET set and no AWS_ACCESS_KEY_ID, AWS_ROLE_ARN, sling now auto-uses the host's credential chain. Set USE_ENVIRONMENT=false to disable. AWS_ROLE_ARN=default remains available for clusters with a default role.