### PR TITLE
V1.6.1

### DIFF
--- a/cmd/sling/resource/llm_PIPELINE.md
+++ b/cmd/sling/resource/llm_PIPELINE.md
@@ -51,7 +51,7 @@ The Sling MCP tool provides these pipeline commands:
 - `pipeline/validate` - Parse and validate the pipeline configuration.
 
 There is no MCP `run` action. Execute pipelines with the CLI: `sling run -p /path/to/pipeline.yaml`.
-There is no MCP `build` action. Execute SQL models with the CLI: `sling build`.
+There is no MCP `build` action. Execute SQL models with the CLI: `sling build run`.
 
 ---
 

--- a/cmd/sling/resource/llm_PLATFORM.md
+++ b/cmd/sling/resource/llm_PLATFORM.md
@@ -632,15 +632,17 @@ Set `SLING_PLATFORM_HOST=https://your-host.example.com` before any command. The 
 
 ## 18. Platform MCP HTTP server
 
-The master also speaks MCP Streamable HTTP at `POST|GET|DELETE /mcp`. Authenticate with the same project token:
+The server also speaks MCP Streamable HTTP at `POST|GET|DELETE /mcp`. Authenticate with the same project token:
 
 ```
 Authorization: Sling-Project-Token <uuid>
 ```
 
+Claude Code:
+
 ```bash
-claude mcp add --transport http sling-platform https://<master>/mcp \
+claude mcp add --transport http sling-platform https://<server>/mcp \
   --header "Authorization: Sling-Project-Token <token>"
 ```
 
-Tools: `project`, `file`, `job`, `execution`, `connection`, `compile`, `monitor`, `infra`. Call `docs` first. `job.run` returns `{exec_id}` — poll `execution.list`.
+Tools (one coarse tool per domain, `action` + `input`): `project`, `file`, `job`, `execution`, `connection`, `compile`, `monitor`, `infra`. Call `docs` on a tool before other actions. `job.run` returns `{exec_id}` — poll `execution.list` (stateless; no server push). The project must enable MCP in Settings → Project. Discover/preview/exec (`connection.discover`, `connection.preview`, `connection.exec`, `compile.replication_preview`) require an online agent and follow Enable Data Preview. `connection.exec` runs **read-only** SQL only — queries are parsed and must be a single read-only statement; mutating statements, DDL, and locking clauses are rejected. Never issue destructive or altering commands (INSERT/UPDATE/DELETE/DDL). Long queries are supported; client disconnect cancels the query. Optional `query_id` on `exec` plus `connection.exec_cancel` cancels from another session. Token, user, org, billing, and git-write routes are not exposed.

--- a/cmd/sling/resource/llm_PLATFORM.md
+++ b/cmd/sling/resource/llm_PLATFORM.md
@@ -13,7 +13,7 @@
 9. [`sling platform jobs get`](#9-sling-platform-jobs-get)
 10. [`sling platform jobs save`](#10-sling-platform-jobs-save)
 11. [`sling platform jobs delete`](#11-sling-platform-jobs-delete)
-12. [`sling platform execs`](#12-sling-platform-execs)
+12. [`sling platform executions`](#12-sling-platform-executions)
 13. [`sling platform files`](#13-sling-platform-files)
 14. [`sling platform connections`](#14-sling-platform-connections)
 15. [Job Payload Reference](#15-job-payload-reference)
@@ -272,21 +272,21 @@ Uses `POST /project/job/delete` with body `{"job_id": "<id>"}`.
 
 ---
 
-## 12. `sling platform execs`
+## 12. `sling platform executions`
 
 Manage and inspect executions.
 
-### `execs list`
+### `executions list`
 
 List recent executions with a job-name column, derived status, and optional time range. Newest first.
 
 ```bash
-sling platform execs list                                    # default: 10 rows, table
-sling platform execs list --status error --limit 5          # filter by status
-sling platform execs list --job-id job_abc123 -o json       # scope to one job, JSON
-sling platform execs list --since 24h                        # last 24 hours
-sling platform execs list --since 7d --status success
-sling platform execs list --since 2026-04-10 --until 2026-04-17
+sling platform executions list                                    # default: 10 rows, table
+sling platform executions list --status error --limit 5          # filter by status
+sling platform executions list --job-id job_abc123 -o json       # scope to one job, JSON
+sling platform executions list --since 24h                        # last 24 hours
+sling platform executions list --since 7d --status success
+sling platform executions list --since 2026-04-10 --until 2026-04-17
 ```
 
 Flags:
@@ -299,37 +299,37 @@ Flags:
 
 Columns (table): `Name`, `Exec ID`, `Job ID`, `Start Time`, `Rows`, `Bytes`, `Status`. Status is derived from per-state counts (Running > Queued > Stalled > Cancelled > Created > Success > Error). When the source run wasn't triggered from a saved job, `Name` falls back to the replication name or `cli-<md5>` for ad-hoc CLI runs.
 
-### `execs status <exec-id>`
+### `executions status <exec-id>`
 
 Fetch the full server-side status record for one execution as pretty-printed JSON.
 
 ```bash
-sling platform execs status exec_abc123
-sling platform execs status exec_abc123 | jq '.status_map'
+sling platform executions status exec_abc123
+sling platform executions status exec_abc123 | jq '.status_map'
 ```
 
 Uses `GET /execution/list?filters=%7B%22exec_id%22%3A%22...%22%7D`.
 
-### `execs cancel <exec-id>`
+### `executions cancel <exec-id>`
 
 Cancel a running execution.
 
 ```bash
-sling platform execs cancel exec_abc123
+sling platform executions cancel exec_abc123
 ```
 
 Uses `POST /execution/cancel` with body `{"exec_id": "<id>"}`.
 
-### `execs log <exec-id>`
+### `executions log <exec-id>`
 
 Print the full log output captured during an execution. Each task/step's log is prefixed with a `=== <name> (status=...) ===` banner. The log contains ANSI color codes by default; use `--no-color` to strip them for grep/diff/save-to-file.
 
 ```bash
-sling platform execs log 3CUJmxllsG8YC1kDYGzU6jYjS5X                       # all streams, colored
-sling platform execs log 3CUJmxllsG8YC1kDYGzU6jYjS5X --no-color             # plain text
-sling platform execs log 3CUJmxllsG8YC1kDYGzU6jYjS5X --task users           # only the "users" stream
-sling platform execs log 3CUJmxllsG8YC1kDYGzU6jYjS5X --status error         # only errored tasks/steps
-sling platform execs log 3CUJmxllsG8YC1kDYGzU6jYjS5X -o json > tasks.json   # raw task records
+sling platform executions log 3CUJmxllsG8YC1kDYGzU6jYjS5X                       # all streams, colored
+sling platform executions log 3CUJmxllsG8YC1kDYGzU6jYjS5X --no-color             # plain text
+sling platform executions log 3CUJmxllsG8YC1kDYGzU6jYjS5X --task users           # only the "users" stream
+sling platform executions log 3CUJmxllsG8YC1kDYGzU6jYjS5X --status error         # only errored tasks/steps
+sling platform executions log 3CUJmxllsG8YC1kDYGzU6jYjS5X -o json > tasks.json   # raw task records
 ```
 
 Flags:

--- a/cmd/sling/resource/llm_PLATFORM.md
+++ b/cmd/sling/resource/llm_PLATFORM.md
@@ -208,7 +208,7 @@ Uses `GET /project/job/get?job_id=<id>`. The positional argument must begin with
 
 ## 10. `sling platform jobs save`
 
-Create a job (if `id` is empty/missing) or update an existing one (if `id` is present). A single command handles both.
+Create a job (if `id` is empty/missing) or update an existing one (if `id` is present). A single command handles both. The auto-created default job (`default: true`) is not editable — omit `id` and create a new job to set a schedule.
 
 ```bash
 # Create: omit id

--- a/cmd/sling/resource/llm_PYTHON.md
+++ b/cmd/sling/resource/llm_PYTHON.md
@@ -27,10 +27,11 @@ from sling.options import SourceOptions, TargetOptions
 - **Source**: `src_conn`, `src_stream`, `src_options`
 - **Target**: `tgt_conn`, `tgt_object`, `tgt_options`
 - **Transforms**: `select`, `where`, `transforms`, `columns`
-- **Mode**: `mode` (full-refresh, incremental, truncate, snapshot, backfill)
+- **Mode**: `mode` (full-refresh, incremental, truncate, snapshot, backfill, definition-only, change-capture)
 - **Limits**: `limit`, `offset`, `range`
 - **Keys**: `primary_key`, `update_key`
-- **Config**: `env`, `debug`, `trace`
+- **CDC**: `cdc_options`
+- **Config**: `env`, `replication`, `pipeline`, `directory`, `job`, `debug`, `trace`, `home_dir`
 - **Python-specific**: `input` (data input from Python)
 
 ### 2. Replication Class

--- a/cmd/sling/resource/llm_REPLICATION.md
+++ b/cmd/sling/resource/llm_REPLICATION.md
@@ -185,7 +185,7 @@ streams:
     object: <target_table_or_file>
     
     # Load behavior
-    mode: full-refresh | incremental | truncate | snapshot | backfill
+    mode: full-refresh | incremental | truncate | snapshot | backfill | definition-only | change-capture
     disabled: true | false
     
     # Key columns
@@ -260,6 +260,8 @@ streams:
 | `truncate` | Clear table, preserve structure | Refresh while keeping DDL |
 | `snapshot` | Append with timestamp | Historical data tracking |
 | `backfill` | Load specific date/ID ranges | Historical data recovery |
+| `definition-only` | Create target table/file structure without data | Schema-only setup |
+| `change-capture` | Stream transaction-log changes (inserts, updates, deletes) | Real-time CDC sync |
 
 ### Incremental Mode Strategies
 

--- a/cmd/sling/resource/mcp.yaml
+++ b/cmd/sling/resource/mcp.yaml
@@ -84,7 +84,7 @@ tools:
     - `action` (string, required): The database action to perform. Valid values:
       - `"get_schemata"` - Get database schemata (schemas, tables, columns)
       - `"get_schemas"` - Get list of schema names
-      - `"query"` - Execute SQL queries (read-only)
+      - `"query"` - Execute SQL queries
       - `"query_cancel"` - Cancel a running query by query_id
       - `"get_columns"` - Get column metadata for a table
     - `input` (object, required): The input parameters for the specific action. The structure varies based on the action:
@@ -106,7 +106,7 @@ tools:
     - `transient` (boolean, optional): Whether to use a transient connection (default: false)
     - `query_id` (string, optional): Client-supplied id (`[A-Za-z0-9_-]`, max 64) so a concurrent `query_cancel` can target this query. Generated if omitted.
 
-      This action executes a SQL query on a database connection and return the results. Long queries are supported. Interrupting the client (Ctrl+C / Escape) cancels the running query. Pass an optional `query_id` to cancel from another concurrent call via `query_cancel`. **WARNING: Only use this tool for SELECT queries and other read-only operations. Never execute destructive queries such as DELETE, DROP, TRUNCATE, ALTER, UPDATE, INSERT, or any other data modification operations.**
+      This action executes a SQL query on a database connection and return the results. Long queries are supported. Interrupting the client (Ctrl+C / Escape) cancels the running query. Pass an optional `query_id` to cancel from another concurrent call via `query_cancel`.
 
       *   If a destructive operation (e.g., dropping an object, deleting significant data, altering table structures) is deemed necessary, **DO NOT execute it directly**. Instead, formulate the required SQL query/statement and **return it to the USER for manual review and execution**.
       *   Always use the least number of columns, to minimize computation and the amount of data being retrieved.

--- a/cmd/sling/resource/mcp.yaml
+++ b/cmd/sling/resource/mcp.yaml
@@ -468,9 +468,9 @@ tools:
     
     **To execute SQL models, use the CLI** (there is no MCP `build` action):
     ```
-    sling build
-    sling build --compile
-    sling build -s stg_users,fct_orders
+    sling build run
+    sling build compile
+    sling build run -s stg_users,fct_orders
     ```
     
     **Output**: The output format depends on the action and audience:

--- a/cmd/sling/sling_assist.go
+++ b/cmd/sling/sling_assist.go
@@ -99,6 +99,7 @@ func init() {
 // the user must run `sling assist setup`.
 func processAssist(c *g.CliSC) (ok bool, err error) {
 	ok = true
+	setAssistTel(c)
 	if notice, refreshErr := assist.AutoRefresh(context.Background()); refreshErr == nil && notice != "" {
 		fmt.Fprintln(os.Stderr, notice)
 	}
@@ -523,6 +524,67 @@ func runAssistError(c *g.CliSC) error {
 		fmt.Printf("  sling assist report --id <exec_id>   # share a redacted report\n")
 	}
 	return nil
+}
+
+func setAssistTel(c *g.CliSC) {
+	vals := flatVals(c)
+	ask := ""
+	if len(flaggy.TrailingArguments) > 0 {
+		ask = strings.TrimSpace(strings.Join(flaggy.TrailingArguments, " "))
+	}
+	resumeSet, _ := resumeFromArgs(os.Args)
+	prof, profileExists, _ := assist.LoadProfile()
+
+	kind := "open"
+	switch {
+	case c.UsedSC() == "setup":
+		kind = "setup"
+	case c.UsedSC() == "error":
+		kind = "error"
+	case c.UsedSC() == "report":
+		kind = "report"
+	case resumeSet:
+		kind = "resume"
+	case !profileExists && strings.TrimSpace(cast.ToString(vals["out"])) == "":
+		kind = "setup"
+	case strings.TrimSpace(cast.ToString(vals["id"])) != "":
+		kind = "investigate"
+	case ask != "":
+		kind = "ask"
+	}
+
+	tel := g.M(
+		"session_kind", kind,
+		"headless", cast.ToBool(vals["non-interactive"]),
+		"nested", assist.NestedLaunch(),
+		"has_ask", ask != "",
+		"has_id", strings.TrimSpace(cast.ToString(vals["id"])) != "",
+		"has_model", strings.TrimSpace(cast.ToString(vals["model"])) != "",
+	)
+	if v := strings.TrimSpace(cast.ToString(vals["agent"])); v != "" {
+		tel["agent"] = v
+	} else if profileExists && prof.Agent != "" {
+		tel["agent"] = prof.Agent
+	}
+	if kind == "setup" {
+		scope := "user"
+		if strings.EqualFold(cast.ToString(vals["scope"]), "project") {
+			scope = "project"
+		}
+		tel["scope"] = scope
+		tel["first_run"] = !profileExists
+	}
+	if kind == "report" {
+		channel := "review"
+		switch {
+		case cast.ToBool(vals["github"]):
+			channel = "github"
+		case cast.ToBool(vals["email"]):
+			channel = "email"
+		}
+		tel["channel"] = channel
+	}
+	env.SetTelVal("assist", g.Marshal(tel))
 }
 
 // flatVals returns the val map from the active subcommand. CliSC stores per-

--- a/cmd/sling/sling_build.go
+++ b/cmd/sling/sling_build.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/flarco/g"
@@ -214,6 +213,11 @@ func processBuild(c *g.CliSC) (ok bool, err error) {
 
 	opts.Compile = compileMode
 
+	os.Setenv("SLING_CLI", "TRUE")
+	if os.Getenv("SLING_RUN_MODE") == "" {
+		os.Setenv("SLING_RUN_MODE", "build")
+	}
+
 	// Validate flag combinations
 	if opts.Prod && opts.Schema != "" {
 		return ok, g.Error("cannot combine --prod and --schema")
@@ -223,7 +227,7 @@ func processBuild(c *g.CliSC) (ok bool, err error) {
 	// work with (no --target, no -r), show help instead of walking the tree.
 	// This avoids slurping every .sql file under cwd as "models".
 	if opts.Target == "" && !opts.Recursive {
-		if _, err := os.Stat(filepath.Join(projectPath, build.ConfigFileName)); os.IsNotExist(err) {
+		if _, found := build.FindConfigFile(projectPath); !found {
 			flaggy.ShowHelp("")
 			return ok, nil
 		}
@@ -260,6 +264,9 @@ func processBuild(c *g.CliSC) (ok bool, err error) {
 	// Execute the build
 	if err := b.Execute(); err != nil {
 		return ok, g.Error(err, "build execution failed")
+	}
+	if err := testOutput(int64(b.ExecRows), b.ExecBytes, 0); err != nil {
+		return ok, err
 	}
 	return ok, nil
 }

--- a/cmd/sling/sling_build.go
+++ b/cmd/sling/sling_build.go
@@ -218,6 +218,16 @@ func processBuild(c *g.CliSC) (ok bool, err error) {
 		os.Setenv("SLING_RUN_MODE", "build")
 	}
 
+	// Print the same startup marker as `sling run` so the agent can detect
+	// that the process is alive before the first build-status heartbeat.
+	if !env.IsThreadChild {
+		if env.NoColor {
+			g.Info(env.Marker)
+		} else {
+			g.Info(env.CyanString(env.Marker))
+		}
+	}
+
 	// Validate flag combinations
 	if opts.Prod && opts.Schema != "" {
 		return ok, g.Error("cannot combine --prod and --schema")

--- a/cmd/sling/sling_build.go
+++ b/cmd/sling/sling_build.go
@@ -14,7 +14,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var cliBuildFlags = []g.Flag{
+var buildPathFlag = g.Flag{
+	Name:        "path",
+	Type:        "string",
+	Description: "The project directory path (default: current directory).\n",
+	Required:    false,
+}
+
+var buildCommonFlags = []g.Flag{
 	{
 		Name:        "target",
 		ShortName:   "t",
@@ -33,12 +40,6 @@ var cliBuildFlags = []g.Flag{
 		Description: "Exclude models matching pattern.",
 	},
 	{
-		Name:        "full-refresh",
-		ShortName:   "f",
-		Type:        "bool",
-		Description: "Force full-refresh for all models.",
-	},
-	{
 		Name:        "schema",
 		Type:        "string",
 		Description: "Override dev schema (forces dev mode, cannot combine with --prod).",
@@ -54,53 +55,10 @@ var cliBuildFlags = []g.Flag{
 		Description: "Variables as YAML/JSON string.",
 	},
 	{
-		Name:        "compile",
-		ShortName:   "c",
-		Type:        "bool",
-		Description: "Compile only — show SQL + DAG, don't execute.",
-	},
-	{
-		Name:        "list",
-		ShortName:   "l",
-		Type:        "bool",
-		Description: "List selected models and exit.",
-	},
-	{
-		Name:        "fail-fast",
-		ShortName:   "x",
-		Type:        "bool",
-		Description: "Stop on first failure (in-flight models finish).",
-	},
-	{
-		Name:        "no-seeds",
-		Type:        "bool",
-		Description: "Skip seed loading.",
-	},
-	{
-		Name:        "range",
-		Type:        "string",
-		Description: "Backfill range for incremental models: 'start,end[,step]'. E.g. '2024-01-01,2024-12-31,1mo'. Does not advance SLING_STATE.",
-	},
-	{
-		Name:        "threads",
-		Type:        "string",
-		Description: "Parallel model executions (default: 4).",
-	},
-	{
 		Name:        "recursive",
 		ShortName:   "R",
 		Type:        "bool",
 		Description: "Recursively discover sling_build.yml in immediate subdirectories.",
-	},
-	{
-		Name:        "test",
-		Type:        "bool",
-		Description: "Run declarative data tests only (skip materialization).",
-	},
-	{
-		Name:        "json",
-		Type:        "bool",
-		Description: "Emit machine-readable JSON for --compile / --list.",
 	},
 	{
 		Name:        "debug",
@@ -115,18 +73,103 @@ var cliBuildFlags = []g.Flag{
 	},
 }
 
+var buildRunFlags = []g.Flag{
+	{
+		Name:        "full-refresh",
+		ShortName:   "f",
+		Type:        "bool",
+		Description: "Force full-refresh for all models.",
+	},
+	{
+		Name:        "range",
+		Type:        "string",
+		Description: "Backfill range for incremental models: 'start,end[,step]'. E.g. '2024-01-01,2024-12-31,1mo'. Does not advance SLING_STATE.",
+	},
+	{
+		Name:        "no-seeds",
+		Type:        "bool",
+		Description: "Skip seed loading.",
+	},
+	{
+		Name:        "threads",
+		Type:        "string",
+		Description: "Parallel model executions (default: 4).",
+	},
+	{
+		Name:        "fail-fast",
+		ShortName:   "x",
+		Type:        "bool",
+		Description: "Stop on first failure (in-flight models finish).",
+	},
+}
+
+var buildTestFlags = []g.Flag{
+	{
+		Name:        "threads",
+		Type:        "string",
+		Description: "Parallel model executions (default: 4).",
+	},
+	{
+		Name:        "fail-fast",
+		ShortName:   "x",
+		Type:        "bool",
+		Description: "Stop on first failure (in-flight models finish).",
+	},
+}
+
+var buildOutputFlags = []g.Flag{
+	{
+		Name:        "json",
+		Type:        "bool",
+		Description: "Emit machine-readable JSON.",
+	},
+}
+
+func concatFlags(parts ...[]g.Flag) []g.Flag {
+	n := 0
+	for _, p := range parts {
+		n += len(p)
+	}
+	out := make([]g.Flag, 0, n)
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
+}
+
 var cliBuild = &g.CliSC{
-	Name:                  "build",
-	Description:           "Build and execute SQL models",
-	AdditionalHelpPrepend: "\nA lightweight SQL model builder with dependency resolution, Jinja templating, and incremental materializations.",
-	ExecuteWithoutFlags:   true,
-	Flags:                 cliBuildFlags,
-	PosFlags: []g.Flag{
+	Name:        "build",
+	Description: "Build and execute SQL models",
+	AdditionalHelpPrepend: "\nCommands:\n" +
+		"  run      Materialize models, then run each model's declarative tests\n" +
+		"  list     List selected models without executing\n" +
+		"  test     Run declarative data tests only (skip materialization and seeds)\n" +
+		"  compile  Render SQL and DAG without executing\n",
+	ExecuteWithoutFlags: true,
+	SubComs: []*g.CliSC{
 		{
-			Name:        "path",
-			Type:        "string",
-			Description: "The project directory path (default: current directory).\n",
-			Required:    false,
+			Name:        "run",
+			Description: "Materialize models, then run each model's declarative tests",
+			PosFlags:    []g.Flag{buildPathFlag},
+			Flags:       concatFlags(buildCommonFlags, buildRunFlags),
+		},
+		{
+			Name:        "list",
+			Description: "List selected models without executing",
+			PosFlags:    []g.Flag{buildPathFlag},
+			Flags:       concatFlags(buildCommonFlags, buildOutputFlags),
+		},
+		{
+			Name:        "test",
+			Description: "Run declarative data tests only (skip materialization and seeds)",
+			PosFlags:    []g.Flag{buildPathFlag},
+			Flags:       concatFlags(buildCommonFlags, buildTestFlags, buildOutputFlags),
+		},
+		{
+			Name:        "compile",
+			Description: "Render SQL and DAG without executing",
+			PosFlags:    []g.Flag{buildPathFlag},
+			Flags:       concatFlags(buildCommonFlags, buildOutputFlags),
 		},
 	},
 	ExecProcess: processBuild,
@@ -144,7 +187,29 @@ func processBuild(c *g.CliSC) (ok bool, err error) {
 	}
 
 	projectPath := "."
-	compileMode := false
+
+	switch c.UsedSC() {
+	case "run":
+		// default execute path
+	case "list":
+		opts.List = true
+	case "test":
+		opts.Test = true
+	case "compile":
+		opts.Compile = true
+	default:
+		flaggy.ShowHelp("")
+		for _, a := range os.Args[1:] {
+			if a == "build" || strings.HasPrefix(a, "-") {
+				continue
+			}
+			if a == "run" || a == "list" || a == "test" || a == "compile" {
+				continue
+			}
+			return ok, g.Error("unknown build command %q, expected run, list, test, or compile", a)
+		}
+		return ok, nil
+	}
 
 	for k, v := range c.Vals {
 		switch k {
@@ -176,10 +241,6 @@ func processBuild(c *g.CliSC) (ok bool, err error) {
 				}
 				opts.Vars = varsMap
 			}
-		case "compile":
-			compileMode = cast.ToBool(v)
-		case "list":
-			opts.List = cast.ToBool(v)
 		case "fail-fast":
 			opts.FailFast = cast.ToBool(v)
 		case "no-seeds":
@@ -194,8 +255,6 @@ func processBuild(c *g.CliSC) (ok bool, err error) {
 			}
 		case "recursive":
 			opts.Recursive = cast.ToBool(v)
-		case "test":
-			opts.Test = cast.ToBool(v)
 		case "json":
 			opts.JSON = cast.ToBool(v)
 		case "debug":
@@ -210,8 +269,6 @@ func processBuild(c *g.CliSC) (ok bool, err error) {
 			}
 		}
 	}
-
-	opts.Compile = compileMode
 
 	os.Setenv("SLING_CLI", "TRUE")
 	if os.Getenv("SLING_RUN_MODE") == "" {
@@ -236,7 +293,7 @@ func processBuild(c *g.CliSC) (ok bool, err error) {
 	// If there's no sling_build.yml at the path and the user gave us nothing to
 	// work with (no --target, no -r), show help instead of walking the tree.
 	// This avoids slurping every .sql file under cwd as "models".
-	if opts.Target == "" && !opts.Recursive {
+	if c.UsedSC() == "run" && opts.Target == "" && !opts.Recursive {
 		if _, found := build.FindConfigFile(projectPath); !found {
 			flaggy.ShowHelp("")
 			return ok, nil
@@ -262,7 +319,7 @@ func processBuild(c *g.CliSC) (ok bool, err error) {
 		return ok, nil
 	}
 
-	if compileMode {
+	if opts.Compile {
 		if opts.JSON {
 			b.PrintCompileJSON()
 		} else {
@@ -273,7 +330,14 @@ func processBuild(c *g.CliSC) (ok bool, err error) {
 
 	// Execute the build
 	if err := b.Execute(); err != nil {
+		if opts.Test && opts.JSON {
+			b.PrintTestJSON()
+		}
 		return ok, g.Error(err, "build execution failed")
+	}
+	if opts.Test && opts.JSON {
+		b.PrintTestJSON()
+		return ok, nil
 	}
 	if err := testOutput(int64(b.ExecRows), b.ExecBytes, 0); err != nil {
 		return ok, err

--- a/cmd/sling/sling_build.go
+++ b/cmd/sling/sling_build.go
@@ -303,11 +303,15 @@ func processBuild(c *g.CliSC) (ok bool, err error) {
 	// Build and compile
 	b, err := build.NewBuild(projectPath, opts)
 	if err != nil {
-		return ok, g.Error(err, "could not load build project")
+		err = g.Error(err, "could not load build project")
+		build.SyncBuildFailure(err)
+		return ok, err
 	}
 
 	if err := b.Compile(); err != nil {
-		return ok, g.Error(err, "could not compile build project")
+		err = g.Error(err, "could not compile build project")
+		build.SyncBuildFailure(err)
+		return ok, err
 	}
 
 	if opts.List {

--- a/cmd/sling/sling_build.go
+++ b/cmd/sling/sling_build.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/flarco/g"
 	"github.com/integrii/flaggy"
+	"github.com/slingdata-io/sling-cli/core/dbio/connection"
 	"github.com/slingdata-io/sling-cli/core/env"
 	"github.com/slingdata-io/sling-cli/core/sling/build"
 	"github.com/spf13/cast"
@@ -185,6 +186,8 @@ func processBuild(c *g.CliSC) (ok bool, err error) {
 	opts := build.BuildOptions{
 		Threads: build.DefaultThreads,
 	}
+	var b *build.Build
+	defer func() { setBuildTel(opts, b) }()
 
 	projectPath := "."
 
@@ -301,7 +304,7 @@ func processBuild(c *g.CliSC) (ok bool, err error) {
 	}
 
 	// Build and compile
-	b, err := build.NewBuild(projectPath, opts)
+	b, err = build.NewBuild(projectPath, opts)
 	if err != nil {
 		err = g.Error(err, "could not load build project")
 		build.SyncBuildFailure(err)
@@ -347,6 +350,44 @@ func processBuild(c *g.CliSC) (ok bool, err error) {
 		return ok, err
 	}
 	return ok, nil
+}
+
+func setBuildTel(opts build.BuildOptions, b *build.Build) {
+	m := g.M(
+		"full_refresh", opts.FullRefresh,
+		"fail_fast", opts.FailFast,
+		"no_seeds", opts.NoSeeds,
+		"recursive", opts.Recursive,
+		"has_range", opts.Range != nil && strings.TrimSpace(*opts.Range) != "",
+		"has_select", len(opts.Select) > 0,
+		"has_schema", opts.Schema != "",
+	)
+	if b != nil {
+		if b.Project != nil {
+			if b.Project.Mode != "" {
+				m["mode"] = b.Project.Mode
+			}
+			m["model_count"] = len(b.Project.Models)
+			m["selected_count"] = len(b.Selected)
+		}
+		if t := buildTelTargetType(b); t != "" {
+			m["target_type"] = t
+		}
+		m["rows"] = b.ExecRows
+	}
+	env.SetTelVal("build", g.Marshal(m))
+}
+
+func buildTelTargetType(b *build.Build) string {
+	name := b.GetTarget()
+	if name == "" {
+		return ""
+	}
+	entry := connection.GetLocalConns().Get(name)
+	if entry.Name == "" || entry.Connection.Type.IsUnknown() {
+		return ""
+	}
+	return entry.Connection.Type.String()
 }
 
 // askPrompt writes label and reads one answer. It returns an error on EOF so

--- a/cmd/sling/sling_cli.go
+++ b/cmd/sling/sling_cli.go
@@ -651,7 +651,7 @@ func cliInit(done chan struct{}) int {
 			err = g.Error(cast.ToString(env.TelMap["error"]))
 		}
 
-		if g.In(g.CliObj.Name, "conns", "update") || env.TelMap["error"] == nil {
+		if g.In(g.CliObj.Name, "conns", "update", "build", "assist", "validate") || env.TelMap["error"] == nil {
 			env.SetTelVal("error", getErrString(err))
 
 			eventName := g.CliObj.Name
@@ -702,6 +702,12 @@ func cliInit(done chan struct{}) int {
 		Track("conns_" + g.CliObj.UsedSC())
 	case g.CliObj.Name == "update":
 		Track("update")
+	case g.In(g.CliObj.Name, "build", "assist", "validate"):
+		eventName := g.CliObj.Name
+		if g.CliObj.UsedSC() != "" {
+			eventName = g.CliObj.Name + "_" + g.CliObj.UsedSC()
+		}
+		Track(eventName)
 	}
 
 	return 0

--- a/cmd/sling/sling_init.go
+++ b/cmd/sling/sling_init.go
@@ -68,7 +68,7 @@ func runInit(opts project.Options, testConns bool) error {
 		g.Info("wrote `%s`", f)
 	}
 	fmt.Println()
-	fmt.Println("  Next: Add .sql models to schema folders and run 'sling build'")
+	fmt.Println("  Next: Add .sql models to schema folders and run 'sling build run'")
 	fmt.Println("  Run a job locally with 'sling run -j <key>'. Schedules fire on the platform once this folder is linked.")
 	fmt.Println()
 

--- a/cmd/sling/sling_validate.go
+++ b/cmd/sling/sling_validate.go
@@ -87,6 +87,7 @@ func processValidate(c *g.CliSC) (ok bool, err error) {
 	}
 
 	results := validate.ParsePaths(paths, opts)
+	setValidateTel(opts, results)
 	text, err := validate.GetOutput(results, opts)
 	if err != nil {
 		return ok, g.Error(err, "could not render validate output")
@@ -99,6 +100,27 @@ func processValidate(c *g.CliSC) (ok bool, err error) {
 		return ok, validateFailErr(results)
 	}
 	return ok, nil
+}
+
+func setValidateTel(opts validate.Options, results []validate.FileResult) {
+	kinds := map[string]int{}
+	fail := 0
+	for _, r := range results {
+		k := string(r.Kind)
+		if k == "" {
+			k = "unknown"
+		}
+		kinds[k]++
+		if !r.OK {
+			fail++
+		}
+	}
+	env.SetTelVal("validate", g.Marshal(g.M(
+		"compile", opts.Compile,
+		"file_count", len(results),
+		"fail_count", fail,
+		"kinds", kinds,
+	)))
 }
 
 func collectValidatePaths(c *g.CliSC) []string {

--- a/core/dbio/api/auth.go
+++ b/core/dbio/api/auth.go
@@ -45,7 +45,7 @@ func (ac *APIConnection) Authenticate() (err error) {
 
 	authenticator, err := ac.MakeAuthenticator()
 	if err != nil {
-		return g.Error(err, "could not make authenticator for: %s", authenticator.AuthType())
+		return g.Error(err, "could not make authenticator for: %s", ac.Spec.Authentication.Type())
 	}
 
 	if err = authenticator.Authenticate(ac.Context.Ctx, &ac.State.Auth); err != nil {
@@ -86,6 +86,8 @@ func (ac *APIConnection) MakeAuthenticator() (authenticator Authenticator, err e
 		authenticator = &AuthenticatorAWSSigV4{AuthenticatorBase: baseAuth}
 	case AuthTypeHMAC:
 		authenticator = &AuthenticatorHMAC{AuthenticatorBase: baseAuth}
+	default:
+		return nil, g.Error("unsupported authentication type: %s", baseAuth.Type)
 	}
 
 	// so we write all the properties

--- a/core/dbio/dbio_types.go
+++ b/core/dbio/dbio_types.go
@@ -281,6 +281,19 @@ func (t Type) IsSQLServer() bool {
 	return g.In(t, TypeDbSQLServer, TypeDbAzure, TypeDbAzureDWH, TypeDbFabric)
 }
 
+// IsColumnStore is true for columnar engines where COUNT(*) is cheap
+// (metadata / projection). Row stores such as Postgres are false.
+func (t Type) IsColumnStore() bool {
+	return g.In(t,
+		TypeDbClickhouse, TypeDbProton,
+		TypeDbSnowflake, TypeDbBigQuery,
+		TypeDbDuckDb, TypeDbDuckLake, TypeDbMotherDuck,
+		TypeDbRedshift, TypeDbDatabricks, TypeDbStarRocks,
+		TypeDbTrino, TypeDbAthena, TypeDbIceberg, TypeDbExasol,
+		TypeDbAzureDWH, TypeDbFabric,
+	)
+}
+
 // IsSingleWriterDB is true for engines that allow only one writer per file.
 func (t Type) IsSingleWriterDB() bool {
 	return g.In(t, TypeDbDuckDb, TypeDbMotherDuck, TypeDbDuckLake)

--- a/core/dbio/dbio_types.go
+++ b/core/dbio/dbio_types.go
@@ -728,6 +728,28 @@ func (t Type) GetTemplateValue(path string) (value string) {
 	return value
 }
 
+// ExplainSQL wraps sql with the dialect's core.explain template so the
+// statement can be validated without executing it. Prefix form (not a
+// subquery wrap) keeps top-level WITH CTEs valid on engines that reject
+// WITH inside a derived table.
+func (t Type) ExplainSQL(sql string) (string, error) {
+	tpl := strings.TrimSpace(t.GetTemplateValue("core.explain"))
+	if tpl == "" {
+		return "", g.Error("explain is not supported for %s", t)
+	}
+	sql = strings.TrimSpace(sql)
+	for strings.HasSuffix(sql, ";") {
+		sql = strings.TrimSpace(strings.TrimSuffix(sql, ";"))
+	}
+	if sql == "" {
+		return "", g.Error("sql is required")
+	}
+	if strings.HasPrefix(strings.ToUpper(sql), "EXPLAIN") {
+		return sql, nil
+	}
+	return g.R(tpl, "sql", sql), nil
+}
+
 type FileType string
 
 const (

--- a/core/dbio/dbio_types_test.go
+++ b/core/dbio/dbio_types_test.go
@@ -1,0 +1,117 @@
+package dbio
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExplainSQLPrefixKeepsCTE(t *testing.T) {
+	sql := "WITH cte AS (SELECT 1 AS x) SELECT * FROM cte"
+	got, err := TypeDbPostgres.ExplainSQL(sql)
+	require.NoError(t, err)
+	assert.Equal(t, "explain "+sql, got)
+	assert.True(t, strings.HasPrefix(strings.ToLower(got), "explain with"))
+	assert.NotContains(t, got, "from (\n")
+}
+
+func TestExplainSQLNestedCTEAndSubquery(t *testing.T) {
+	sql := `
+WITH a AS (
+  SELECT id FROM users WHERE active
+), b AS (
+  SELECT a.id, o.total FROM a JOIN (SELECT * FROM orders) o ON o.user_id = a.id
+)
+SELECT * FROM b
+`
+	got, err := TypeDbSnowflake.ExplainSQL(sql)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(strings.ToLower(strings.TrimSpace(got)), "explain using tabular"))
+	assert.Contains(t, got, "WITH a AS")
+}
+
+func TestExplainSQLDialects(t *testing.T) {
+	sql := "select 1"
+	cases := []struct {
+		typ    Type
+		substr string
+	}{
+		{TypeDbPostgres, "explain select 1"},
+		{TypeDbMySQL, "explain select 1"},
+		{TypeDbSQLite, "explain query plan select 1"},
+		{TypeDbD1, "explain query plan select 1"},
+		{TypeDbOracle, "explain plan for select 1"},
+		{TypeDbSnowflake, "explain using tabular select 1"},
+		{TypeDbDatabricks, "explain formatted select 1"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.typ), func(t *testing.T) {
+			got, err := tc.typ.ExplainSQL(sql)
+			require.NoError(t, err)
+			assert.Equal(t, tc.substr, strings.TrimSpace(got))
+		})
+	}
+}
+
+func TestExplainSQLServerWrapsCTE(t *testing.T) {
+	sql := "WITH cte AS (SELECT 1 AS x) SELECT * FROM cte"
+	got, err := TypeDbSQLServer.ExplainSQL(sql)
+	require.NoError(t, err)
+	assert.Contains(t, got, "select top 0 * from (")
+	assert.Contains(t, got, sql)
+	assert.Contains(t, got, ") as _sling_explain")
+	assert.False(t, strings.HasPrefix(strings.ToLower(strings.TrimSpace(got)), "explain"))
+}
+
+func TestExplainSQLBigQueryWrapsCTE(t *testing.T) {
+	sql := "WITH cte AS (SELECT 1 AS x) SELECT * FROM cte"
+	got, err := TypeDbBigQuery.ExplainSQL(sql)
+	require.NoError(t, err)
+	assert.Contains(t, got, "select * from (")
+	assert.Contains(t, got, sql)
+	assert.Contains(t, got, "where false")
+}
+
+func TestExplainSQLStripsSemicolonAndSkipsDouble(t *testing.T) {
+	got, err := TypeDbPostgres.ExplainSQL("select 1;")
+	require.NoError(t, err)
+	assert.Equal(t, "explain select 1", got)
+
+	already := "EXPLAIN SELECT 1"
+	got, err = TypeDbPostgres.ExplainSQL(already)
+	require.NoError(t, err)
+	assert.Equal(t, already, got)
+}
+
+func TestExplainSQLUnsupported(t *testing.T) {
+	_, err := TypeDbMongoDB.ExplainSQL("select 1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported")
+
+	_, err = TypeDbPostgres.ExplainSQL("  ;  ")
+	require.Error(t, err)
+}
+
+func TestExplainTemplatePresentForSQLDatabases(t *testing.T) {
+	noExplain := map[Type]bool{
+		TypeDbMongoDB:       true,
+		TypeDbElasticsearch: true,
+		TypeDbAzureTable:    true,
+		TypeDbBigTable:      true,
+		TypeDbPrometheus:    true,
+	}
+	for _, td := range AllType {
+		if !td.Value.IsDb() {
+			continue
+		}
+		val := strings.TrimSpace(td.Value.GetTemplateValue("core.explain"))
+		if noExplain[td.Value] {
+			assert.Empty(t, val, "%s should not have core.explain", td.Value)
+			continue
+		}
+		assert.NotEmpty(t, val, "%s missing core.explain", td.Value)
+		assert.Contains(t, val, "{sql}", "%s core.explain must include {sql}", td.Value)
+	}
+}

--- a/core/dbio/iop/datatype.go
+++ b/core/dbio/iop/datatype.go
@@ -223,9 +223,9 @@ type ColumnStats struct {
 	MinLen       int    `json:"min_len,omitempty"`
 	MaxLen       int    `json:"max_len,omitempty"`
 	MaxDecLen    int    `json:"max_dec_len,omitempty"`
-	Min          int64  `json:"min"`
-	Max          int64  `json:"max"`
-	NullCnt      int64  `json:"null_cnt"`
+	Min          int64  `json:"min,omitempty"`
+	Max          int64  `json:"max,omitempty"`
+	NullCnt      int64  `json:"null_cnt,omitempty"`
 	IntCnt       int64  `json:"int_cnt,omitempty"`
 	DecCnt       int64  `json:"dec_cnt,omitempty"`
 	BoolCnt      int64  `json:"bool_cnt,omitempty"`
@@ -235,9 +235,9 @@ type ColumnStats struct {
 	DateTimeCnt  int64  `json:"datetime_cnt,omitempty"`
 	DateTimeZCnt int64  `json:"datetimez_cnt,omitempty"`
 	GeometryCnt  int64  `json:"geometry_cnt,omitempty"`
-	TotalCnt     int64  `json:"total_cnt"`
-	UniqCnt      int64  `json:"uniq_cnt"`
-	Checksum     uint64 `json:"checksum"`
+	TotalCnt     int64  `json:"total_cnt,omitempty"`
+	UniqCnt      int64  `json:"uniq_cnt,omitempty"`
+	Checksum     uint64 `json:"checksum,omitempty"`
 	LastVal      any    `json:"-"` // last non-empty value. useful for state incremental
 }
 

--- a/core/dbio/iop/duckdb.go
+++ b/core/dbio/iop/duckdb.go
@@ -849,14 +849,11 @@ func (duck *DuckDb) newQuery(ctx context.Context, sql string) (query *duckDbQuer
 				}
 
 				if duck.Proc != nil && !dq.isDone() && (duck.Proc.Exited() || duck.Proc.GetScanErr() != nil) {
-					reason := "duckdb process exited before query completed"
-					if duck.Proc.GetScanErr() != nil {
-						reason = "duckdb stdout scanner stopped before query completed"
-					}
-					err := g.Error("%s: %s", reason, duck.Proc.CmdErrorText())
+					err := duck.procDeathErr()
 					dq.setErr(err)
 					dq.writer.CloseWithError(err)
 					dq.reader.CloseWithError(err)
+					duck.kill() // dead or unreadable; mark disconnected so the next query reopens
 					return
 				}
 			}
@@ -864,6 +861,30 @@ func (duck *DuckDb) newQuery(ctx context.Context, sql string) (query *duckDbQuer
 	}()
 
 	return dq
+}
+
+// procDeathErr describes a process that died or lost its stdout scanner
+// mid-query. Capture is off for duckdb, so CmdErrorText is normally empty and
+// the exit status (e.g. "signal: killed") is the only clue on a silent death.
+func (duck *DuckDb) procDeathErr() error {
+	if scanErr := duck.Proc.GetScanErr(); scanErr != nil {
+		return g.Error(scanErr, "duckdb stdout scanner stopped before query completed")
+	}
+
+	detail := duck.Proc.CmdErrorText()
+	if detail == "" {
+		if procErr := duck.Proc.GetErr(); procErr != nil {
+			detail = procErr.Error() // e.g. "signal: killed", "exit status 1"
+		} else if code := duck.Proc.GetExitCode(); code != nil {
+			detail = g.F("exit code %d", *code)
+		} else {
+			detail = "unknown cause"
+		}
+	}
+	if strings.Contains(detail, "signal: killed") {
+		detail += " (process was killed, possibly by the OS out-of-memory killer)"
+	}
+	return g.Error("duckdb process exited before query completed: %s", detail)
 }
 
 // waitForResult waits for the execution of a SQL query and returns the result

--- a/core/dbio/iop/duckdb_test.go
+++ b/core/dbio/iop/duckdb_test.go
@@ -3,6 +3,7 @@ package iop
 import (
 	"context"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/slingdata-io/sling-cli/core/dbio"
 	"github.com/spf13/cast"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDuckDb(t *testing.T) {
@@ -207,6 +209,50 @@ func TestDuckDbNoDeadlock(t *testing.T) {
 			}
 		})
 	})
+}
+
+// A duckdb process that dies silently (OOM kill, crash) must surface its exit
+// status instead of a bare "exited before query completed:" and must reopen on
+// the next query.
+func TestDuckDbProcessDeathError(t *testing.T) {
+	t.Setenv("SLING_DUCKDB_STALL_TIMEOUT", "0")
+
+	duck := NewDuckDb(context.Background())
+	defer duck.Close()
+
+	_, err := duck.Exec("create table death_repro (id bigint)")
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() {
+		// a long insert stays silent on stdout until it completes
+		_, err := duck.Exec("insert into death_repro select i from range(1, 50000000000) t(i)")
+		done <- err
+	}()
+
+	time.Sleep(500 * time.Millisecond)
+	require.NoError(t, duck.Proc.Cmd.Process.Kill())
+
+	select {
+	case err = <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("query did not return after the duckdb process died")
+	}
+
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "duckdb process exited before query completed")
+	assert.False(t, strings.HasSuffix(strings.TrimSpace(msg), ":"), msg)
+	if runtime.GOOS != "windows" {
+		assert.Contains(t, msg, "signal: killed", msg)
+		assert.Contains(t, msg, "out-of-memory", msg)
+	}
+
+	// the connection must reopen on the next query
+	data, err := duck.Query("select 9 as n")
+	if assert.NoError(t, err) && assert.Len(t, data.Rows, 1) {
+		assert.Equal(t, int64(9), data.Rows[0][0])
+	}
 }
 
 func TestDuckDbStreamArrow(t *testing.T) {

--- a/core/dbio/templates/azuredwh.yaml
+++ b/core/dbio/templates/azuredwh.yaml
@@ -1,4 +1,9 @@
 core:
+  # T-SQL has no EXPLAIN. Wrap so WITH CTEs stay inside the derived table.
+  explain: |
+    select top 0 * from (
+    {sql}
+    ) as _sling_explain
   drop_table: drop table {table}
   drop_view: drop view {view}
   replace: insert into {table} ({fields}) values ({values}) on conflict ({pk_fields}) do update set {set_fields}

--- a/core/dbio/templates/azuresql.yaml
+++ b/core/dbio/templates/azuresql.yaml
@@ -1,4 +1,9 @@
 core:
+  # T-SQL has no EXPLAIN. Wrap so WITH CTEs stay inside the derived table.
+  explain: |
+    select top 0 * from (
+    {sql}
+    ) as _sling_explain
   drop_table: IF OBJECT_ID(N'{table}', N'U') IS NOT NULL DROP TABLE {table}
   drop_view: IF OBJECT_ID(N'{view}', N'V') IS NOT NULL DROP VIEW {view}
   drop_index: |

--- a/core/dbio/templates/azuretable.yaml
+++ b/core/dbio/templates/azuretable.yaml
@@ -1,4 +1,5 @@
 core:
+  explain: ""
   incremental_select: '{incremental_where_cond}'
   incremental_where: '{ "update_key": "{update_key}", "value": "{value}" }'
   backfill_where: '{ "update_key": "{update_key}", "start_value": "{start_value}", "end_value": "{end_value}" }'

--- a/core/dbio/templates/base.yaml
+++ b/core/dbio/templates/base.yaml
@@ -31,6 +31,11 @@ core:
     select * from (
       {sql}
     ) as t limit {limit} offset {offset}
+  # Prefix EXPLAIN so top-level WITH CTEs stay valid. Do not wrap as
+  # `select * from ({sql}) t` — Hive/Spark reject WITH in a derived table,
+  # and SQL Server rejects ORDER BY in a derived table without TOP/OFFSET.
+  # EXPLAIN (not EXPLAIN ANALYZE) validates without running the query.
+  explain: explain {sql}
   insert_from_table: insert into {tgt_table} ({tgt_fields}) select {src_fields} from {src_table}
   truncate_table: truncate table {table}
   alter_columns: alter table {table} {col_ddl}

--- a/core/dbio/templates/bigquery.yaml
+++ b/core/dbio/templates/bigquery.yaml
@@ -1,4 +1,11 @@
 core:
+  # BigQuery has no SQL EXPLAIN (dry-run is API-only). Wrap with WHERE FALSE
+  # so WITH CTEs stay inside the subquery and no rows are returned.
+  explain: |
+    select * from (
+    {sql}
+    ) as _sling_explain
+    where false
   drop_table: drop table if exists {table}
   drop_view: drop view if exists {view}
   drop_index: "select 'indexes do not apply for bigquery'"

--- a/core/dbio/templates/bigtable.yaml
+++ b/core/dbio/templates/bigtable.yaml
@@ -1,4 +1,5 @@
 core:
+  explain: ""
   drop_table: '{"action": "delete_table", "table": "{table}"}'
 
 variable:

--- a/core/dbio/templates/connections.json
+++ b/core/dbio/templates/connections.json
@@ -427,6 +427,22 @@
         }
       }
     },
+    "odbc": {
+      "name": "ODBC",
+      "description": "Generic ODBC database connection",
+      "category": "database",
+      "properties": {
+        "conn_string": {
+          "type": "string",
+          "description": "ODBC connection string (DSN or DSN-less)",
+          "required": true
+        },
+        "conn_template": {
+          "type": "string",
+          "description": "SQL template name for query syntax (e.g. sqlserver, postgres, mysql)"
+        }
+      }
+    },
     "oracle": {
       "name": "Oracle",
       "description": "Oracle database connection",
@@ -478,6 +494,10 @@
           "description": "Port number",
           "default": 1433
         },
+        "instance": {
+          "type": "string",
+          "description": "Named instance (uses SQL Browser on UDP 1434; omit when setting port)"
+        },
         "user": {
           "type": "string",
           "description": "Username for authentication",
@@ -507,6 +527,57 @@
           "type": "boolean",
           "description": "Trust server certificate",
           "default": false
+        }
+      }
+    },
+    "scylladb": {
+      "name": "ScyllaDB",
+      "description": "ScyllaDB / Cassandra-compatible database connection",
+      "category": "database",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Hostname / IP of the contact point",
+          "required": true
+        },
+        "port": {
+          "type": "number",
+          "description": "Port number",
+          "default": 9042
+        },
+        "user": {
+          "type": "string",
+          "description": "Username for authentication"
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for authentication"
+        },
+        "keyspace": {
+          "type": "string",
+          "description": "Default keyspace (aliases: database, schema)"
+        },
+        "hosts": {
+          "type": "string",
+          "description": "Additional contact points (comma-separated)"
+        },
+        "local_dc": {
+          "type": "string",
+          "description": "Local datacenter for DC-aware routing"
+        },
+        "consistency": {
+          "type": "string",
+          "description": "Default consistency level (e.g. QUORUM, LOCAL_QUORUM)"
+        },
+        "disable_initial_host_lookup": {
+          "type": "boolean",
+          "description": "Skip peer host lookup (useful for Docker/K8s)",
+          "default": true
+        },
+        "num_conns": {
+          "type": "number",
+          "description": "Connections per host",
+          "default": 2
         }
       }
     },
@@ -901,6 +972,78 @@
         }
       }
     },
+    "fabric": {
+      "name": "Microsoft Fabric",
+      "description": "Microsoft Fabric warehouse connection",
+      "category": "database",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Fabric warehouse hostname",
+          "required": true
+        },
+        "port": {
+          "type": "number",
+          "description": "Port number",
+          "default": 1433
+        },
+        "user": {
+          "type": "string",
+          "description": "Username for authentication"
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for authentication"
+        },
+        "database": {
+          "type": "string",
+          "description": "Warehouse or database name",
+          "required": true
+        },
+        "schema": {
+          "type": "string",
+          "description": "Default schema name"
+        },
+        "fedauth": {
+          "type": "string",
+          "description": "Azure AD authentication mode (e.g. ActiveDirectoryAzCli)"
+        },
+        "client_id": {
+          "type": "string",
+          "description": "Azure service principal application ID"
+        },
+        "tenant_id": {
+          "type": "string",
+          "description": "Microsoft Entra tenant ID"
+        },
+        "client_secret": {
+          "type": "string",
+          "description": "Azure service principal client secret"
+        },
+        "abfs_endpoint": {
+          "type": "string",
+          "description": "OneLake / ABFS endpoint for bulk staging"
+        },
+        "abfs_filesystem": {
+          "type": "string",
+          "description": "OneLake workspace UUID for bulk staging"
+        },
+        "abfs_parent": {
+          "type": "string",
+          "description": "Lakehouse UUID/Files path for bulk staging"
+        },
+        "encrypt": {
+          "type": "boolean",
+          "description": "Encrypt connection",
+          "default": true
+        },
+        "trust_server_certificate": {
+          "type": "boolean",
+          "description": "Trust server certificate",
+          "default": false
+        }
+      }
+    },
     "databricks": {
       "name": "Databricks",
       "description": "Databricks lakehouse platform",
@@ -1132,14 +1275,139 @@
       "description": "DuckLake data lakehouse",
       "category": "datalake",
       "properties": {
-        "path": {
+        "catalog_type": {
           "type": "string",
-          "description": "DuckLake path",
+          "description": "Catalog database type: duckdb, sqlite, postgres, or mysql",
+          "default": "duckdb",
+          "enum": [
+            "duckdb",
+            "sqlite",
+            "postgres",
+            "mysql"
+          ]
+        },
+        "catalog_conn_string": {
+          "type": "string",
+          "description": "Connection string for the catalog database",
           "required": true
         },
-        "format": {
+        "catalog_schema": {
           "type": "string",
-          "description": "Data format"
+          "description": "Schema for catalog tables (postgres/mysql)"
+        },
+        "data_path": {
+          "type": "string",
+          "description": "Path to data files (local, s3://, r2://, az://, gs://)"
+        },
+        "data_inlining_limit": {
+          "type": "number",
+          "description": "Row limit for DATA_INLINING_ROW_LIMIT"
+        },
+        "copy_method": {
+          "type": "string",
+          "description": "Copy method into DuckDB",
+          "default": "arrow_http",
+          "enum": [
+            "csv_http",
+            "arrow_http"
+          ]
+        },
+        "schema": {
+          "type": "string",
+          "description": "Default schema",
+          "default": "main"
+        },
+        "encrypted": {
+          "type": "boolean",
+          "description": "Write data using Parquet encryption"
+        },
+        "url_style": {
+          "type": "string",
+          "description": "S3 URL style (e.g. path for MinIO)"
+        },
+        "use_ssl": {
+          "type": "boolean",
+          "description": "Use HTTPS for S3-compatible endpoints"
+        },
+        "duckdb_version": {
+          "type": "string",
+          "description": "DuckDB CLI version to use"
+        },
+        "max_buffer_size": {
+          "type": "number",
+          "description": "Max buffer size when piping from DuckDB CLI"
+        },
+        "max_line_size": {
+          "type": "number",
+          "description": "Max CSV line size when copy_method is csv_http"
+        },
+        "s3_access_key_id": {
+          "type": "string",
+          "description": "AWS / S3 access key ID"
+        },
+        "s3_secret_access_key": {
+          "type": "string",
+          "description": "AWS / S3 secret access key"
+        },
+        "s3_session_token": {
+          "type": "string",
+          "description": "AWS session token"
+        },
+        "s3_region": {
+          "type": "string",
+          "description": "AWS region"
+        },
+        "s3_profile": {
+          "type": "string",
+          "description": "AWS profile name"
+        },
+        "s3_endpoint": {
+          "type": "string",
+          "description": "S3-compatible endpoint URL"
+        },
+        "azure_account_name": {
+          "type": "string",
+          "description": "Azure storage account name"
+        },
+        "azure_account_key": {
+          "type": "string",
+          "description": "Azure storage account key"
+        },
+        "azure_sas_token": {
+          "type": "string",
+          "description": "Azure SAS token"
+        },
+        "azure_tenant_id": {
+          "type": "string",
+          "description": "Azure tenant ID"
+        },
+        "azure_client_id": {
+          "type": "string",
+          "description": "Azure client ID"
+        },
+        "azure_client_secret": {
+          "type": "string",
+          "description": "Azure client secret"
+        },
+        "azure_connection_string": {
+          "type": "string",
+          "description": "Azure connection string"
+        },
+        "gcs_key_file": {
+          "type": "string",
+          "description": "Path to GCS service account key file"
+        },
+        "gcs_project_id": {
+          "type": "string",
+          "description": "GCS project ID"
+        },
+        "gcs_access_key_id": {
+          "type": "string",
+          "description": "GCS HMAC access key ID"
+        },
+        "gcs_secret_access_key": {
+          "type": "string",
+          "description": "GCS HMAC secret access key"
         }
       }
     },
@@ -1148,14 +1416,126 @@
       "description": "Apache Iceberg table format",
       "category": "datalake",
       "properties": {
-        "catalog_uri": {
+        "catalog_type": {
           "type": "string",
-          "description": "Iceberg catalog URI",
-          "required": true
+          "description": "Catalog type: rest, glue, or sql",
+          "default": "rest",
+          "enum": [
+            "rest",
+            "glue",
+            "sql"
+          ]
         },
-        "warehouse": {
+        "schema": {
           "type": "string",
-          "description": "Warehouse path"
+          "description": "Default schema",
+          "default": "main"
+        },
+        "rest_uri": {
+          "type": "string",
+          "description": "REST catalog endpoint URI"
+        },
+        "rest_warehouse": {
+          "type": "string",
+          "description": "Warehouse location for the REST catalog"
+        },
+        "rest_token": {
+          "type": "string",
+          "description": "OAuth token for REST catalog auth"
+        },
+        "rest_oauth_client_id": {
+          "type": "string",
+          "description": "OAuth client ID"
+        },
+        "rest_oauth_client_secret": {
+          "type": "string",
+          "description": "OAuth client secret"
+        },
+        "rest_oauth_scope": {
+          "type": "string",
+          "description": "OAuth scope"
+        },
+        "rest_oauth_server_uri": {
+          "type": "string",
+          "description": "OAuth server URI for token requests"
+        },
+        "rest_prefix": {
+          "type": "string",
+          "description": "API prefix for the REST catalog"
+        },
+        "rest_metadata_location": {
+          "type": "string",
+          "description": "Custom metadata location"
+        },
+        "rest_extra_props": {
+          "type": "string",
+          "description": "Additional REST properties as JSON string"
+        },
+        "rest_sigv4_enable": {
+          "type": "boolean",
+          "description": "Enable AWS SigV4 authentication"
+        },
+        "rest_sigv4_region": {
+          "type": "string",
+          "description": "AWS region for SigV4"
+        },
+        "rest_sigv4_service": {
+          "type": "string",
+          "description": "AWS service name for SigV4"
+        },
+        "glue_warehouse": {
+          "type": "string",
+          "description": "Glue warehouse location in S3"
+        },
+        "glue_account_id": {
+          "type": "string",
+          "description": "AWS account ID for Glue catalog"
+        },
+        "glue_namespace": {
+          "type": "string",
+          "description": "Namespace in the Glue catalog"
+        },
+        "glue_extra_props": {
+          "type": "string",
+          "description": "Extra Glue properties (JSON/object)"
+        },
+        "sql_catalog_name": {
+          "type": "string",
+          "description": "Name of the SQL catalog",
+          "default": "sql"
+        },
+        "sql_catalog_conn": {
+          "type": "string",
+          "description": "Sling database connection name for SQL catalog backend"
+        },
+        "sql_catalog_init": {
+          "type": "boolean",
+          "description": "Initialize catalog tables if missing",
+          "default": true
+        },
+        "s3_access_key_id": {
+          "type": "string",
+          "description": "AWS / S3 access key ID"
+        },
+        "s3_secret_access_key": {
+          "type": "string",
+          "description": "AWS / S3 secret access key"
+        },
+        "s3_session_token": {
+          "type": "string",
+          "description": "AWS session token"
+        },
+        "s3_region": {
+          "type": "string",
+          "description": "AWS region"
+        },
+        "s3_profile": {
+          "type": "string",
+          "description": "AWS profile name"
+        },
+        "s3_endpoint": {
+          "type": "string",
+          "description": "S3-compatible endpoint URL"
         }
       }
     },

--- a/core/dbio/templates/d1.yaml
+++ b/core/dbio/templates/d1.yaml
@@ -1,4 +1,5 @@
 core:
+  explain: explain query plan {sql}
   drop_table: drop table if exists {table}
   drop_view: drop view if exists {view}
   drop_index: drop index if exists {index}

--- a/core/dbio/templates/databricks.yaml
+++ b/core/dbio/templates/databricks.yaml
@@ -1,4 +1,5 @@
 core:
+  explain: explain formatted {sql}
   drop_table: drop table if exists {table}
   drop_view: drop view if exists {view}
   create_schema: create schema if not exists {schema}

--- a/core/dbio/templates/databricks.yaml
+++ b/core/dbio/templates/databricks.yaml
@@ -150,10 +150,10 @@ core:
     )
 
   merge_update: |
-    UPDATE {tgt_table} tgt
-    SET {set_fields}
-    FROM {src_table} src
-    WHERE {src_tgt_pk_equal}
+    MERGE INTO {tgt_table} tgt
+    USING (SELECT {src_fields} FROM {src_table}) src
+    ON ({src_tgt_pk_equal})
+    WHEN MATCHED THEN UPDATE SET {set_fields}
 
   merge_update_insert: |
     MERGE INTO {tgt_table} tgt

--- a/core/dbio/templates/db2.yaml
+++ b/core/dbio/templates/db2.yaml
@@ -1,4 +1,5 @@
 core:
+  explain: explain plan for {sql}
   drop_table: |
     BEGIN
       DECLARE CONTINUE HANDLER FOR SQLSTATE '42704' BEGIN END;

--- a/core/dbio/templates/elasticsearch.yaml
+++ b/core/dbio/templates/elasticsearch.yaml
@@ -1,4 +1,5 @@
 core:
+  explain: ""
   incremental_select: '{incremental_where_cond}'
   incremental_where: '{ "update_key": "{update_key}", "value": "{value}" }'
   backfill_where: '{ "update_key": "{update_key}", "start_value": "{start_value}", "end_value": "{end_value}" }'

--- a/core/dbio/templates/fabric.yaml
+++ b/core/dbio/templates/fabric.yaml
@@ -1,4 +1,9 @@
 core:
+  # T-SQL has no EXPLAIN. Wrap so WITH CTEs stay inside the derived table.
+  explain: |
+    select top 0 * from (
+    {sql}
+    ) as _sling_explain
   drop_table: IF OBJECT_ID(N'{table}', N'U') IS NOT NULL DROP TABLE {table}
   drop_view: IF OBJECT_ID(N'{view}', N'V') IS NOT NULL DROP VIEW {view}
   replace: insert into {table} ({fields}) values ({values}) on conflict ({pk_fields}) do update set {set_fields}

--- a/core/dbio/templates/mongodb.yaml
+++ b/core/dbio/templates/mongodb.yaml
@@ -1,4 +1,5 @@
 core:
+  explain: ""
   incremental_select: '{incremental_where_cond}'
   incremental_where: '{ "update_key": "{update_key}", "value": "{value}" }'
   backfill_where: '{ "update_key": "{update_key}", "start_value": "{start_value}", "end_value": "{end_value}" }'

--- a/core/dbio/templates/oracle.yaml
+++ b/core/dbio/templates/oracle.yaml
@@ -1,4 +1,5 @@
 core:
+  explain: explain plan for {sql}
   create_table: |
     BEGIN
       EXECUTE IMMEDIATE 'create table {table} ({col_types})';

--- a/core/dbio/templates/prometheus.yaml
+++ b/core/dbio/templates/prometheus.yaml
@@ -1,3 +1,6 @@
+core:
+  explain: ""
+
 variable:
   tmp_folder: /tmp
   timestamp_layout_str: '{value}'

--- a/core/dbio/templates/snowflake.yaml
+++ b/core/dbio/templates/snowflake.yaml
@@ -1,4 +1,5 @@
 core:
+  explain: explain using tabular {sql}
   drop_table: drop table if exists {table}
   drop_view: drop view if exists {view}
   drop_index: "select 'indexes do not apply for snowflake'"

--- a/core/dbio/templates/sqlite.yaml
+++ b/core/dbio/templates/sqlite.yaml
@@ -1,4 +1,5 @@
 core:
+  explain: explain query plan {sql}
   drop_table: drop table if exists {table}
   drop_view: drop view if exists {view}
   drop_index: drop index if exists {index}

--- a/core/dbio/templates/sqlserver.yaml
+++ b/core/dbio/templates/sqlserver.yaml
@@ -1,4 +1,10 @@
 core:
+  # T-SQL has no EXPLAIN. Wrap so WITH CTEs stay inside the derived table.
+  # TOP 0 avoids returning rows. Inner ORDER BY without TOP/OFFSET may fail.
+  explain: |
+    select top 0 * from (
+    {sql}
+    ) as _sling_explain
   drop_table: IF OBJECT_ID(N'{table}', N'U') IS NOT NULL DROP TABLE {table}
   drop_view: IF OBJECT_ID(N'{view}', N'V') IS NOT NULL DROP VIEW {view}
   drop_index: |

--- a/core/sling/assist/assist.go
+++ b/core/sling/assist/assist.go
@@ -94,6 +94,7 @@ var projectRootMarkers = []string{
 	"pyproject.toml",
 	"Cargo.toml",
 	"sling_build.yml",
+	"sling_build.yaml",
 	".sling",
 }
 

--- a/core/sling/assist/prompts.yaml
+++ b/core/sling/assist/prompts.yaml
@@ -27,7 +27,7 @@ _skeleton: |-
 _rules: |-
   - You help with Sling CLI (https://docs.slingdata.io/llms.txt).
   - Use Sling MCP tools when they are wired (connection, database, replication, pipeline, api_spec, file_system).
-  - Validate YAML with MCP `validate`. Execute replications and pipelines with `sling run`. Execute SQL models with `sling build`. There is no MCP `run` or `build` action.
+  - Validate YAML with MCP `validate`. Execute replications and pipelines with `sling run`. Execute SQL models with `sling build run`. There is no MCP `run` or `build` action.
   - Do not invent connection names, streams, or modes. Ask one focused question instead.
   - Never ask for credentials in chat. Use ${VAR} refs and `sling conns set`.
   - Do not read env.yaml or print secrets. Connection names and types only.

--- a/core/sling/assist/report.go
+++ b/core/sling/assist/report.go
@@ -26,23 +26,22 @@ const (
 	githubIssueBaseURL = "https://github.com/slingdata-io/sling-cli/issues/new"
 	contactFormBaseURL = "https://slingdata.io/contact/"
 	maxLogExcerptBytes = 64 * 1024
-	maxSkeletonBytes   = 4 * 1024
 )
 
 // ReportDraft is the composed, redacted report. Both routes consume it.
 type ReportDraft struct {
-	Title        string `json:"title"`
-	Description  string `json:"description"`
-	Config       string `json:"config"`
-	LogExcerpt   string `json:"log_excerpt"`
-	Version      string `json:"version"`
-	OS           string `json:"os"`
-	SourceType   string `json:"source_type"`
-	TargetType   string `json:"target_type"`
-	SignatureID  string `json:"signature_id"`
-	Skeleton     string `json:"skeleton"`
-	ExecID       string `json:"exec_id"`
-	ConnName     string `json:"conn_name,omitempty"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Config      string `json:"config"`
+	LogExcerpt  string `json:"log_excerpt"`
+	Version     string `json:"version"`
+	OS          string `json:"os"`
+	SourceType  string `json:"source_type"`
+	TargetType  string `json:"target_type"`
+	SignatureID string `json:"signature_id"`
+	Skeleton    string `json:"skeleton"`
+	ExecID      string `json:"exec_id"`
+	ConnName    string `json:"conn_name,omitempty"`
 	// CustomDescription is caller-supplied context, shown above the error.
 	CustomDescription string `json:"custom_description,omitempty"`
 }
@@ -90,20 +89,78 @@ func ComposeReport(execID string) (ReportDraft, error) {
 	}
 
 	d := ReportDraft{
-		Title:        reportTitle(label, src, tgt),
-		Description:  reportDescription(redactForReport(errText)),
-		Config:       reportConfig(configPath, connName, le.LogDir),
-		LogExcerpt:   reportLogExcerpt(redactForReport(runLog)),
-		Version:      core.Version,
-		OS:           reportOSName(),
-		SourceType:   src,
-		TargetType:   tgt,
-		SignatureID:  sigID,
-		Skeleton:     skel,
-		ExecID:       le.ID,
-		ConnName:     connName,
+		Title:       reportTitle(label, src, tgt),
+		Description: reportDescription(redactForReport(errText)),
+		Config:      reportConfig(configPath, connName, le.LogDir),
+		LogExcerpt:  reportLogExcerpt(redactForReport(runLog)),
+		Version:     core.Version,
+		OS:          reportOSName(),
+		SourceType:  src,
+		TargetType:  tgt,
+		SignatureID: sigID,
+		Skeleton:    skel,
+		ExecID:      le.ID,
+		ConnName:    connName,
 	}
 	return d, nil
+}
+
+// ReportParts is raw evidence collected outside a local snapshot.
+// ComposeReport redacts it the same way the exec-id ComposeReport
+// redacts on-disk files.
+type ReportParts struct {
+	ExecID            string
+	ErrorText         string
+	LogText           string
+	ConfigBody        string
+	Version           string
+	OS                string
+	SourceType        string
+	TargetType        string
+	ConnName          string
+	CustomDescription string
+}
+
+// ComposeReport builds a redacted ReportDraft from already-collected fields.
+func (p ReportParts) ComposeReport() ReportDraft {
+	src := p.SourceType
+	tgt := p.TargetType
+	skel := Skeleton(p.ErrorText)
+	sig := SignError(p.ErrorText, SignMeta{SourceType: dbio.Type(src), TargetType: dbio.Type(tgt)})
+	label := sig.ShortLabel
+	if src == "" {
+		src = string(sig.Meta.SourceType)
+	}
+	if tgt == "" {
+		tgt = string(sig.Meta.TargetType)
+	}
+	version := p.Version
+	if version == "" {
+		version = core.Version
+	}
+	osName := p.OS
+	if osName == "" {
+		osName = reportOSName()
+	}
+	config := strings.TrimSpace(redactForReport(p.ConfigBody))
+	if config == "" {
+		config = "(not captured)"
+	}
+	return ReportDraft{
+		Title:             reportTitle(label, src, tgt),
+		Description:       reportDescription(redactForReport(p.ErrorText)),
+		Config:            config,
+		LogExcerpt:        reportLogExcerpt(redactForReport(p.LogText)),
+		Version:           version,
+		OS:                osName,
+		SourceType:        src,
+		TargetType:        tgt,
+		SignatureID:       sig.ID,
+		Skeleton:          skel,
+		ExecID:            p.ExecID,
+		ConnName:          p.ConnName,
+		CustomDescription: p.CustomDescription,
+	}
 }
 
 func reportTitle(label, src, tgt string) string {
@@ -300,6 +357,13 @@ func (d ReportDraft) GitHubIssueURL() string {
 // instead (see deliverContactForm).
 func (d ReportDraft) ContactFormURL() string {
 	return contactFormBaseURL + "?issue=" + base64.RawURLEncoding.EncodeToString([]byte(d.BodyMarkdown()))
+}
+
+// ContactFormFits reports whether ContactFormURL stays under the Cloudflare
+// request-line budget. When false, callers should return BodyMarkdown for
+// manual paste instead of the prefilled URL.
+func (d ReportDraft) ContactFormFits() bool {
+	return len(d.ContactFormURL()) <= contactFormURLMax
 }
 
 // deliverGitHubIssue opens a prefilled GitHub issue when the URL fits.
@@ -511,4 +575,3 @@ func confirmSendReport() (bool, error) {
 	}
 	return ok, nil
 }
-

--- a/core/sling/assist/report_test.go
+++ b/core/sling/assist/report_test.go
@@ -356,3 +356,72 @@ func TestHandleReportComposeRedacts(t *testing.T) {
 		t.Fatalf("compose leaked path: %q", d.LogExcerpt)
 	}
 }
+
+func TestComposeReportFromRedactsSecrets(t *testing.T) {
+	d := ReportParts{
+		ExecID:    "exec_platform1",
+		ErrorText: "could not read /Users/alice/secret/file.csv from host",
+		LogText: strings.Join([]string{
+			"opened https://user:s3cretpass@db.internal.example.com/sync",
+			"path=/Users/alice/secret/file.csv",
+			"failed to copy rows",
+		}, "\n"),
+		ConfigBody:        "source: postgres\nurl: https://user:s3cretpass@db.internal.example.com/prod\n",
+		Version:           "1.4.24",
+		OS:                "Linux",
+		SourceType:        "postgres",
+		TargetType:        "snowflake",
+		CustomDescription: "reproduced on first stream",
+	}.ComposeReport()
+	if d.SignatureID == "" {
+		t.Fatal("missing signature")
+	}
+	if !strings.Contains(d.Title, "postgres→snowflake") {
+		t.Fatalf("title = %q", d.Title)
+	}
+	md := d.BodyMarkdown()
+	for _, secret := range []string{"/Users/alice", "db.internal.example.com", "s3cretpass"} {
+		if strings.Contains(d.LogExcerpt, secret) {
+			t.Fatalf("secret %q leaked in LogExcerpt: %q", secret, d.LogExcerpt)
+		}
+		if strings.Contains(d.Config, secret) {
+			t.Fatalf("secret %q leaked in Config: %q", secret, d.Config)
+		}
+		if strings.Contains(md, secret) {
+			t.Fatalf("secret %q leaked in markdown", secret)
+		}
+		if strings.Contains(d.GitHubIssueURL(), secret) {
+			t.Fatalf("secret %q leaked in GitHub URL", secret)
+		}
+	}
+	if !strings.Contains(md, "reproduced on first stream") {
+		t.Fatalf("custom description missing:\n%s", md)
+	}
+}
+
+func TestComposeReportFromContactFormFits(t *testing.T) {
+	small := ReportParts{
+		ExecID:    "exec_small",
+		ErrorText: "boom",
+		LogText:   "log",
+		Version:   "1.4.24",
+		OS:        "Mac",
+	}.ComposeReport()
+	if !small.ContactFormFits() {
+		t.Fatal("small report should fit")
+	}
+	big := ReportDraft{
+		Title:       "boom",
+		Description: "kept",
+		Config:      strings.Repeat("col: value\n", 4000),
+		LogExcerpt:  strings.Repeat("log line\n", 4000),
+		Version:     "1.4.24",
+		OS:          "Mac",
+	}
+	if big.ContactFormFits() {
+		t.Fatal("oversized report should not fit")
+	}
+	if n := len(big.GitHubIssueURL()); n > githubIssueURLMax {
+		t.Fatalf("github url len %d > %d", n, githubIssueURLMax)
+	}
+}

--- a/core/sling/assist/skills/sling-api-specs/FUNCTIONS.md
+++ b/core/sling/assist/skills/sling-api-specs/FUNCTIONS.md
@@ -16,6 +16,12 @@ Functions available within `{...}` expressions. Double-quoted strings are prefer
 | `split_part(str, sep, idx)` | Get split part (1-based) | `split_part("a,b,c", ",", 2)` → "b" |
 | `join(array, sep)` | Join array | `join(["a","b"], ", ")` → "a, b" |
 | `length(value)` | Length of string/array/map | `length("hello")` → 5 |
+| `snake(string)` | Snake case | `snake("Hello World")` → "hello_world" |
+| `slugify(string)` | URL slug | `slugify("Hello World!")` → "hello-world" |
+| `remove_diacritics(s)` | Remove accents | `remove_diacritics("café")` → "cafe" |
+| `replace_accents(s)` | Alias of remove_diacritics | `replace_accents("café")` → "cafe" |
+| `replace_non_printable(s)` | Strip control chars | Cleans non-printable |
+| `replace_0x00(s)` | Remove null bytes | Cleans \x00 |
 
 ## Numeric Functions
 
@@ -29,6 +35,8 @@ Functions available within `{...}` expressions. Double-quoted strings are prefer
 | `least(array\|vals...)` | Minimum value | `least(1, 5, 3)` → 1 |
 | `is_greater(a, b)` | Check a > b | `is_greater(5, 3)` → true |
 | `is_less(a, b)` | Check a < b | `is_less(3, 5)` → true |
+| `int_range(start, end)` | Integer range array | `int_range(1, 3)` → [1,2,3] |
+| `bool_parse(value)` | Parse boolean | `bool_parse("true")` → true |
 
 ## Date Functions
 
@@ -45,6 +53,8 @@ Uses strftime format conventions.
 | `date_extract(date, part)` | Extract part | `date_extract(now(), "year")` → 2024 |
 | `date_last(date[, period])` | Last day of period | `date_last(now(), "month")` |
 | `date_first(date[, period])` | First day of period | `date_first(now(), "month")` |
+| `date_timezone(date, tz)` | Convert timezone | `date_timezone(now(), "UTC")` |
+| `date_range(start, end[, step])` | Alias of range for dates | `date_range(d1, d2, "1d")` |
 | `range(start, end[, step])` | Array of time objects | `range(d1, d2, "1d")` |
 
 **Units**: year, month, week, day, hour, minute, second
@@ -77,6 +87,7 @@ range(date_add(now(), -7, "day"), now(), "1d")
 | `null_if(val, sentinel[, …])` | Null if equal | `null_if("N/A", "N/A")` → null |
 | `nullif(val, sentinel[, …])` | Alias of null_if | `nullif(x, "")` → null |
 | `value(v1, v2, ...)` | First non-empty | `value("", "default")` → "default" |
+| `first_valid(v1, v2, ...)` | Alias of value | `first_valid("", "default")` → "default" |
 | `require(val[, msg])` | Ensure not null | `require(secrets.key, "Key required")` |
 | `cast(val, type)` | Convert type | `cast("42", "int")` → 42 |
 | `try_cast(val, type)` | Convert or null | `try_cast("abc", "int")` → null |
@@ -99,6 +110,7 @@ range(date_add(now(), -7, "day"), now(), "1d")
 | `values(map)` | Get values | `values({"a":1})` → [1] |
 | `exists(coll, item)` | Check existence | `exists({"a":1}, "a")` → true |
 | `jmespath(obj, expr)` | JMESPath query | `jmespath(data, "items[].id")` |
+| `jp(obj, expr)` | Alias of jmespath | `jp(data, "items[].id")` |
 | `jq(obj, expr)` | jq filter (returns array) | `jq(data, ".items[].id")` |
 | `get_path(obj, path)` | Dot notation access | `get_path(data, "a.b[0]")` |
 | `object_rename(map, old, new, ...)` | Rename keys | `object_rename(m, "a", "x")` |
@@ -107,6 +119,8 @@ range(date_add(now(), -7, "day"), now(), "1d")
 | `object_merge(m1, m2, ...)` | Merge maps | `object_merge(m1, m2)` |
 | `object_zip(keys, vals)` | Create from arrays | `object_zip(["a"], [1])` → {"a":1} |
 | `filter(array, expr)` | Filter array | `filter([1,2,3], "value > 1")` → [2,3] |
+| `pluck(array, key)` | Extract field from objects | `pluck([{a:1}], "a")` → [1] |
+| `explode(array)` | Explode array values | Used when flattening lists |
 | `map(array, expr)` | Transform array | `map([1,2,3], "value * 2")` → [2,4,6] |
 | `sort(array[, desc])` | Sort array | `sort([3,1,2])` → [1,2,3] |
 | `chunk(array\|queue, size)` | Split into chunks | `chunk(queue.ids, 50)` |
@@ -141,6 +155,7 @@ chunk(queue.ids, 50)
 | `encode_base64(string)` | Base64 encode | `encode_base64("hello")` |
 | `decode_base64(string)` | Base64 decode | `decode_base64("aGVsbG8=")` |
 | `hash(str[, algo])` | Hash string | `hash("hello", "sha256")` |
+| `json_parse(string)` | Parse JSON string | `json_parse('{"a":1}')` |
 
 **Hash algorithms**: md5, sha1, sha256
 
@@ -152,6 +167,12 @@ chunk(queue.ids, 50)
 | `log(message)` | Log and return | `log("Debug: " + record.id)` |
 | `regex_match(str, pattern)` | Check regex match | `regex_match("img.jpg", ".*\\.jpg")` |
 | `regex_extract(str, pat[, idx])` | Extract regex group | `regex_extract("id=123", "id=(\\d+)", 1)` → "123" |
+| `regex_replace(str, pat, repl)` | Regex replace | `regex_replace("a1", "\\d", "X")` → "aX" |
+| `type_of(value)` | Runtime type name | `type_of(42)` → "integer" |
+| `parse_ms_uuid(string)` | Parse MS UUID timestamp | Extracts time from MS-style UUID |
+| `pretty_table(rows)` | Format rows as table | Debug / log helper |
+| `conn_property(name)` | Connection property | Reads from active connection |
+| `machine_stats()` | Host stats object | Runtime diagnostics |
 
 ## Common Patterns
 

--- a/core/sling/assist/skills/sling-api-specs/INCREMENTAL.md
+++ b/core/sling/assist/skills/sling-api-specs/INCREMENTAL.md
@@ -222,7 +222,7 @@ endpoints:
 - Use `maximum` aggregation for timestamps
 - Use `last` aggregation for cursors
 - Context variables are read-only
-- Inspect the run log to see sync state (CLI: `--debug`; platform: `execs.log`)
+- Inspect the run log to see sync state (CLI: `--debug`; platform: `executions.log`)
 
 ## Related Topics
 

--- a/core/sling/assist/skills/sling-api-specs/INCREMENTAL.md
+++ b/core/sling/assist/skills/sling-api-specs/INCREMENTAL.md
@@ -191,11 +191,7 @@ state:
     }
 ```
 
-Run with override:
-
-```bash
-OVERRIDE_START_DATE="2023-06-01" sling run -r replication.yaml
-```
+Set `OVERRIDE_START_DATE` as a run variable (CLI: an env var on `sling run`; platform: a job `config.variables` entry).
 
 ## Multiple Sync Variables
 
@@ -226,7 +222,7 @@ endpoints:
 - Use `maximum` aggregation for timestamps
 - Use `last` aggregation for cursors
 - Context variables are read-only
-- Test with `--debug` to see sync state
+- Inspect the run log to see sync state (CLI: `--debug`; platform: `execs.log`)
 
 ## Related Topics
 

--- a/core/sling/assist/skills/sling-build/SKILL.md
+++ b/core/sling/assist/skills/sling-build/SKILL.md
@@ -81,7 +81,7 @@ Put YAML in a `/** **/` block. It must be the first content in the file. Leading
 
 You can also use `/* { ... } */` or `-- { ... }` with a brace object.
 
-Front-matter does not rename the model. The model name is the file stem.
+Front-matter does not rename the model. The model name is the file stem. `ref()`, selectors, and `@name` accept the stem or the prod table `schema.table`. Model names are unique across the project.
 
 ## sling_build.yml essentials
 
@@ -90,7 +90,7 @@ target: MY_SNOWFLAKE
 defaults:
   mode: full-refresh
 dev:
-  schema: dev_$USER
+  schema: dev_${USER}
   target: MY_SNOWFLAKE_DEV
 dbt_project: false   # set true for models/+seeds/ layout
 ```
@@ -131,23 +131,25 @@ Never reference a SELECT alias inside the same query's JOIN or WHERE. Use the so
 
 When the warehouse stores an authoritative total (for example `o_totalprice`), aggregate that column. Recompute from components only when asked.
 
-| Goal                                | Command                                              |
-|-------------------------------------|------------------------------------------------------|
-| Compile (no execute)                | `sling build --compile`                              |
-| Run a subset                        | `sling build -s stg_users,fct_orders`                |
-| Run a model + downstream            | `sling build -s +stg_users`                          |
-| Run models by tag                   | `sling build -s tag:daily`                           |
-| List selected models (no execute)   | `sling build -s tag:daily --list`                    |
-| Force full-refresh on incrementals  | `sling build --full-refresh`                         |
-| Dev mode override                   | `sling build --schema dev_alice`                     |
-| Force prod mode                     | `sling build --prod`                                 |
-| Backfill range                      | `sling build -s fct_orders -r 2024-01-01,2024-12-31` |
-| Pass variables                      | `sling build --vars '{start_date: 2024-01-01}'`      |
-| Parallel model runs                 | `sling build --threads 4`                            |
-| Skip seed loading                   | `sling build --no-seeds`                             |
-| Stop on first failure               | `sling build --fail-fast`                            |
-| Sub-project discovery               | `sling build -R` (scans immediate subdirectories)    |
-| Create a project                    | `sling init` (writes `models/sling_build.yml`) |
+| Goal                                | Command                                                    |
+|-------------------------------------|------------------------------------------------------------|
+| Compile (no execute)                | `sling build compile`                                      |
+| Run a subset                        | `sling build run -s stg_users,fct_orders`                  |
+| Run a model + downstream            | `sling build run -s +stg_users`                            |
+| Run models by tag                   | `sling build run -s tag:daily`                             |
+| List selected models (no execute)   | `sling build list -s tag:daily`                            |
+| Path glob                           | `sling build list -s analytics/plausible/*`                |
+| Force full-refresh on incrementals  | `sling build run --full-refresh`                           |
+| Dev mode override                   | `sling build run --schema dev_alice`                       |
+| Force prod mode                     | `sling build run --prod`                                   |
+| Backfill range                      | `sling build run -s fct_orders --range 2024-01-01,2024-12-31,1mo` |
+| Pass variables                      | `sling build run --vars '{start_date: 2024-01-01}'`        |
+| Parallel model runs                 | `sling build run --threads 4`                              |
+| Skip seed loading                   | `sling build run --no-seeds`                               |
+| Stop on first failure               | `sling build run --fail-fast`                              |
+| Sub-project discovery               | `sling build run -R` (scans immediate subdirectories)      |
+| Run declarative tests only          | `sling build test`                                         |
+| Create a project                    | `sling init` (writes `models/sling_build.yml`)              |
 
 Notes:
 - Seeds (CSV files, in `seeds/` with `dbt_project: true`) load before models unless `--no-seeds` is passed.
@@ -156,7 +158,9 @@ Notes:
 - One project root. Do not leave nested scratch projects (`probe/`, `.probe/`). Parent compile skips a subdirectory that has its own `sling_build.yml` unless you pass `-R`.
 - Resolve the Gather first checklist before you write a new model. When you edit an incremental model, preserve saved-state semantics unless asked otherwise.
 
-Definition of done: `sling build . --target X` (or `--test`) completes with 0 failures. Compile alone does not execute SQL, so it does not prove correctness.
+Definition of done: `sling build run . --target X` (or `sling build test`) completes with 0 failures. Compile alone does not execute SQL, so it does not prove correctness.
+
+`${VAR}` in `sling_build.yml` (for example `dev.schema: dev_${USER}`) is expanded from the environment. An unset variable in an active field is an error; use `${VAR:-fallback}` or `--prod` / `--schema` to skip the field.
 
 ## Use the MCP tools to validate
 
@@ -167,8 +171,8 @@ Definition of done: `sling build . --target X` (or `--test`) completes with 0 fa
 When the user asks for a new model, prefer to:
 1. Inspect upstream columns with `database.get_columns` (or `sling conns discover CONN --columns`).
 2. Draft the SQL, including YAML frontmatter when materialization isn't `full-refresh`.
-3. Run `sling build --compile -s <model>` to confirm the SQL renders cleanly.
-4. Run `sling build . --target <conn>` (or `-s <model>`) until it completes with 0 failures.
+3. Run `sling build compile -s <model>` to confirm the SQL renders cleanly.
+4. Run `sling build run . --target <conn>` (or `-s <model>`) until it completes with 0 failures.
 5. Remove scratch files and nested probe projects before you finish.
 
 ## Full Documentation

--- a/core/sling/assist/skills/sling-build/SKILL.md
+++ b/core/sling/assist/skills/sling-build/SKILL.md
@@ -50,6 +50,39 @@ models/
 
 Staging selects from raw via `src()`. Marts use `ref()` to staging or intermediate only. Marts never touch raw.
 
+## `src()` and `ref()`
+
+`src()` is a passthrough. It does **not** add a `raw_` prefix.
+
+```sql
+-- two args: schema, table
+select * from {{ src('raw_stripe', 'invoice') }}
+-- result: select * from raw_stripe.invoice
+
+-- one arg: schema.table
+select * from {{ src('raw_stripe.invoice') }}
+-- result: select * from raw_stripe.invoice
+```
+
+`source()` is an alias of `src()`.
+
+`ref('name')` resolves a model or seed in this project to its full table name. An unknown name is a compile error.
+
+```sql
+select * from {{ ref('stg_orders') }}
+-- result: select * from staging.stg_orders
+```
+
+Duplicate model names in the project are a hard error at load time.
+
+## Front-matter
+
+Put YAML in a `/** **/` block. It must be the first content in the file. Leading whitespace is allowed. Comments before the block are not. The engine treats the rest of the file as SQL.
+
+You can also use `/* { ... } */` or `-- { ... }` with a brace object.
+
+Front-matter does not rename the model. The model name is the file stem.
+
 ## sling_build.yml essentials
 
 ```yaml
@@ -85,7 +118,7 @@ range:
   lookback: 2d
 **/
 
-select * from {{ ref("stg_orders") }} where updated_at > '{{ this.last_value }}'
+select * from {{ ref("stg_orders") }} where {{ incremental_where_cond() }}
 ```
 
 Front-matter `range:` (`start`, `advance`, `lookback`) is the durable backfill window. Pair it with `update_key` and `unique_key`. Do not reverse-engineer the binary for this.

--- a/core/sling/assist/skills/sling-build/STRUCTURE.md
+++ b/core/sling/assist/skills/sling-build/STRUCTURE.md
@@ -4,26 +4,50 @@ Companion to the main build guide. Folder layout for a full ELT repo: https://do
 
 A build project is a directory with `sling_build.yml` plus `.sql` models (and optional seeds). In the canonical project that directory is `models/`.
 
-## Folder = schema
+## Folder = schema, file = table
 
-The 1st folder level is the schema name. Nested folders become an underscore-joined prefix on the model name. Root-level files use the `public` schema.
+The 1st folder level is the schema name. The file name is the table name. Nested folders organize files only; they do not change the table name. Root-level files use the `public` schema.
 
-| File Path | Schema | Prefix | Name | Full Table Name |
-|-----------|--------|--------|------|-----------------|
-| `raw.sql` | public | | raw | `public.raw` |
-| `staging/stg_orders.sql` | staging | | stg_orders | `staging.stg_orders` |
-| `staging/country_codes.csv` | staging | | country_codes | `staging.country_codes` |
-| `marts/core/dim_customers.sql` | marts | core | dim_customers | `marts.core_dim_customers` |
-| `marts/core/fct_orders.sql` | marts | core | fct_orders | `marts.core_fct_orders` |
-| `seeds/status_map.json` | seeds | | status_map | `seeds.status_map` |
+| File Path | Schema | Name | Full Table Name |
+|-----------|--------|------|-----------------|
+| `raw.sql` | public | raw | `public.raw` |
+| `staging/stg_orders.sql` | staging | stg_orders | `staging.stg_orders` |
+| `staging/country_codes.csv` | staging | country_codes | `staging.country_codes` |
+| `marts/core/dim_customers.sql` | marts | dim_customers | `marts.dim_customers` |
+| `marts/core/fct_orders.sql` | marts | fct_orders | `marts.fct_orders` |
+| `seeds/status_map.json` | seeds | status_map | `seeds.status_map` |
 
 Docs: https://docs.slingdata.io/concepts/build/structure.md#naming-rules
 
 ## Names are global
 
-Model and seed names must be unique across the whole project, in every folder. Duplicate names are a hard engine error (`validateUniqueNames`).
+Model names must be unique across the whole project. Two `events.sql` files in different folders are a hard engine error at load:
 
-`stg_customers.sql` in `staging/` and `marts/` still collides. Use `stg_<source>__<entity>` so two sources with the same entity do not collide.
+```
+duplicate model name 'events': found in both 'analytics/plausible/events.sql' and 'analytics/stripe/events.sql'
+```
+
+`ref()`, selectors, and `@name` accept the model name or the prod table (`analytics.events`).
+
+## Database (three-part names)
+
+Folders never set the database. Set it with the `database` key, at the same three levels as `schema`:
+
+```yaml
+# sling_build.yml
+target: MY_SNOWFLAKE
+defaults:
+  database: ANALYTICS_DB
+dev:
+  schema: dev_${USER}
+  database: SCRATCH_DB     # optional; falls back to defaults.database
+```
+
+A model overrides it in front-matter with `database: FIN_DB`.
+
+Order: front-matter, then `dev.database` in dev mode, then `defaults.database`, else empty (two-part name).
+
+Supported dialects: Snowflake, BigQuery, Databricks, Trino, DuckDB family, SQL Server family, Fabric. Other dialects give a compile error.
 
 ## Four layers (project convention)
 
@@ -49,8 +73,10 @@ Staging selects from raw via `src()`. Marts use `ref()` to staging or intermedia
 
 | File Path | Prod | Dev (`dev_fritz`) |
 |-----------|------|-------------------|
-| `staging/stg_orders.sql` | `staging.stg_orders` | `dev_fritz.staging_stg_orders` |
-| `marts/core/dim_customers.sql` | `marts.core_dim_customers` | `dev_fritz.marts_core_dim_customers` |
+| `staging/stg_orders.sql` | `staging.stg_orders` | `dev_fritz.stg_orders` |
+| `marts/core/dim_customers.sql` | `marts.dim_customers` | `dev_fritz.dim_customers` |
+
+Dev and prod names differ only by schema. Names are unique project-wide, so one dev schema never has a collision.
 
 Dev mode is on when `dev:` is present in `sling_build.yml`. Prod mode writes folder-based schemas (CLI `--prod`, pipeline step `prod: true`). Forcing a schema (CLI `--schema`, step `schema:`) selects a dev schema.
 

--- a/core/sling/assist/skills/sling-build/STRUCTURE.md
+++ b/core/sling/assist/skills/sling-build/STRUCTURE.md
@@ -1,6 +1,6 @@
 # Build structure and naming
 
-Companion to [SKILL.md](SKILL.md). Folder layout for a full ELT repo is in [PROJECT.md](../sling/PROJECT.md).
+Companion to the main build guide. Folder layout for a full ELT repo: https://docs.slingdata.io/concepts/project-structure.md
 
 A build project is a directory with `sling_build.yml` plus `.sql` models (and optional seeds). In the canonical project that directory is `models/`.
 
@@ -52,10 +52,10 @@ Staging selects from raw via `src()`. Marts use `ref()` to staging or intermedia
 | `staging/stg_orders.sql` | `staging.stg_orders` | `dev_fritz.staging_stg_orders` |
 | `marts/core/dim_customers.sql` | `marts.core_dim_customers` | `dev_fritz.marts_core_dim_customers` |
 
-Dev mode is on when `dev:` is present in `sling_build.yml`. `--prod` writes folder-based schemas. `--schema` forces a dev schema.
+Dev mode is on when `dev:` is present in `sling_build.yml`. Prod mode writes folder-based schemas (CLI `--prod`, pipeline step `prod: true`). Forcing a schema (CLI `--schema`, step `schema:`) selects a dev schema.
 
 ## Nested configs
 
-`-R` / `--recursive` is opt-in. Without `-R`, only `<path>/sling_build.yml` loads.
+Recursive discovery is opt-in (CLI `-R`/`--recursive`, pipeline step `recursive: true`). Without it, only `<path>/sling_build.yml` loads.
 
-A subdirectory with its own `sling_build.yml` is a nested project. Parent discovery skips it unless you pass `-R` (immediate children only). Do not leave scratch projects (`probe/`) inside a parent.
+A subdirectory with its own `sling_build.yml` is a nested project. Parent discovery skips it unless recursion is enabled (immediate children only). Do not leave scratch projects (`probe/`) inside a parent.

--- a/core/sling/assist/skills/sling-pipelines/SKILL.md
+++ b/core/sling/assist/skills/sling-pipelines/SKILL.md
@@ -70,7 +70,7 @@ sling run -p /path/to/pipeline.yaml
 sling run -p /path/to/pipeline.yaml --debug
 ```
 
-SQL models use `sling build` (there is no MCP `build` action).
+SQL models use `sling build run` (there is no MCP `build` action).
 
 ## Step Types
 
@@ -80,7 +80,7 @@ See [STEPS.md](STEPS.md) for full syntax and options of each type.
 |------|-------------|
 | `log` | Output messages |
 | `replication` | Run a replication (file or inline) |
-| `build` | Run a SQL model project (`sling build`) |
+| `build` | Run a SQL model project (`sling build run`) |
 | `query` | Execute SQL |
 | `http` | HTTP requests |
 | `command` | Shell commands |

--- a/core/sling/assist/skills/sling-pipelines/STEPS.md
+++ b/core/sling/assist/skills/sling-pipelines/STEPS.md
@@ -118,7 +118,7 @@ streams:
   to: "aws_s3/archive/{timestamp.YYYY}/{timestamp.MM}/source.csv"
 ```
 
-Location form is `CONN/path`. `local/rel/file.csv` is cwd-relative; `local//abs/path` (two slashes) is absolute. Bare relative paths (`data/a.csv`, `{loop.value.path}`) are treated as local cwd-relative. After a `list` step prefer `{loop.value.location}` — it is already `CONN/path`.
+Location form is `CONN/path`. `local/rel/file.csv` is relative to the working directory of whichever host runs the step; `local//abs/path` (two slashes) is absolute. Bare relative paths (`data/a.csv`, `{loop.value.path}`) are treated as local relative paths. Prefer a named file connection over `local` when the step may run on a remote agent. After a `list` step prefer `{loop.value.location}` — it is already `CONN/path`.
 
 ### delete
 ```yaml
@@ -224,7 +224,7 @@ Shortcut form: `build: models` (type is inferred). Results land in `state.<id>.o
 ```
 
 ### routine
-Runs a named, reusable group of steps defined in a YAML file under the routines directory (`~/.sling/routines/` or `SLING_ROUTINES_DIR`), where files declare a top-level `routines:` map.
+Runs a named, reusable group of steps defined in a YAML file that declares a top-level `routines:` map. The CLI reads these from `~/.sling/routines/` (or `SLING_ROUTINES_DIR`); on the platform they are project files.
 ```yaml
 - type: routine
   routine: notify_slack

--- a/core/sling/assist/skills/sling-pipelines/STEPS.md
+++ b/core/sling/assist/skills/sling-pipelines/STEPS.md
@@ -191,22 +191,25 @@ Sets values in the `store.*` scope. (`store` is the legacy alias for this type.)
 An inline config can be given via `replication:` instead of `path`.
 
 ### build
-Runs a Sling Build project (SQL models). Completes load → transform in one pipeline.
+Runs a Sling Build project (SQL models). Completes load → transform in one pipeline. `command` matches the CLI verbs: `run` (default), `test`, `compile`, `list`.
 
 ```yaml
 - type: build
   build: models          # project directory (also the working dir)
+  command: run           # run | test | compile | list
   prod: true             # write folder-based schemas
   id: transform
   # optional:
   # target: MY_WAREHOUSE
   # select: [stg_orders, fct_orders]
-  # full_refresh: true
+  # full_refresh: true    # run only
   # fail_fast: true
   # threads: 2
+  # env:
+  #   SLING_DEV_USER: alice
 ```
 
-Shortcut form: `build: models` (type is inferred). Results land in `state.<id>.ok`, `state.<id>.failed`, `state.<id>.total`.
+Shortcut form: `build: models` (type is inferred). `test: true` is an alias for `command: test`. Results land in `state.<id>.ok`, `state.<id>.failed`, `state.<id>.total`, `state.<id>.command`.
 
 ### group
 ```yaml

--- a/core/sling/assist/skills/sling-platform/SKILL.md
+++ b/core/sling/assist/skills/sling-platform/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: sling-platform
 description: >
-  Sling Platform CLI — `sling platform jobs|execs|files|connections`, creating and scheduling jobs, activating/deactivating, checking run history, investigating failed executions, and pushing file fixes back to the platform. Also indexes docs for monitors (freshness, schema drift, anomaly detection), agents, and self-hosting. Use when the user is managing or debugging anything hosted on Sling Platform.
+  Sling Platform CLI — `sling platform jobs|executions|files|connections`, creating and scheduling jobs, activating/deactivating, checking run history, investigating failed executions, and pushing file fixes back to the platform. Also indexes docs for monitors (freshness, schema drift, anomaly detection), agents, and self-hosting. Use when the user is managing or debugging anything hosted on Sling Platform.
 ---
 
 # Sling Platform — Working with Hosted Projects
@@ -32,10 +32,10 @@ sling platform status             # smoke test: project info + counts
 | `sling platform jobs activate <id>` | Enable a job's schedules                          |
 | `sling platform jobs deactivate <id>` | Disable a job's schedules                       |
 | `sling platform jobs delete <id>`  | Remove a job (`--force` skips confirm)             |
-| `sling platform execs list`        | Run history; `--job-id`, `--job-name`, `--status`, `--since`, `--until`, `--limit` |
-| `sling platform execs status <id>` | Per-task / per-step state of one execution         |
-| `sling platform execs log <id>`    | Full log; `--task <stream/step>`, `--status error` to filter |
-| `sling platform execs cancel <id>` | Cancel a running exec                              |
+| `sling platform executions list`        | Run history; `--job-id`, `--job-name`, `--status`, `--since`, `--until`, `--limit` |
+| `sling platform executions status <id>` | Per-task / per-step state of one execution         |
+| `sling platform executions log <id>`    | Full log; `--task <stream/step>`, `--status error` to filter |
+| `sling platform executions cancel <id>` | Cancel a running exec                              |
 | `sling platform files list`        | List YAML files (replications, pipelines, specs)   |
 | `sling platform files get <name>`  | Print a file                                       |
 | `sling platform files save <name>` | Write a file: `-f <path>`, `-f -` (stdin), or `-b '<body>'` |
@@ -51,14 +51,14 @@ Most list/get commands accept `-o json` — prefer it when parsing output.
 If both the CLI stdio MCP (`sling serve mcp`) and the Platform HTTP MCP are attached, pick by location:
 
 - **Local** `env.yaml`, local files, local validate → stdio tools `connection`, `database`, `file_system`, `replication`, `pipeline`, `api_spec`.
-- **Hosted project** (this skill) → platform tools `jobs`, `execs`, `files`, `connections`, `agents`, `compile`, `project`, `monitor`.
+- **Hosted project** (this skill) → platform tools `jobs`, `executions`, `files`, `connections`, `agents`, `replications`, `pipelines`, `builds`, `project`, `monitors`, `specs`.
 
 Same vocabulary as the CLI. `jobs trigger` in the shell is `jobs.trigger` over MCP.
 
 | CLI | MCP |
 |-----|-----|
 | `sling platform jobs list/get/save/trigger/activate/deactivate/status` | `jobs.list` / `get` / `save` / `trigger` / `activate` / `deactivate` / `status` |
-| `sling platform execs list/status/log/cancel` | `execs.list` / `status` / `log` / `cancel` |
+| `sling platform executions list/status/log/cancel` | `executions.list` / `status` / `log` / `cancel` |
 | `sling platform files list/get/save/delete/rename` | `files.list` / `get` / `save` / `delete` / `rename` |
 | `sling platform connections list/test` | `connections.list` / `test` |
 | `sling platform status` | `project.status` |
@@ -116,18 +116,18 @@ cat job.json | sling platform jobs save -f -
 
 ```bash
 sling platform jobs status --name users        # per-job: status, last executed, next scheduled
-sling platform execs list --job-name users --limit 1     # most recent run (name must match one job)
-sling platform execs list --job-id <id> --since 7d       # last week's history
-sling platform execs list --status error --since 24h     # all recent failures
+sling platform executions list --job-name users --limit 1     # most recent run (name must match one job)
+sling platform executions list --job-id <id> --since 7d       # last week's history
+sling platform executions list --status error --since 24h     # all recent failures
 ```
 
 ### Investigate a failed exec
 
 `sling assist --id <exec_id>` starts an assist session with this workflow pre-loaded when the exec exists on the platform.
 
-1. `sling platform execs list --status error --limit 5` — find the failure.
-2. `sling platform execs status <exec_id>` — which task/stream/step failed.
-3. `sling platform execs log <exec_id> --status error` — logs for failing tasks only (add `--task <name>` to zoom in; `--no-color` for clean text).
+1. `sling platform executions list --status error --limit 5` — find the failure.
+2. `sling platform executions status <exec_id>` — which task/stream/step failed.
+3. `sling platform executions log <exec_id> --status error` — logs for failing tasks only (add `--task <name>` to zoom in; `--no-color` for clean text).
 4. `sling platform files get <file_name>` — pull the YAML to read/edit locally.
 5. Validate the fix locally with MCP `replication validate` / `pipeline validate`, then run it: `sling run -r users.yaml` or `sling run -p pipeline.yaml`.
 6. `cat fixed.yaml | sling platform files save <file_name> -f -` — push back.

--- a/core/sling/assist/skills/sling-python/SKILL.md
+++ b/core/sling/assist/skills/sling-python/SKILL.md
@@ -48,7 +48,7 @@ Plain pip also works: `pip install sling` / `pip install 'sling[arrow]'`. The sl
 
 ## `Sling` — single tasks and streaming
 
-Kwargs mirror CLI flags: `src_conn`, `src_stream`, `src_options`, `tgt_conn`, `tgt_object`, `tgt_options`, `mode`, `primary_key`, `update_key`, `select`, `where`, `limit`, `range`, `env`, `debug`.
+Kwargs mirror CLI flags: `src_conn`, `src_stream`, `src_options`, `tgt_conn`, `tgt_object`, `tgt_options`, `mode`, `primary_key`, `update_key`, `select`, `where`, `limit`, `offset`, `range`, `streams`, `columns`, `transforms`, `cdc_options`, `stdout`, `env`, `debug`, `trace`, `replication`, `pipeline`, `directory`, `job`, `config`, `home_dir`. Python-only: `input=` for pushing data in.
 
 ```python
 from sling import Sling, Mode
@@ -141,7 +141,7 @@ Pipeline(
 ).run()
 ```
 
-Step classes (aliases of `Hook*`): `StepQuery`, `StepHTTP`, `StepCheck`, `StepRead`, `StepWrite`, `StepCopy`, `StepDelete`, `StepLog`, `StepInspect`, `StepList`, `StepReplication`, `StepCommand`, `StepGroup`, `StepStore`. See the `sling-pipelines` skill for each step's parameters.
+Step classes (aliases of `Hook*`): `StepQuery`, `StepHTTP`, `StepCheck`, `StepRead`, `StepWrite`, `StepCopy`, `StepDelete`, `StepLog`, `StepInspect`, `StepList`, `StepReplication`, `StepCommand`, `StepGroup`, `StepSet` (legacy `StepStore`), `StepRoutine`, `StepBuild`. See the `sling-pipelines` skill for each step's parameters.
 
 ## `Connection` — test and query
 

--- a/core/sling/assist/skills/sling-replications/TRANSFORMS.md
+++ b/core/sling/assist/skills/sling-replications/TRANSFORMS.md
@@ -47,6 +47,7 @@ transforms:
 | `snake(s)` | Snake case | `snake("Hello World")` -> "hello_world" |
 | `slugify(s)` | URL slug | `slugify("Hello World!")` -> "hello-world" |
 | `remove_diacritics(s)` | Remove accents | `remove_diacritics("café")` -> "cafe" |
+| `replace_accents(s)` | Alias of remove_diacritics | `replace_accents("café")` -> "cafe" |
 | `replace_non_printable(s)` | Clean string | Removes control chars |
 | `replace_0x00(s)` | Remove null bytes | Cleans null chars |
 
@@ -79,6 +80,7 @@ transforms:
 | `date_first(d, period)` | First of period | `date_first(now(), "month")` |
 | `date_last(d, period)` | Last of period | `date_last(now(), "month")` |
 | `date_range(s, e, step)` | Date range | `date_range("2024-01-01", "2024-01-03", "1d")` |
+| `range(s, e[, step])` | Alias of date_range (time array) | `range(d1, d2, "1d")` |
 | `date_timezone(d, tz)` | Convert TZ | `date_timezone(now(), "America/New_York")` |
 
 **Date units**: year, month, week, day, hour, minute, second
@@ -117,9 +119,15 @@ transforms:
 | `sort(arr, desc?)` | Sort array | `sort([3,1,2])` -> [1,2,3] |
 | `pluck(arr, key)` | Extract field | `pluck([{a:1},{a:2}], "a")` -> [1,2] |
 | `jmespath(obj, expr)` | JMESPath query | `jmespath(data, "items[].name")` |
+| `jp(obj, expr)` | Alias of jmespath | `jp(data, "items[].name")` |
 | `jq(obj, expr)` | jq filter (returns array) | `jq(data, ".items[].name")` |
 | `get_path(obj, path)` | Get by path | `get_path(obj, "a.b[0]")` |
 | `object_merge(...)` | Merge objects | `object_merge({a:1}, {b:2})` |
+| `object_delete(obj, keys...)` | Delete keys | `object_delete(obj, "a")` |
+| `object_rename(obj, map)` | Rename keys | `object_rename(obj, {"a":"b"})` |
+| `object_zip(keys, vals)` | Zip to object | `object_zip(["a"], [1])` |
+| `object_casing(obj, casing)` | Recase keys | `object_casing(obj, "snake")` |
+| `explode(arr)` | Explode array to rows | Used in staged transforms |
 | `chunk(arr, size)` | Split chunks | `chunk([1,2,3,4], 2)` |
 
 ## Encoding Functions
@@ -143,6 +151,10 @@ transforms:
 | `regex_extract(s, pat, i)` | Extract match | `regex_extract("id=123", "id=(\\d+)", 1)` |
 | `regex_replace(s, pat, r)` | Replace pattern | `regex_replace("a1b2", "\\d", "X")` |
 | `type_of(v)` | Get type | `type_of(42)` -> "integer" |
+| `parse_ms_uuid(s)` | Parse MS UUID timestamp | Extracts time from MS-style UUID |
+| `pretty_table(rows)` | Format as table string | Debug / log helper |
+| `conn_property(name)` | Connection property | Reads from active connection |
+| `machine_stats()` | Host stats object | Runtime diagnostics |
 
 ## Transform Examples
 

--- a/core/sling/assist/skills/sling/PROJECT.md
+++ b/core/sling/assist/skills/sling/PROJECT.md
@@ -119,7 +119,7 @@ Probe state before you change files. Then tell the user the next step. Every har
 |--------------|-----------|
 | Zero connections | Scaffold connections. Load [CONNECTIONS.md](CONNECTIONS.md). Do not ask for secrets in chat. |
 | No project (no `replications/`, `models/`, or `pipelines/`) | Run `sling init` to scaffold the canonical layout above. |
-| Project present | Lint, then `sling build models --compile`, then run. |
+| Project present | Lint, then `sling build compile models`, then `sling build run`. |
 
 Always end with the next step on this ladder. Do not skip the probe.
 
@@ -154,7 +154,7 @@ Keep **one model per file**. Split when:
 * A mart query mixes two grains (order vs order line) — make two marts.
 * A file grows past one SELECT with a clear name — extract the shared logic to intermediate or a macro.
 
-Do not split only to match a BI folder. Nested folders under `marts/` become a name prefix (`marts/core/fct_orders.sql` → `marts.core_fct_orders`). Prefer a flat `marts/` unless the prefix is deliberate.
+Do not split only to match a BI folder. Nested folders under `marts/` do not change the table name (`marts/core/fct_orders.sql` → `marts.fct_orders`). Model names are unique across the project.
 
 ### Layer
 

--- a/core/sling/assist/skills/sling/SKILL.md
+++ b/core/sling/assist/skills/sling/SKILL.md
@@ -91,8 +91,8 @@ sling conns exec MY_PG "select 1"   # Run a SQL query (add -o json|csv|arrow)
 sling run -r replication.yaml       # Run replication
 sling run -p pipeline.yaml          # Run pipeline
 sling run -r replication.yaml --debug   # Run with debug logging
-sling build                         # Run SQL models
-sling build --compile               # Compile models without executing
+sling build run                     # Run SQL models
+sling build compile                 # Compile models without executing
 sling assist --id <id>              # Investigate a failure (id from the error footer)
 sling assist error <sig>            # Look up an error signature (from prompt context)
 sling assist report --id <id>       # Review a redacted issue report

--- a/core/sling/assist/testdata/print_ask.golden
+++ b/core/sling/assist/testdata/print_ask.golden
@@ -1,7 +1,7 @@
 # Rules
 - You help with Sling CLI (https://docs.slingdata.io/llms.txt).
 - Use Sling MCP tools when they are wired (connection, database, replication, pipeline, api_spec, file_system).
-- Validate YAML with MCP `validate`. Execute replications and pipelines with `sling run`. Execute SQL models with `sling build`. There is no MCP `run` or `build` action.
+- Validate YAML with MCP `validate`. Execute replications and pipelines with `sling run`. Execute SQL models with `sling build run`. There is no MCP `run` or `build` action.
 - Do not invent connection names, streams, or modes. Ask one focused question instead.
 - Never ask for credentials in chat. Use ${VAR} refs and `sling conns set`.
 - Do not read env.yaml or print secrets. Connection names and types only.

--- a/core/sling/assist/testdata/print_default.golden
+++ b/core/sling/assist/testdata/print_default.golden
@@ -1,7 +1,7 @@
 # Rules
 - You help with Sling CLI (https://docs.slingdata.io/llms.txt).
 - Use Sling MCP tools when they are wired (connection, database, replication, pipeline, api_spec, file_system).
-- Validate YAML with MCP `validate`. Execute replications and pipelines with `sling run`. Execute SQL models with `sling build`. There is no MCP `run` or `build` action.
+- Validate YAML with MCP `validate`. Execute replications and pipelines with `sling run`. Execute SQL models with `sling build run`. There is no MCP `run` or `build` action.
 - Do not invent connection names, streams, or modes. Ask one focused question instead.
 - Never ask for credentials in chat. Use ${VAR} refs and `sling conns set`.
 - Do not read env.yaml or print secrets. Connection names and types only.

--- a/core/sling/assist/testdata/print_failed_run.golden
+++ b/core/sling/assist/testdata/print_failed_run.golden
@@ -1,7 +1,7 @@
 # Rules
 - You help with Sling CLI (https://docs.slingdata.io/llms.txt).
 - Use Sling MCP tools when they are wired (connection, database, replication, pipeline, api_spec, file_system).
-- Validate YAML with MCP `validate`. Execute replications and pipelines with `sling run`. Execute SQL models with `sling build`. There is no MCP `run` or `build` action.
+- Validate YAML with MCP `validate`. Execute replications and pipelines with `sling run`. Execute SQL models with `sling build run`. There is no MCP `run` or `build` action.
 - Do not invent connection names, streams, or modes. Ask one focused question instead.
 - Never ask for credentials in chat. Use ${VAR} refs and `sling conns set`.
 - Do not read env.yaml or print secrets. Connection names and types only.

--- a/core/sling/assist/testdata/print_no_project.golden
+++ b/core/sling/assist/testdata/print_no_project.golden
@@ -1,7 +1,7 @@
 # Rules
 - You help with Sling CLI (https://docs.slingdata.io/llms.txt).
 - Use Sling MCP tools when they are wired (connection, database, replication, pipeline, api_spec, file_system).
-- Validate YAML with MCP `validate`. Execute replications and pipelines with `sling run`. Execute SQL models with `sling build`. There is no MCP `run` or `build` action.
+- Validate YAML with MCP `validate`. Execute replications and pipelines with `sling run`. Execute SQL models with `sling build run`. There is no MCP `run` or `build` action.
 - Do not invent connection names, streams, or modes. Ask one focused question instead.
 - Never ask for credentials in chat. Use ${VAR} refs and `sling conns set`.
 - Do not read env.yaml or print secrets. Connection names and types only.

--- a/core/sling/assist/testdata/print_zero_connections.golden
+++ b/core/sling/assist/testdata/print_zero_connections.golden
@@ -1,7 +1,7 @@
 # Rules
 - You help with Sling CLI (https://docs.slingdata.io/llms.txt).
 - Use Sling MCP tools when they are wired (connection, database, replication, pipeline, api_spec, file_system).
-- Validate YAML with MCP `validate`. Execute replications and pipelines with `sling run`. Execute SQL models with `sling build`. There is no MCP `run` or `build` action.
+- Validate YAML with MCP `validate`. Execute replications and pipelines with `sling run`. Execute SQL models with `sling build run`. There is no MCP `run` or `build` action.
 - Do not invent connection names, streams, or modes. Ask one focused question instead.
 - Never ask for credentials in chat. Use ${VAR} refs and `sling conns set`.
 - Do not read env.yaml or print secrets. Connection names and types only.

--- a/core/sling/build/build.go
+++ b/core/sling/build/build.go
@@ -29,7 +29,7 @@ type Build struct {
 	connEntries connection.ConnEntries // pre-resolved connection entries for parallel execution
 	ExecRows    uint64                 // sum of model/seed rows after Execute
 	ExecBytes   uint64
-	Results     []ExecutionResult      // per-node results after Execute
+	Results     []ExecutionResult // per-node results after Execute
 }
 
 // NewBuild creates a new Build from the given project directory and options.
@@ -502,55 +502,96 @@ func (b *Build) PrintCompileJSON() {
 	if len(b.SubBuilds) > 0 {
 		var all []map[string]any
 		for _, sub := range b.SubBuilds {
-			all = append(all, sub.compileJSONPayload())
+			all = append(all, sub.CompileJSONPayload())
 		}
 		fmt.Println(g.Marshal(all))
 		return
 	}
-	fmt.Println(g.Marshal(b.compileJSONPayload()))
+	fmt.Println(g.Marshal(b.CompileJSONPayload()))
 }
 
-// CompileJSONPayload returns the --compile --json object.
+// NodeTypeModel and NodeTypeSeed are the compiled node types.
+const (
+	NodeTypeModel = "model"
+	NodeTypeSeed  = "seed"
+)
+
+// Compiled returns the project config with the compile output set: the resolved
+// target, the selected nodes in execution order, and the compiled SQL of each.
 // Safe when Compile did not finish (e.g. a cycle): order/nodes stay empty.
-func (b *Build) CompileJSONPayload() map[string]any {
+func (b *Build) Compiled() *BuildConfig {
 	if b == nil {
-		return map[string]any{"order": []string{}, "nodes": []map[string]any{}, "target": ""}
+		return &BuildConfig{Order: []string{}, Nodes: []Node{}}
 	}
-	if b.DAG == nil {
-		return map[string]any{"order": []string{}, "nodes": []map[string]any{}, "target": b.GetTarget()}
-	}
-	return b.compileJSONPayload()
-}
 
-func (b *Build) compileJSONPayload() map[string]any {
-	nodes := make([]map[string]any, 0, len(b.Selected))
+	// set the output on the project config itself, so the config and its
+	// compile output stay one object (like sling.ReplicationConfig.Tasks)
+	cfg := b.Project.GetConfig()
+	cfg.Target = b.GetTarget()
+	cfg.Order = []string{}
+	cfg.Nodes = []Node{}
+	cfg.Compiled = false
+
+	if b.DAG == nil {
+		return cfg
+	}
+
 	for _, name := range b.Selected {
 		node := b.DAG.Nodes[name]
 		if node == nil {
 			continue
 		}
-		m := map[string]any{"name": name}
+		n := Node{Name: name}
 		if node.Seed != nil {
-			m["type"] = "seed"
-			m["table"] = node.Seed.FullTableName
-			m["file"] = filepath.ToSlash(node.Seed.RelPath)
+			n.Type = NodeTypeSeed
+			n.Table = node.Seed.FullTableName
+			n.File = filepath.ToSlash(node.Seed.RelPath)
 		} else if node.Model != nil {
-			m["type"] = "model"
-			m["table"] = node.Model.FullTableName
-			m["file"] = filepath.ToSlash(node.Model.RelPath)
-			m["mode"] = b.GetModelMode(node.Model)
-			m["dependencies"] = node.Dependencies
-			m["sql"] = node.Model.CompiledSQL
-			if len(node.Model.Config.Tests) > 0 {
-				m["tests"] = node.Model.Config.Tests
+			n.Type = NodeTypeModel
+			n.Table = node.Model.FullTableName
+			n.File = filepath.ToSlash(node.Model.RelPath)
+			n.Mode = b.GetModelMode(node.Model)
+			n.Dependencies = node.Dependencies
+			n.SQL = node.Model.CompiledSQL
+			n.Tests = node.Model.Config.Tests
+		}
+		cfg.Nodes = append(cfg.Nodes, n)
+	}
+	cfg.Order = append(cfg.Order, b.Selected...)
+	cfg.Compiled = true
+
+	return cfg
+}
+
+// CompileJSONPayload returns the --compile --json object.
+func (b *Build) CompileJSONPayload() map[string]any {
+	return b.Compiled().JSONPayload()
+}
+
+// JSONPayload renders the compile output as the --compile --json object.
+// Node keys are omitted when empty, to keep the payload as it was.
+func (c *BuildConfig) JSONPayload() map[string]any {
+	nodes := make([]map[string]any, 0, len(c.Nodes))
+	for _, node := range c.Nodes {
+		m := map[string]any{"name": node.Name}
+		setIf := func(key string, val any, ok bool) {
+			if ok {
+				m[key] = val
 			}
 		}
+		setIf("type", node.Type, node.Type != "")
+		setIf("table", node.Table, node.Table != "")
+		setIf("file", node.File, node.File != "")
+		setIf("mode", node.Mode, node.Mode != "")
+		setIf("dependencies", node.Dependencies, node.Type == NodeTypeModel)
+		setIf("sql", node.SQL, node.SQL != "")
+		setIf("tests", node.Tests, len(node.Tests) > 0)
 		nodes = append(nodes, m)
 	}
 	return map[string]any{
-		"order":  append([]string{}, b.Selected...),
+		"order":  c.Order,
 		"nodes":  nodes,
-		"target": b.GetTarget(),
+		"target": c.Target,
 	}
 }
 

--- a/core/sling/build/build.go
+++ b/core/sling/build/build.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 
 	"github.com/flarco/g"
+	"github.com/samber/lo"
 	"github.com/slingdata-io/golyglot"
 	"github.com/slingdata-io/sling-cli/core/dbio"
 	"github.com/slingdata-io/sling-cli/core/dbio/connection"
@@ -27,6 +29,7 @@ type Build struct {
 	connEntries connection.ConnEntries // pre-resolved connection entries for parallel execution
 	ExecRows    uint64                 // sum of model/seed rows after Execute
 	ExecBytes   uint64
+	Results     []ExecutionResult      // per-node results after Execute
 }
 
 // NewBuild creates a new Build from the given project directory and options.
@@ -50,7 +53,7 @@ func NewBuild(dir string, opts BuildOptions) (*Build, error) {
 func (b *Build) Compile() error {
 	// For sub-projects (independent builds), compile each one
 	if len(b.Project.SubProjects) > 0 {
-		if !b.Options.Compile {
+		if !b.Options.Compile && !b.Options.List {
 			return nil // sub-projects are compiled individually during Execute
 		}
 		for _, subProject := range b.Project.SubProjects {
@@ -74,7 +77,7 @@ func (b *Build) Compile() error {
 	if b.Options.Target != "" {
 		target = b.Options.Target
 	}
-	if target == "" {
+	if target == "" && !b.Options.List {
 		return g.Error("No target specified. Use '--target <conn>' or set target in sling_build.yml.")
 	}
 
@@ -102,7 +105,10 @@ func (b *Build) Compile() error {
 		if model.Config.Rewrite != nil && !*model.Config.Rewrite {
 			continue
 		}
-		rewritten, deps := RewriteTableReferences(model.CompiledSQL, b.Project, model.Name)
+		rewritten, deps, err := RewriteTableReferences(model.CompiledSQL, b.Project, model.Name)
+		if err != nil {
+			return g.Error(err, "could not rewrite table references in model '%s'", model.Name)
+		}
 		model.CompiledSQL = rewritten
 		for _, dep := range deps {
 			if !containsStr(model.DependsOn, dep) {
@@ -111,9 +117,15 @@ func (b *Build) Compile() error {
 		}
 	}
 
-	// Split multi-statement models into pre-statements, model query, and post-statements
-	if err := b.splitMultiStatementModels(); err != nil {
-		return g.Error(err, "could not parse multi-statement models")
+	// Split multi-statement models into pre-statements, model query, and post-statements.
+	// List without a target skips this — splitting needs a dialect.
+	if target != "" {
+		if err := b.validateDatabaseSupport(); err != nil {
+			return err
+		}
+		if err := b.splitMultiStatementModels(); err != nil {
+			return g.Error(err, "could not parse multi-statement models")
+		}
 	}
 
 	// Auto-detect SQL references as a safety net for DependsOn (catches edge cases
@@ -149,6 +161,7 @@ func (b *Build) Compile() error {
 
 	// Apply selectors
 	selector := NewSelector(b.Options.Select, b.Options.Exclude)
+	selector.Project = b.Project
 	selected, err := selector.Apply(b.DAG)
 	if err != nil {
 		return g.Error(err, "could not apply selectors")
@@ -208,6 +221,33 @@ func (b *Build) splitMultiStatementModels() error {
 		model.PostStatements = result.PostStatements
 	}
 	return nil
+}
+
+// validateDatabaseSupport fails when a model or seed sets a database but the
+// target dialect cannot address objects as database.schema.table.
+func (b *Build) validateDatabaseSupport() error {
+	dbType := b.resolveDbType()
+	if dbType == dbio.TypeUnknown || dbType.SupportsThreePartName() {
+		return nil
+	}
+	for _, name := range sortedKeys(b.Project.Models) {
+		if db := b.Project.Models[name].Database; db != "" {
+			return g.Error("model '%s': database '%s' is set but %s does not support database.schema.table names", name, db, dbType)
+		}
+	}
+	for _, name := range sortedKeys(b.Project.Seeds) {
+		if db := b.Project.Seeds[name].Database; db != "" {
+			return g.Error("seed '%s': database '%s' is set but %s does not support database.schema.table names", name, db, dbType)
+		}
+	}
+	return nil
+}
+
+// sortedKeys returns map keys in sorted order for deterministic error output.
+func sortedKeys[T any](m map[string]T) []string {
+	keys := lo.Keys(m)
+	sort.Strings(keys)
+	return keys
 }
 
 // resolveDbType determines the database type from the target connection
@@ -283,6 +323,7 @@ func (b *Build) Execute() error {
 	}
 
 	err = executor.Execute()
+	b.Results = executor.Results
 	for _, r := range executor.Results {
 		b.ExecRows += r.Rows
 		b.ExecBytes += r.Bytes
@@ -306,27 +347,56 @@ func (b *Build) PrintListOutput() {
 		return
 	}
 
+	showTable := b.GetTarget() != ""
+	type row struct {
+		name, table, mode, file string
+	}
+	var rows []row
+	nameW, tableW := 0, 0
 	for _, name := range b.Selected {
 		node := b.DAG.Nodes[name]
+		if node == nil {
+			continue
+		}
 		if b.Options.NoSeeds && node.Seed != nil {
 			continue
 		}
-		nodeType := ""
+		r := row{name: name}
 		if node.Seed != nil {
-			nodeType = "seed"
+			r.mode = "seed"
+			r.table = node.Seed.FullTableName
+			r.file = node.Seed.RelPath
 		} else if node.Model != nil {
-			nodeType = b.GetModelMode(node.Model)
+			r.mode = b.GetModelMode(node.Model)
+			r.table = node.Model.FullTableName
+			r.file = node.Model.RelPath
 		}
-		fmt.Printf("%s (%s)\n", name, nodeType)
+		if len(r.name) > nameW {
+			nameW = len(r.name)
+		}
+		if len(r.table) > tableW {
+			tableW = len(r.table)
+		}
+		rows = append(rows, r)
+	}
+	for _, r := range rows {
+		if showTable {
+			fmt.Printf("%-*s   %-*s   (%s)\n", nameW, r.name, tableW, r.table, r.mode)
+		} else {
+			fmt.Printf("%-*s   %s   (%s)\n", nameW, r.name, r.file, r.mode)
+		}
 	}
 }
 
 // PrintListJSON prints selected nodes as JSON.
 func (b *Build) PrintListJSON() {
 	type item struct {
-		Name string `json:"name"`
-		Type string `json:"type"`
+		Name  string `json:"name"`
+		Type  string `json:"type"`
+		Table string `json:"table,omitempty"`
+		File  string `json:"file,omitempty"`
 	}
+	showTable := b.GetTarget() != ""
 	var items []item
 	for _, name := range b.Selected {
 		node := b.DAG.Nodes[name]
@@ -339,8 +409,42 @@ func (b *Build) PrintListJSON() {
 		it := item{Name: name}
 		if node.Seed != nil {
 			it.Type = "seed"
+			it.File = node.Seed.RelPath
+			if showTable {
+				it.Table = node.Seed.FullTableName
+			}
 		} else if node.Model != nil {
 			it.Type = b.GetModelMode(node.Model)
+			it.File = node.Model.RelPath
+			if showTable {
+				it.Table = node.Model.FullTableName
+			}
+		}
+		items = append(items, it)
+	}
+	fmt.Println(g.Marshal(items))
+}
+
+// PrintTestJSON prints per-node test results as JSON.
+func (b *Build) PrintTestJSON() {
+	type item struct {
+		Name     string `json:"name"`
+		Type     string `json:"type"`
+		Status   string `json:"status"`
+		Error    string `json:"error,omitempty"`
+		Duration string `json:"duration,omitempty"`
+	}
+	items := make([]item, 0, len(b.Results))
+	for _, r := range b.Results {
+		it := item{Name: r.Name, Type: r.NodeType, Duration: r.Duration.String()}
+		switch {
+		case r.Skipped:
+			it.Status = "skip"
+		case r.Err != nil:
+			it.Status = "fail"
+			it.Error = r.Err.Error()
+		default:
+			it.Status = "ok"
 		}
 		items = append(items, it)
 	}

--- a/core/sling/build/build.go
+++ b/core/sling/build/build.go
@@ -25,6 +25,8 @@ type Build struct {
 	Selected    []string               // selected node names after selector filtering
 	SubBuilds   []*Build               // compiled sub-projects (for multi-target compile mode)
 	connEntries connection.ConnEntries // pre-resolved connection entries for parallel execution
+	ExecRows    uint64                 // sum of model/seed rows after Execute
+	ExecBytes   uint64
 }
 
 // NewBuild creates a new Build from the given project directory and options.
@@ -280,7 +282,12 @@ func (b *Build) Execute() error {
 		return err
 	}
 
-	return executor.Execute()
+	err = executor.Execute()
+	for _, r := range executor.Results {
+		b.ExecRows += r.Rows
+		b.ExecBytes += r.Bytes
+	}
+	return err
 }
 
 // PrintListOutput prints the selected models/seeds and exits.

--- a/core/sling/build/build.go
+++ b/core/sling/build/build.go
@@ -319,6 +319,7 @@ func (b *Build) Execute() error {
 
 	executor, err := NewExecutor(b)
 	if err != nil {
+		SyncBuildFailure(err)
 		return err
 	}
 

--- a/core/sling/build/build.go
+++ b/core/sling/build/build.go
@@ -589,9 +589,10 @@ func (c *BuildConfig) JSONPayload() map[string]any {
 		nodes = append(nodes, m)
 	}
 	return map[string]any{
-		"order":  c.Order,
-		"nodes":  nodes,
-		"target": c.Target,
+		"order":    c.Order,
+		"nodes":    nodes,
+		"target":   c.Target,
+		"compiled": c.Compiled,
 	}
 }
 

--- a/core/sling/build/build_test.go
+++ b/core/sling/build/build_test.go
@@ -482,3 +482,13 @@ WHERE created_at > (SELECT MAX(created_at) FROM {{ this }})
 	fmt.Println("style:", style, "err:", err)
 	fmt.Println("StyleDbt:", StyleDbt, "StyleSling:", StyleSling)
 }
+
+func TestCompileDatabaseUnsupportedDialect(t *testing.T) {
+	project, err := LoadProject(getTestFixturePath("database_project"), BuildOptions{Prod: true})
+	require.NoError(t, err)
+
+	b := &Build{Project: project, Options: BuildOptions{Target: "POSTGRES", Prod: true}}
+	err = b.Compile()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support database.schema.table")
+}

--- a/core/sling/build/build_test.go
+++ b/core/sling/build/build_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/flarco/g"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -491,4 +493,27 @@ func TestCompileDatabaseUnsupportedDialect(t *testing.T) {
 	err = b.Compile()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not support database.schema.table")
+}
+
+// The platform scheduler gates a build run on the "compiled" flag surviving the
+// agent-to-master JSON round-trip. Dropping it errors with "no model compiled".
+func TestJSONPayloadCarriesCompiled(t *testing.T) {
+	dir := getTestFixturePath("sample_project")
+
+	b, err := NewBuild(dir, BuildOptions{Target: "POSTGRES"})
+	require.NoError(t, err)
+	require.NoError(t, b.Compile())
+
+	payload := b.CompileJSONPayload()
+	require.Contains(t, payload, "compiled")
+	assert.Equal(t, true, payload["compiled"])
+
+	var got *BuildConfig
+	require.NoError(t, g.JSONConvert(payload, &got))
+	assert.True(t, got.Compiled)
+	assert.NotEmpty(t, got.Nodes)
+
+	// a build that never compiled must stay false
+	var nilBuild *Build
+	assert.Equal(t, false, nilBuild.Compiled().JSONPayload()["compiled"])
 }

--- a/core/sling/build/ddl.go
+++ b/core/sling/build/ddl.go
@@ -168,7 +168,7 @@ func (e *Executor) createTableAs(fullName, selectSQL string, model *Model) (uint
 	dbType := e.DbConn.GetType()
 
 	if e.isClickHouse() {
-		engineClause := "ENGINE = Memory"
+		engineClause := "ENGINE = MergeTree()"
 		orderByClause := "ORDER BY tuple()"
 		settings := ""
 		if model != nil {

--- a/core/sling/build/ddl.go
+++ b/core/sling/build/ddl.go
@@ -155,21 +155,20 @@ func (e *Executor) truncateTable(fullName string) error {
 }
 
 // insertSelect inserts the result of a SELECT into an existing table.
-func (e *Executor) insertSelect(fullName, selectSQL string) error {
+func (e *Executor) insertSelect(fullName, selectSQL string) (uint64, error) {
 	quoted, err := e.quoteFullTableName(fullName)
 	if err != nil {
-		return err
+		return 0, err
 	}
-	_, err = e.DbConn.Exec(g.F("INSERT INTO %s (%s)", quoted, selectSQL))
-	return err
+	return rowsFromExec(e.DbConn.Exec(g.F("INSERT INTO %s (%s)", quoted, selectSQL)))
 }
 
 // createTableAs creates a table from a SELECT, dialect-aware.
 // model may be nil for temp tables that don't need ClickHouse engine config.
-func (e *Executor) createTableAs(fullName, selectSQL string, model *Model) error {
+func (e *Executor) createTableAs(fullName, selectSQL string, model *Model) (uint64, error) {
 	quoted, err := e.quoteFullTableName(fullName)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	dbType := e.DbConn.GetType()
 
@@ -187,52 +186,46 @@ func (e *Executor) createTableAs(fullName, selectSQL string, model *Model) error
 				settings = " SETTINGS allow_nullable_key = 1"
 			}
 		}
-		_, err = e.DbConn.Exec(g.F("CREATE TABLE %s %s %s%s AS (%s)", quoted, engineClause, orderByClause, settings, selectSQL))
-		return err
+		return rowsFromExec(e.DbConn.Exec(g.F("CREATE TABLE %s %s %s%s AS (%s)", quoted, engineClause, orderByClause, settings, selectSQL)))
 	}
 
 	if isSQLServerFamily(dbType) {
 		// SQL Server has no CTAS; use SELECT INTO
-		_, err = e.DbConn.Exec(g.F("SELECT * INTO %s FROM (%s) AS _sling_src", quoted, selectSQL))
-		return err
+		return rowsFromExec(e.DbConn.Exec(g.F("SELECT * INTO %s FROM (%s) AS _sling_src", quoted, selectSQL)))
 	}
 
 	// Standard CTAS (Postgres, MySQL, Snowflake, BigQuery, DuckDB, …)
-	_, err = e.DbConn.Exec(g.F("CREATE TABLE %s AS (%s)", quoted, selectSQL))
-	return err
+	return rowsFromExec(e.DbConn.Exec(g.F("CREATE TABLE %s AS (%s)", quoted, selectSQL)))
 }
 
 // createOrReplaceTableAs atomically rebuilds a table from a SELECT when the
 // dialect supports CREATE OR REPLACE TABLE.
-func (e *Executor) createOrReplaceTableAs(fullName, selectSQL string, model *Model) error {
+func (e *Executor) createOrReplaceTableAs(fullName, selectSQL string, model *Model) (uint64, error) {
 	quoted, err := e.quoteFullTableName(fullName)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	if e.isClickHouse() {
 		// ClickHouse: drop + create (atomic path uses rename elsewhere)
 		return e.createTableAs(fullName, selectSQL, model)
 	}
-	_, err = e.DbConn.Exec(g.F("CREATE OR REPLACE TABLE %s AS (%s)", quoted, selectSQL))
-	return err
+	return rowsFromExec(e.DbConn.Exec(g.F("CREATE OR REPLACE TABLE %s AS (%s)", quoted, selectSQL)))
 }
 
 // createOrReplaceView creates/replaces a view, dialect-aware.
-func (e *Executor) createOrReplaceView(fullName, selectSQL string) error {
+func (e *Executor) createOrReplaceView(fullName, selectSQL string) (uint64, error) {
 	quoted, err := e.quoteFullTableName(fullName)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	dbType := e.DbConn.GetType()
 
 	if isSQLServerFamily(dbType) {
 		// SQL Server 2016+: CREATE OR ALTER VIEW
-		_, err = e.DbConn.Exec(g.F("CREATE OR ALTER VIEW %s AS %s", quoted, selectSQL))
-		return err
+		return rowsFromExec(e.DbConn.Exec(g.F("CREATE OR ALTER VIEW %s AS %s", quoted, selectSQL)))
 	}
 
-	_, err = e.DbConn.Exec(g.F("CREATE OR REPLACE VIEW %s AS (%s)", quoted, selectSQL))
-	return err
+	return rowsFromExec(e.DbConn.Exec(g.F("CREATE OR REPLACE VIEW %s AS (%s)", quoted, selectSQL)))
 }
 
 // renameTable renames oldFull → newFull using the dialect template.

--- a/core/sling/build/ddl.go
+++ b/core/sling/build/ddl.go
@@ -17,11 +17,6 @@ func (e *Executor) quoteFullTableName(fullName string) (string, error) {
 	return table.FDQN(), nil
 }
 
-// quotedName returns just the quoted bare table name (no schema).
-func (e *Executor) quotedName(name string) string {
-	return e.DbConn.Quote(name)
-}
-
 // supportsDropCascade reports whether the dialect accepts CASCADE on DROP.
 func supportsDropCascade(t dbio.Type) bool {
 	return g.In(t,
@@ -258,20 +253,4 @@ func (e *Executor) renameTable(oldFull, newFull string) error {
 	sql := g.R(tpl, "table", oldQuoted, "new_table", newRef)
 	_, err = e.DbConn.Exec(sql)
 	return err
-}
-
-// bareTableName extracts the unqualified table name from schema.table.
-func bareTableName(fullName string) string {
-	if idx := strings.LastIndex(fullName, "."); idx >= 0 {
-		return fullName[idx+1:]
-	}
-	return fullName
-}
-
-// schemaOf extracts the schema from schema.table.
-func schemaOf(fullName string) string {
-	if idx := strings.LastIndex(fullName, "."); idx >= 0 {
-		return fullName[:idx]
-	}
-	return ""
 }

--- a/core/sling/build/executor.go
+++ b/core/sling/build/executor.go
@@ -902,6 +902,7 @@ func (e *Executor) executeLegacyIncremental(model *Model) (uint64, error) {
 	if _, err = e.createTempTable(tempTable, incrementalSQL); err != nil {
 		return 0, g.Error(err, "could not create temp table for incremental merge on '%s'", model.Name)
 	}
+	staged := e.countIfColumnStore(tempTable, 0)
 
 	// Generate and execute merge SQL using sling's merge infrastructure
 	uniqueKeys := getUniqueKeys(model)
@@ -923,7 +924,10 @@ func (e *Executor) executeLegacyIncremental(model *Model) (uint64, error) {
 	if err != nil {
 		return 0, g.Error(err, "could not execute incremental merge for '%s'", model.Name)
 	}
-	return e.countIfColumnStore(tempTable, rows), nil
+	if e.DbConn != nil && e.DbConn.GetType().IsColumnStore() {
+		return staged, nil
+	}
+	return rows, nil
 }
 
 // executeAppend handles append-only mode (formerly "snapshot").
@@ -1969,6 +1973,7 @@ func (e *Executor) runMergeForChunk(model *Model, incCtx *IncrementalContext) (u
 	if _, err = e.createTempTable(tempTable, incrementalSQL); err != nil {
 		return 0, g.Error(err, "could not create temp table for incremental merge on '%s'", model.Name)
 	}
+	staged := e.countIfColumnStore(tempTable, 0)
 
 	tgtQuoted, err := e.quoteFullTableName(t)
 	if err != nil {
@@ -1987,7 +1992,10 @@ func (e *Executor) runMergeForChunk(model *Model, incCtx *IncrementalContext) (u
 	if err != nil {
 		return 0, g.Error(err, "could not execute incremental merge for '%s'", model.Name)
 	}
-	return e.countIfColumnStore(tempTable, rows), nil
+	if e.DbConn != nil && e.DbConn.GetType().IsColumnStore() {
+		return staged, nil
+	}
+	return rows, nil
 }
 
 // handleChunkError formats an error from a failed chunk and optionally prints

--- a/core/sling/build/executor.go
+++ b/core/sling/build/executor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -34,9 +35,13 @@ type Executor struct {
 	failedSet   map[string]bool // tracks failed nodes for skipping downstream
 	stopped     bool            // set when fail-fast triggers; prevents new dispatches
 
-	OutputLines chan *g.LogLine
 	prevLogSink func(*g.LogLine)
 	startTime   *time.Time
+
+	// Per-model log buffers. env.LogSink is process-global
+	modelLogs   map[string]g.LogLines
+	modelLogsMu sync.Mutex
+	gidModels   sync.Map // uint64 goroutine id → model name
 }
 
 // ExecutionResult holds the outcome of executing one node.
@@ -110,7 +115,7 @@ func NewExecutor(b *Build) (*Executor, error) {
 		connEntries: b.connEntries,
 		failedSet:   make(map[string]bool),
 		ctx:         g.NewContext(context.Background()),
-		OutputLines: make(chan *g.LogLine, 5000),
+		modelLogs:   make(map[string]g.LogLines),
 	}, nil
 }
 
@@ -359,8 +364,6 @@ func (e *Executor) Execute() error {
 			completed++
 			cond.Broadcast()
 			mu.Unlock()
-
-			e.printProgress(nodeIdx, total, result, false)
 		}
 	}
 
@@ -431,6 +434,9 @@ func (e *Executor) Execute() error {
 
 // runNode executes a single DAG node and returns its result.
 func (e *Executor) runNode(nodeName string, nodeIndex, total int) ExecutionResult {
+	unbind := e.bindModel(nodeName)
+	defer unbind()
+
 	start := time.Now()
 	node := e.Build.DAG.Nodes[nodeName]
 
@@ -440,6 +446,7 @@ func (e *Executor) runNode(nodeName string, nodeIndex, total int) ExecutionResul
 	if node == nil {
 		result.Err = g.Error("node '%s' not found in DAG", nodeName)
 		result.Duration = time.Since(start)
+		e.printProgress(nodeIndex, total, result, false)
 		e.syncModelStatus(nodeName, result, sling.ExecStatusError)
 		return result
 	}
@@ -466,6 +473,7 @@ func (e *Executor) runNode(nodeName string, nodeIndex, total int) ExecutionResul
 			result.Mode = e.Build.GetModelMode(node.Model)
 			result.Name = node.Model.FullTableName
 		}
+		e.printProgress(nodeIndex, total, result, false)
 		e.syncModelStatus(nodeName, result, sling.ExecStatusSkipped)
 		return result
 	}
@@ -485,6 +493,7 @@ func (e *Executor) runNode(nodeName string, nodeIndex, total int) ExecutionResul
 		snap := result
 		e.ctx.Unlock()
 		stopHB()
+		e.printProgress(nodeIndex, total, snap, false)
 		e.syncModelStatus(nodeName, snap, resultStatus(snap))
 		return snap
 	}
@@ -514,6 +523,7 @@ func (e *Executor) runNode(nodeName string, nodeIndex, total int) ExecutionResul
 		snap := result
 		e.ctx.Unlock()
 		stopHB()
+		e.printProgress(nodeIndex, total, snap, false)
 		e.syncModelStatus(nodeName, snap, resultStatus(snap))
 		return snap
 	}
@@ -1071,16 +1081,14 @@ func (e *Executor) attachLogSink() {
 	prev := env.LogSink
 	e.prevLogSink = prev
 	env.LogSink = func(ll *g.LogLine) {
+		name := e.modelForGID()
+		if name != "" {
+			ll.Group = g.F("%s,%s", env.ExecID, name)
+		}
 		if prev != nil {
 			prev(ll)
 		}
-		if e.OutputLines == nil {
-			return
-		}
-		select {
-		case e.OutputLines <- ll:
-		default:
-		}
+		e.appendLog(name, ll)
 	}
 }
 
@@ -1088,19 +1096,63 @@ func (e *Executor) detachLogSink() {
 	env.LogSink = e.prevLogSink
 }
 
-func (e *Executor) drainLogs() g.LogLines {
-	lines := g.LogLines{}
-	if e.OutputLines == nil {
-		return lines
+const maxModelLogBuf = 5000
+
+func (e *Executor) bindModel(modelName string) func() {
+	gid := goroutineID()
+	e.gidModels.Store(gid, modelName)
+	return func() {
+		e.gidModels.Delete(gid)
 	}
-	for {
-		select {
-		case ol := <-e.OutputLines:
-			lines = append(lines, *ol)
-		default:
-			return lines
+}
+
+func (e *Executor) modelForGID() string {
+	v, ok := e.gidModels.Load(goroutineID())
+	if !ok {
+		return ""
+	}
+	name, _ := v.(string)
+	return name
+}
+
+func (e *Executor) appendLog(modelName string, ll *g.LogLine) {
+	if ll == nil {
+		return
+	}
+	e.modelLogsMu.Lock()
+	defer e.modelLogsMu.Unlock()
+	if e.modelLogs == nil {
+		e.modelLogs = make(map[string]g.LogLines)
+	}
+	if len(e.modelLogs[modelName]) >= maxModelLogBuf {
+		return
+	}
+	e.modelLogs[modelName] = append(e.modelLogs[modelName], *ll)
+}
+
+func (e *Executor) drainLogs(modelName string) g.LogLines {
+	e.modelLogsMu.Lock()
+	defer e.modelLogsMu.Unlock()
+	lines := e.modelLogs[modelName]
+	e.modelLogs[modelName] = nil
+	return lines
+}
+
+// goroutineID returns the current goroutine's id from the stack prefix.
+// Used to route process-global LogSink lines to the in-flight model.
+func goroutineID() uint64 {
+	var buf [64]byte
+	n := runtime.Stack(buf[:], false)
+	// "goroutine 123 [running]..."
+	id := uint64(0)
+	for i := 10; i < n; i++ {
+		c := buf[i]
+		if c < '0' || c > '9' {
+			break
 		}
+		id = id*10 + uint64(c-'0')
 	}
+	return id
 }
 
 func (e *Executor) fileName() *string {
@@ -1157,7 +1209,7 @@ func (e *Executor) makeModelStatus(modelName string, result ExecutionResult, sta
 		Order:      e.selectedOrder(modelName),
 		Tries:      e.tryNumber(),
 		TryNumber:  e.tryNumber(),
-		NewLines:   e.drainLogs(),
+		NewLines:   e.drainLogs(modelName),
 		TimeNs:     time.Now().UnixNano(),
 		AgentID:    g.Getenv("SLING_RUNNER_ID", os.Getenv("SLING_AGENT_ID")),
 	}
@@ -1248,7 +1300,7 @@ func (e *Executor) makeBuildStatus(status sling.ExecStatus, runErr error) *store
 		ModelCount: 0,
 		Tries:      e.tryNumber(),
 		TryNumber:  e.tryNumber(),
-		NewLines:   e.drainLogs(),
+		NewLines:   e.drainLogs(""),
 		TimeNs:     time.Now().UnixNano(),
 		AgentID:    g.Getenv("SLING_RUNNER_ID", os.Getenv("SLING_AGENT_ID")),
 	}
@@ -1297,7 +1349,7 @@ func (e *Executor) printProgress(index, total int, result ExecutionResult, start
 
 	// Format: [1/8] staging.country_codes (seed) ........... START
 	// Format: [1/8] staging.country_codes (seed) ........... OK (0.2s)
-	prefix := g.F("[%d/%d] %s (%s) ", index, total, result.Name, env.DarkGrayString(nodeType))
+	prefix := progressPrefix(index, total, result.Name, nodeType)
 
 	dotsLen := 70 - len(prefix)
 	if dotsLen < 3 {
@@ -1321,6 +1373,12 @@ func (e *Executor) printProgress(index, total int, result ExecutionResult, start
 		status = env.RedString("FAIL")
 	}
 	e.ctx.Info("%s%s %s (%s)", prefix, dots, status, durationStr)
+}
+
+// progressPrefix is the left side of a progress line, including the dim
+// "(mode)" so both parentheses share the same color as the mode name.
+func progressPrefix(index, total int, name, nodeType string) string {
+	return g.F("[%d/%d] %s %s ", index, total, name, env.DarkGrayString("("+nodeType+")"))
 }
 
 // formatDuration formats a duration as a human-readable string.

--- a/core/sling/build/executor.go
+++ b/core/sling/build/executor.go
@@ -74,6 +74,7 @@ type BuildState struct {
 type BuildModelState struct {
 	Name     string `json:"name,omitempty"`
 	Schema   string `json:"schema,omitempty"`
+	Database string `json:"database,omitempty"`
 	FullName string `json:"full_name,omitempty"`
 	Mode     string `json:"mode,omitempty"`
 }
@@ -192,31 +193,62 @@ func (e *Executor) Close() {
 
 // CreateSchemas creates all unique schemas needed by the selected nodes.
 func (e *Executor) CreateSchemas() error {
-	schemas := make(map[string]bool)
+	type schemaKey struct{ database, schema string }
+	schemas := make(map[schemaKey]bool)
 	for _, name := range e.Build.Selected {
 		node := e.Build.DAG.Nodes[name]
 		if node.Model != nil {
-			schemas[node.Model.Schema] = true
+			schemas[schemaKey{node.Model.Database, node.Model.Schema}] = true
 		}
 		if node.Seed != nil {
-			schemas[node.Seed.Schema] = true
+			schemas[schemaKey{node.Seed.Database, node.Seed.Schema}] = true
 		}
 	}
 
-	for schema := range schemas {
+	dbType := e.DbConn.GetType()
+	for key := range schemas {
+		// SQL Server family cannot CREATE SCHEMA in another database.
+		if key.database != "" && g.In(dbType, dbio.TypeDbSQLServer, dbio.TypeDbAzure, dbio.TypeDbAzureDWH, dbio.TypeDbFabric) {
+			if !strings.EqualFold(key.database, e.DbConn.GetProp("database")) {
+				g.Warn("skipping schema creation for '%s.%s': %s cannot create a schema in another database", key.database, key.schema, dbType)
+				continue
+			}
+		}
+
+		qualifier, err := e.quoteSchemaQualifier(key.database, key.schema)
+		if err != nil {
+			return err
+		}
 		sql := g.R(
 			e.DbConn.Template().Value("core.create_schema"),
-			"schema", e.DbConn.Quote(schema),
+			"schema", qualifier,
 		)
 		if _, err := e.DbConn.Exec(sql); err != nil {
 			// Ignore "already exists" errors for databases without IF NOT EXISTS
 			errLower := strings.ToLower(err.Error())
 			if !strings.Contains(errLower, "already exists") && !strings.Contains(errLower, "duplicate") {
-				return g.Error(err, "could not create schema '%s'", schema)
+				return g.Error(err, "could not create schema '%s'", key.schema)
 			}
 		}
 	}
 	return nil
+}
+
+// quoteSchemaQualifier renders [database.]schema quoted for the dialect. It
+// goes through ParseTableName so the case normalization matches the one
+// applied to the model's own table name.
+func (e *Executor) quoteSchemaQualifier(db, schema string) (string, error) {
+	name := schema
+	if db != "" {
+		name = db + "." + schema
+	}
+	// ParseTableName needs a table part; add a placeholder and drop it after.
+	table, err := database.ParseTableName(name+"._", e.DbConn.GetType())
+	if err != nil {
+		return "", g.Error(err, "could not parse schema name '%s'", name)
+	}
+	table.Name = ""
+	return table.FDQN(), nil
 }
 
 // Execute runs all selected nodes with a ready-queue scheduler.
@@ -579,6 +611,7 @@ func (e *Executor) parseModelHooks(model *Model, mode string) error {
 		Model: BuildModelState{
 			Name:     model.Name,
 			Schema:   model.Schema,
+			Database: model.Database,
 			FullName: model.FullTableName,
 			Mode:     mode,
 		},
@@ -840,7 +873,10 @@ func (e *Executor) executeLegacyIncremental(model *Model) (uint64, error) {
 
 	// Re-apply table reference rewriting after incremental recompilation
 	if model.Config.Rewrite == nil || *model.Config.Rewrite {
-		rewritten, _ := RewriteTableReferences(model.CompiledSQL, e.Build.Project, model.Name)
+		rewritten, _, err := RewriteTableReferences(model.CompiledSQL, e.Build.Project, model.Name)
+		if err != nil {
+			return 0, err
+		}
 		model.CompiledSQL = rewritten
 	}
 
@@ -1074,7 +1110,7 @@ func getTempTableName(model *Model, runID string) string {
 		return '_'
 	}, model.Name)
 	tempName := g.F("_sling_build_tmp_%s_%s", safeName, runID)
-	return g.F("%s.%s", model.Schema, tempName)
+	return TableIdentity{Name: tempName, Schema: model.Schema, Database: model.Database}.FullName()
 }
 
 func (e *Executor) attachLogSink() {
@@ -1342,6 +1378,9 @@ func (e *Executor) makeBuildStatus(status sling.ExecStatus, runErr error) *store
 // When started is true, prints the "START" line (no duration).
 // When started is false, prints the final status with duration.
 func (e *Executor) printProgress(index, total int, result ExecutionResult, started bool) {
+	if e.Build != nil && e.Build.Options.JSON {
+		return
+	}
 	nodeType := result.Mode
 	if result.NodeType == "seed" {
 		nodeType = "seed"
@@ -1748,7 +1787,11 @@ func (e *Executor) probeSourceMin(model *Model, updateKey string) (string, iop.C
 		return "", "", g.Error(err, "probeSourceMin: could not compile model '%s'", model.Name)
 	}
 
-	rewritten, _ := RewriteTableReferences(model.CompiledSQL, e.Build.Project, model.Name)
+	rewritten, _, rwErr := RewriteTableReferences(model.CompiledSQL, e.Build.Project, model.Name)
+	if rwErr != nil {
+		model.CompiledSQL = savedSQL
+		return "", "", rwErr
+	}
 	result, err := MakeModelSQL(rewritten, e.DbConn.GetType())
 	model.CompiledSQL = savedSQL // always restore
 
@@ -1875,7 +1918,10 @@ func (e *Executor) runMergeForChunk(model *Model, incCtx *IncrementalContext) (u
 
 	// Honor rewrite: false
 	if model.Config.Rewrite == nil || *model.Config.Rewrite {
-		rewritten, _ := RewriteTableReferences(model.CompiledSQL, e.Build.Project, model.Name)
+		rewritten, _, err := RewriteTableReferences(model.CompiledSQL, e.Build.Project, model.Name)
+		if err != nil {
+			return 0, err
+		}
 		model.CompiledSQL = rewritten
 	}
 

--- a/core/sling/build/executor.go
+++ b/core/sling/build/executor.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/flarco/g"
 	"github.com/samber/lo"
+	"github.com/slingdata-io/sling-cli/core"
 	"github.com/slingdata-io/sling-cli/core/dbio"
 	"github.com/slingdata-io/sling-cli/core/dbio/connection"
 	"github.com/slingdata-io/sling-cli/core/dbio/database"
@@ -1337,6 +1338,7 @@ func (e *Executor) makeBuildStatus(status sling.ExecStatus, runErr error) *store
 		FileName:   e.fileName(),
 		Target:     e.ConnName,
 		Status:     status,
+		Version:    core.Version,
 		ModelCount: 0,
 		Tries:      e.tryNumber(),
 		TryNumber:  e.tryNumber(),
@@ -1392,6 +1394,7 @@ func SyncBuildFailure(runErr error) {
 		Status:      sling.ExecStatusError,
 		Error:       g.Ptr(runErr.Error()),
 		ExitCode:    1,
+		Version:     core.Version,
 		TimeNs:      now.UnixNano(),
 		StartTimeNs: g.Int64(now.UnixNano()),
 		EndTimeNs:   g.Int64(now.UnixNano()),

--- a/core/sling/build/executor.go
+++ b/core/sling/build/executor.go
@@ -1087,15 +1087,15 @@ func (e *Executor) getTempTableName(model *Model) string {
 	return getTempTableName(model, e.RunID)
 }
 
-// createTempTable stages SQL into a temp table. ClickHouse uses Memory engine
-// (no ORDER BY). Other dialects use CREATE TABLE AS.
+// createTempTable stages SQL into a temp table. ClickHouse gets an explicit
+// MergeTree engine.
 func (e *Executor) createTempTable(tempTable, sql string) (uint64, error) {
 	if e.isClickHouse() {
 		quoted, err := e.quoteFullTableName(tempTable)
 		if err != nil {
 			return 0, err
 		}
-		return rowsFromExec(e.DbConn.Exec(g.F("CREATE TABLE %s ENGINE = Memory AS (%s)", quoted, sql)))
+		return rowsFromExec(e.DbConn.Exec(g.F("CREATE TABLE %s ENGINE = MergeTree() ORDER BY tuple() AS (%s)", quoted, sql)))
 	}
 	return e.createTableAs(tempTable, sql, nil)
 }

--- a/core/sling/build/executor.go
+++ b/core/sling/build/executor.go
@@ -1346,7 +1346,6 @@ func (e *Executor) makeBuildStatus(status sling.ExecStatus, runErr error) *store
 		bs.FullRefresh = e.Build.Options.FullRefresh
 		bs.ModelCount = len(e.Build.Selected)
 	}
-	bs.Hostname, _ = os.Hostname()
 	if e.startTime != nil {
 		bs.StartTimeNs = g.Int64(e.startTime.UnixNano())
 	}
@@ -1372,6 +1371,33 @@ func (e *Executor) makeBuildStatus(status sling.ExecStatus, runErr error) *store
 		}
 	}
 	return bs
+}
+
+// SyncBuildFailure reports a build that failed before an Executor existed
+func SyncBuildFailure(runErr error) {
+	if runErr == nil || !sling.IsBuildRunMode() {
+		return
+	}
+
+	now := time.Now()
+	bs := &store.BuildStatus{
+		ProjectID: g.String(os.Getenv("SLING_PROJECT_ID")),
+		JobID:     os.Getenv("SLING_JOB_ID"),
+		ExecID:    os.Getenv("SLING_EXEC_ID"),
+		// Target is unknown this early; the platform keeps the value it has.
+		Status:      sling.ExecStatusError,
+		Error:       g.Ptr(runErr.Error()),
+		ExitCode:    1,
+		TimeNs:      now.UnixNano(),
+		StartTimeNs: g.Int64(now.UnixNano()),
+		EndTimeNs:   g.Int64(now.UnixNano()),
+		AgentID:     g.Getenv("SLING_RUNNER_ID", os.Getenv("SLING_AGENT_ID")),
+	}
+	if v := os.Getenv("SLING_FILE_NAME"); v != "" {
+		bs.FileName = g.Ptr(v)
+	}
+
+	sling.StoreSet(bs)
 }
 
 // printProgress prints a single line of execution progress.

--- a/core/sling/build/executor.go
+++ b/core/sling/build/executor.go
@@ -1736,17 +1736,17 @@ func resolveIncrementalRange(e *Executor, model *Model) (*Range, error) {
 	if lowerRaw == "" {
 		maxVal, maxType, err := e.queryTargetMax(model, updateKey)
 		if err != nil {
-			g.Warn("build[%s]: tier B probe failed (%s); falling through to first-run", model.Name, err)
+			g.Warn("build[%s]: probe failed (%s); falling through to first-run", model.Name, err)
 		} else if maxVal != "" {
 			lowerRaw = maxVal
 			colType = maxType
-			g.Debug("build[%s]: tier B — target MAX %q", model.Name, lowerRaw)
+			g.Debug("build[%s]: target MAX %q", model.Name, lowerRaw)
 		}
 	}
 
 	// Tier C: first run — unbounded lower
 	if lowerRaw == "" {
-		g.Debug("build[%s]: tier C — first run, no lower bound", model.Name)
+		g.Debug("build[%s]: first run, no lower bound", model.Name)
 		r := &Range{
 			UpdateState: true,
 			Chunks: []RangeChunk{{

--- a/core/sling/build/executor.go
+++ b/core/sling/build/executor.go
@@ -2,18 +2,23 @@ package build
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/flarco/g"
+	"github.com/samber/lo"
 	"github.com/slingdata-io/sling-cli/core/dbio"
 	"github.com/slingdata-io/sling-cli/core/dbio/connection"
 	"github.com/slingdata-io/sling-cli/core/dbio/database"
 	"github.com/slingdata-io/sling-cli/core/dbio/iop"
 	"github.com/slingdata-io/sling-cli/core/env"
 	"github.com/slingdata-io/sling-cli/core/sling"
+	"github.com/slingdata-io/sling-cli/core/store"
 	"github.com/spf13/cast"
 )
 
@@ -28,16 +33,26 @@ type Executor struct {
 	ctx         *g.Context
 	failedSet   map[string]bool // tracks failed nodes for skipping downstream
 	stopped     bool            // set when fail-fast triggers; prevents new dispatches
+
+	OutputLines chan *g.LogLine
+	prevLogSink func(*g.LogLine)
+	startTime   *time.Time
 }
 
 // ExecutionResult holds the outcome of executing one node.
 type ExecutionResult struct {
-	Name     string
-	NodeType string // "seed" or "model"
-	Mode     string // "full-refresh", "view", "truncate", "incremental", "append"
-	Duration time.Duration
-	Err      error
-	Skipped  bool
+	Name      string
+	NodeType  string // "seed", "model", or "test"
+	Mode      string // "full-refresh", "view", "truncate", "incremental", "append"
+	Duration  time.Duration
+	Err       error
+	Skipped   bool
+	StartTime *time.Time
+	// Rows is sql.Result.RowsAffected, or COUNT(*) on column-store
+	// full-refresh / truncate / first-run append. Incremental and subsequent
+	// append count the staging temp table. CREATE VIEW reports 0.
+	Rows  uint64
+	Bytes uint64
 }
 
 // BuildState implements sling.RuntimeState for build model hooks.
@@ -95,7 +110,48 @@ func NewExecutor(b *Build) (*Executor, error) {
 		connEntries: b.connEntries,
 		failedSet:   make(map[string]bool),
 		ctx:         g.NewContext(context.Background()),
+		OutputLines: make(chan *g.LogLine, 5000),
 	}, nil
+}
+
+// rowsFromResult returns RowsAffected clamped to 0.
+// CREATE VIEW reports 0. Some drivers return -1.
+func rowsFromResult(result sql.Result) uint64 {
+	if result == nil {
+		return 0
+	}
+	n, err := result.RowsAffected()
+	if err != nil || n < 0 {
+		return 0
+	}
+	return uint64(n)
+}
+
+func rowsFromExec(result sql.Result, err error) (uint64, error) {
+	if err != nil {
+		return 0, err
+	}
+	return rowsFromResult(result), nil
+}
+
+// countIfColumnStore runs COUNT(*) on columnar engines. CTAS/INSERT/MERGE often
+// report RowsAffected 0. Call on the target after full-refresh/truncate, or on
+// the staging temp table after incremental/append.
+func (e *Executor) countIfColumnStore(fullName string, rows uint64) uint64 {
+	if e.DbConn == nil || !e.DbConn.GetType().IsColumnStore() {
+		return rows
+	}
+	quoted, err := e.quoteFullTableName(fullName)
+	if err != nil {
+		g.Debug("skip count of %s: %s", fullName, err)
+		return rows
+	}
+	n, err := e.DbConn.GetCount(quoted)
+	if err != nil || n < 0 {
+		g.Debug("count of %s failed: %s", quoted, err)
+		return rows
+	}
+	return uint64(n)
 }
 
 // Connect establishes a database connection to the target.
@@ -161,19 +217,40 @@ func (e *Executor) CreateSchemas() error {
 // Execute runs all selected nodes with a ready-queue scheduler.
 // A node is dispatched as soon as its selected dependencies complete (no level barriers).
 func (e *Executor) Execute() error {
+	start := time.Now()
+	e.startTime = &start
+	e.attachLogSink()
+	defer e.detachLogSink()
+
 	if err := e.Connect(); err != nil {
+		if !sling.IsPipelineRunMode() {
+			e.syncBuildStatus(sling.ExecStatusError, err)
+		}
 		return err
 	}
 	defer e.Close()
 
 	if err := e.CreateSchemas(); err != nil {
+		if !sling.IsPipelineRunMode() {
+			e.syncBuildStatus(sling.ExecStatusError, err)
+		}
 		return err
 	}
 
 	total := len(e.Build.Selected)
 	if total == 0 {
 		fmt.Println("No models selected.")
+		if !sling.IsPipelineRunMode() {
+			e.syncBuildStatus(sling.ExecStatusSuccess, nil)
+		}
 		return nil
+	}
+
+	stopHB := func() {}
+	if !sling.IsPipelineRunMode() {
+		e.syncBuildStatus(sling.ExecStatusRunning, nil)
+		stopHB = e.startBuildHeartbeat()
+		defer stopHB()
 	}
 
 	threads := e.Build.Options.Threads
@@ -260,11 +337,11 @@ func (e *Executor) Execute() error {
 			result := e.runNode(name, nodeIdx, total)
 
 			mu.Lock()
-			e.Results = append(e.Results, result)
 			seedSkipped := result.Skipped && e.Build.Options.NoSeeds &&
 				e.Build.DAG.Nodes[name] != nil && e.Build.DAG.Nodes[name].Seed != nil
 			// failedSet is also read under e.ctx.Mux in runNode — hold both
 			e.ctx.Mux.Lock()
+			e.Results = append(e.Results, result)
 			if result.Err != nil || (result.Skipped && !seedSkipped) {
 				e.failedSet[name] = true
 			}
@@ -305,7 +382,7 @@ func (e *Executor) Execute() error {
 		if wasStarted {
 			continue
 		}
-		result := ExecutionResult{Name: name, Skipped: true}
+		result := ExecutionResult{Name: name, Skipped: true, StartTime: g.Ptr(time.Now())}
 		if node := e.Build.DAG.Nodes[name]; node != nil {
 			if node.Seed != nil {
 				result.NodeType = "seed"
@@ -317,10 +394,11 @@ func (e *Executor) Execute() error {
 				result.Name = node.Model.FullTableName
 			}
 		}
-		e.Results = append(e.Results, result)
 		e.ctx.Mux.Lock()
+		e.Results = append(e.Results, result)
 		e.failedSet[name] = true
 		e.ctx.Mux.Unlock()
+		e.syncModelStatus(name, result, sling.ExecStatusSkipped)
 	}
 
 	fmt.Println()
@@ -337,7 +415,16 @@ func (e *Executor) Execute() error {
 		for i, err := range errs {
 			msgs[i] = err.Error()
 		}
-		return g.Error("build completed with %d error(s): %s", len(errs), strings.Join(msgs, "; "))
+		err := g.Error("build completed with %d error(s): %s", len(errs), strings.Join(msgs, "; "))
+		stopHB()
+		if !sling.IsPipelineRunMode() {
+			e.syncBuildStatus(sling.ExecStatusError, err)
+		}
+		return err
+	}
+	stopHB()
+	if !sling.IsPipelineRunMode() {
+		e.syncBuildStatus(sling.ExecStatusSuccess, nil)
 	}
 	return nil
 }
@@ -349,9 +436,11 @@ func (e *Executor) runNode(nodeName string, nodeIndex, total int) ExecutionResul
 
 	var result ExecutionResult
 	result.Name = nodeName
+	result.StartTime = g.Ptr(start)
 	if node == nil {
 		result.Err = g.Error("node '%s' not found in DAG", nodeName)
 		result.Duration = time.Since(start)
+		e.syncModelStatus(nodeName, result, sling.ExecStatusError)
 		return result
 	}
 
@@ -377,17 +466,27 @@ func (e *Executor) runNode(nodeName string, nodeIndex, total int) ExecutionResul
 			result.Mode = e.Build.GetModelMode(node.Model)
 			result.Name = node.Model.FullTableName
 		}
+		e.syncModelStatus(nodeName, result, sling.ExecStatusSkipped)
 		return result
 	}
 
+	stopHB := func() {}
 	if node.Seed != nil {
 		result.NodeType = "seed"
 		result.Mode = "full-refresh"
 		result.Name = node.Seed.FullTableName
 		e.printProgress(nodeIndex, total, result, true)
-		result.Err = e.executeSeed(node.Seed)
+		e.syncModelStatus(nodeName, result, sling.ExecStatusRunning)
+		stopHB = e.startModelHeartbeat(nodeName, &result)
+		rows, bytes, err := e.executeSeed(node.Seed)
+		e.ctx.Lock()
+		result.Rows, result.Bytes, result.Err = rows, bytes, err
 		result.Duration = time.Since(start)
-		return result
+		snap := result
+		e.ctx.Unlock()
+		stopHB()
+		e.syncModelStatus(nodeName, snap, resultStatus(snap))
+		return snap
 	}
 
 	if node.Model != nil {
@@ -395,18 +494,40 @@ func (e *Executor) runNode(nodeName string, nodeIndex, total int) ExecutionResul
 		result.NodeType = "model"
 		result.Mode = mode
 		if testOnly {
+			result.NodeType = "test"
 			result.Mode = "test"
 		}
 		result.Name = node.Model.FullTableName
 		e.printProgress(nodeIndex, total, result, true)
+		e.syncModelStatus(nodeName, result, sling.ExecStatusRunning)
+		stopHB = e.startModelHeartbeat(nodeName, &result)
+		var rows uint64
+		var err error
 		if testOnly {
-			result.Err = e.executeModelTests(node.Model)
+			err = e.executeModelTests(node.Model)
 		} else {
-			result.Err = e.executeModel(node.Model, mode)
+			rows, err = e.executeModel(node.Model, mode)
 		}
+		e.ctx.Lock()
+		result.Rows, result.Err = rows, err
 		result.Duration = time.Since(start)
+		snap := result
+		e.ctx.Unlock()
+		stopHB()
+		e.syncModelStatus(nodeName, snap, resultStatus(snap))
+		return snap
 	}
 	return result
+}
+
+func resultStatus(result ExecutionResult) sling.ExecStatus {
+	if result.Skipped {
+		return sling.ExecStatusSkipped
+	}
+	if result.Err != nil {
+		return sling.ExecStatusError
+	}
+	return sling.ExecStatusSuccess
 }
 
 // isDownstreamOfFailed checks if any upstream dependency of the node has failed.
@@ -425,7 +546,7 @@ func (e *Executor) isDownstreamOfFailed(name string) bool {
 }
 
 // executeSeed loads a seed file using the sling task infrastructure.
-func (e *Executor) executeSeed(seed *Seed) error {
+func (e *Executor) executeSeed(seed *Seed) (rows, bytes uint64, err error) {
 	// LoadSeed opens its own target connection. DuckDB-family files allow
 	// one writer, so release the executor handle first.
 	if e.DbConn != nil && e.DbConn.GetType().IsSingleWriterDB() {
@@ -494,16 +615,16 @@ func (e *Executor) parseModelHooks(model *Model, mode string) error {
 }
 
 // executeModel executes a single model based on its mode.
-func (e *Executor) executeModel(model *Model, mode string) error {
+func (e *Executor) executeModel(model *Model, mode string) (rows uint64, err error) {
 	// Parse and execute start hooks
 	if err := e.parseModelHooks(model, mode); err != nil {
-		return g.Error(err, "could not parse hooks for model '%s'", model.Name)
+		return 0, g.Error(err, "could not parse hooks for model '%s'", model.Name)
 	}
 
 	if len(model.startHooks) > 0 {
 		g.Debug("running start hooks for %s", model.Name)
 		if err := model.startHooks.Execute(); err != nil {
-			return g.Error(err, "start hook failed for model '%s'", model.Name)
+			return 0, g.Error(err, "start hook failed for model '%s'", model.Name)
 		}
 	}
 
@@ -511,42 +632,41 @@ func (e *Executor) executeModel(model *Model, mode string) error {
 	for i, stmt := range model.PreStatements {
 		g.Debug("running pre-statement %d/%d for %s", i+1, len(model.PreStatements), model.Name)
 		if _, err := e.DbConn.Exec(stmt); err != nil {
-			return g.Error(err, "pre-statement %d failed for model '%s'", i+1, model.Name)
+			return 0, g.Error(err, "pre-statement %d failed for model '%s'", i+1, model.Name)
 		}
 	}
 
-	var err error
 	switch mode {
 	case "full-refresh":
-		err = e.executeFullRefresh(model)
+		rows, err = e.executeFullRefresh(model)
 	case "view":
-		err = e.executeView(model)
+		rows, err = e.executeView(model)
 	case "truncate":
-		err = e.executeTruncate(model)
+		rows, err = e.executeTruncate(model)
 	case "incremental":
-		err = e.executeIncremental(model)
+		rows, err = e.executeIncremental(model)
 	case "append", "snapshot": // snapshot is deprecated alias
-		err = e.executeAppend(model)
+		rows, err = e.executeAppend(model)
 	default:
 		err = g.Error("unknown mode '%s' for model '%s'", mode, model.Name)
 	}
 
 	if err != nil {
-		return err
+		return rows, err
 	}
 
 	// Post-statements (from multi-statement SQL file)
 	for i, stmt := range model.PostStatements {
 		g.Debug("running post-statement %d/%d for %s", i+1, len(model.PostStatements), model.Name)
 		if _, err := e.DbConn.Exec(stmt); err != nil {
-			return g.Error(err, "post-statement %d failed for model '%s'", i+1, model.Name)
+			return rows, g.Error(err, "post-statement %d failed for model '%s'", i+1, model.Name)
 		}
 	}
 
 	// Declarative data tests
 	if len(model.Config.Tests) > 0 {
 		if err := e.executeModelTests(model); err != nil {
-			return err
+			return rows, err
 		}
 	}
 
@@ -554,66 +674,72 @@ func (e *Executor) executeModel(model *Model, mode string) error {
 	if len(model.endHooks) > 0 {
 		g.Debug("running end hooks for %s", model.Name)
 		if err := model.endHooks.Execute(); err != nil {
-			return g.Error(err, "end hook failed for model '%s'", model.Name)
+			return rows, g.Error(err, "end hook failed for model '%s'", model.Name)
 		}
 	}
 
-	return nil
+	return rows, nil
 }
 
 // executeFullRefresh rebuilds the table. Prefer atomic swap (tmp + rename) or
 // CREATE OR REPLACE TABLE where supported so the target is never missing mid-build.
-func (e *Executor) executeFullRefresh(model *Model) error {
+func (e *Executor) executeFullRefresh(model *Model) (uint64, error) {
 	sql := model.CompiledSQL
 	cascade := e.wantCascade(model)
 
 	// Drop any existing view first (model may previously have been a view)
 	_ = e.dropView(model.FullTableName, cascade)
 
+	var rows uint64
+	var err error
+
 	// Path A: CREATE OR REPLACE TABLE (Snowflake, BigQuery, DuckDB, Databricks)
 	if supportsCreateOrReplaceTable(e.DbConn.GetType()) && !e.isClickHouse() {
-		return e.createOrReplaceTableAs(model.FullTableName, sql, model)
+		rows, err = e.createOrReplaceTableAs(model.FullTableName, sql, model)
+	} else if e.supportsRenameTable() {
+		// Path B: atomic temp + rename swap when rename is available
+		rows, err = e.executeFullRefreshAtomic(model, sql, cascade)
+	} else {
+		// Path C: fallback — drop then CTAS (brief downtime window)
+		if err = e.dropTable(model.FullTableName, cascade); err != nil {
+			return 0, err
+		}
+		rows, err = e.createTableAs(model.FullTableName, sql, model)
 	}
-
-	// Path B: atomic temp + rename swap when rename is available
-	if e.supportsRenameTable() {
-		return e.executeFullRefreshAtomic(model, sql, cascade)
+	if err != nil {
+		return rows, err
 	}
-
-	// Path C: fallback — drop then CTAS (brief downtime window)
-	if err := e.dropTable(model.FullTableName, cascade); err != nil {
-		return err
-	}
-	return e.createTableAs(model.FullTableName, sql, model)
+	return e.countIfColumnStore(model.FullTableName, rows), nil
 }
 
 // executeFullRefreshAtomic creates into a temp table, then renames into place.
-func (e *Executor) executeFullRefreshAtomic(model *Model, sql string, cascade bool) error {
+func (e *Executor) executeFullRefreshAtomic(model *Model, sql string, cascade bool) (uint64, error) {
 	tmpFull := e.getTempTableName(model)
 	// Ensure temp is clean
 	_ = e.dropTable(tmpFull, false)
 
-	if err := e.createTableAs(tmpFull, sql, model); err != nil {
+	rows, err := e.createTableAs(tmpFull, sql, model)
+	if err != nil {
 		_ = e.dropTable(tmpFull, false)
-		return g.Error(err, "could not create temp table for full-refresh of '%s'", model.Name)
+		return 0, g.Error(err, "could not create temp table for full-refresh of '%s'", model.Name)
 	}
 
 	// Drop target (or rename aside if we want even less downtime — drop is fine
 	// once data is ready in tmp; window is only drop+rename, not CTAS duration)
 	if err := e.dropTable(model.FullTableName, cascade); err != nil {
 		_ = e.dropTable(tmpFull, false)
-		return err
+		return rows, err
 	}
 
 	if err := e.renameTable(tmpFull, model.FullTableName); err != nil {
 		// Best-effort: leave tmp so data isn't lost
-		return g.Error(err, "could not rename temp table to '%s' (temp left at %s)", model.FullTableName, tmpFull)
+		return rows, g.Error(err, "could not rename temp table to '%s' (temp left at %s)", model.FullTableName, tmpFull)
 	}
-	return nil
+	return rows, nil
 }
 
 // executeView creates or replaces a view.
-func (e *Executor) executeView(model *Model) error {
+func (e *Executor) executeView(model *Model) (uint64, error) {
 	cascade := e.wantCascade(model)
 
 	// Drop any existing table first (dirty fixtures plant tables that
@@ -630,36 +756,44 @@ func (e *Executor) executeView(model *Model) error {
 }
 
 // executeTruncate creates the table on first run, truncates + inserts on subsequent runs.
-func (e *Executor) executeTruncate(model *Model) error {
+func (e *Executor) executeTruncate(model *Model) (uint64, error) {
 	sql := model.CompiledSQL
 
 	exists, err := e.tableExists(model)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	if !exists {
-		return e.createTableAs(model.FullTableName, sql, model)
+		rows, err := e.createTableAs(model.FullTableName, sql, model)
+		if err != nil {
+			return 0, err
+		}
+		return e.countIfColumnStore(model.FullTableName, rows), nil
 	}
 
 	if err := e.truncateTable(model.FullTableName); err != nil {
-		return err
+		return 0, err
 	}
-	return e.insertSelect(model.FullTableName, sql)
+	rows, err := e.insertSelect(model.FullTableName, sql)
+	if err != nil {
+		return 0, err
+	}
+	return e.countIfColumnStore(model.FullTableName, rows), nil
 }
 
 // executeIncremental dispatches to the correct incremental strategy based on the
 // model's detected style. dbt-style models use executeLegacyIncremental (the
 // original is_incremental() path); sling-style models use resolveRange + executeRange.
-func (e *Executor) executeIncremental(model *Model) error {
+func (e *Executor) executeIncremental(model *Model) (uint64, error) {
 	uniqueKeys := getUniqueKeys(model)
 	if len(uniqueKeys) == 0 {
-		return g.Error("model '%s' uses incremental mode but has no unique_key defined in config()", model.Name)
+		return 0, g.Error("model '%s' uses incremental mode but has no unique_key defined in config()", model.Name)
 	}
 
 	exists, err := e.tableExists(model)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	if !exists || e.Build.Options.FullRefresh {
 		return e.executeFullRefresh(model)
@@ -668,30 +802,30 @@ func (e *Executor) executeIncremental(model *Model) error {
 	switch model.Style {
 	case StyleDbt:
 		if e.Build.Options.Range != nil {
-			return g.Error("model '%s' uses is_incremental() (dbt style); --range requires {incremental_where_cond} (sling style)", model.Name)
+			return 0, g.Error("model '%s' uses is_incremental() (dbt style); --range requires incremental_where_cond() (sling style)", model.Name)
 		}
 		return e.executeLegacyIncremental(model)
 	case StyleSling:
 		r, err := e.resolveRange(model)
 		if err != nil {
-			return err
+			return 0, err
 		}
 		return e.executeRange(model, r)
 	default:
-		return g.Error("model '%s': unknown incremental style %d", model.Name, model.Style)
+		return 0, g.Error("model '%s': unknown incremental style %d", model.Name, model.Style)
 	}
 }
 
 // executeLegacyIncremental is the original dbt-style incremental path, preserved
 // byte-for-byte. Recompiles with is_incremental()=true, stages into a temp table,
 // and merges using the configured strategy.
-func (e *Executor) executeLegacyIncremental(model *Model) error {
+func (e *Executor) executeLegacyIncremental(model *Model) (uint64, error) {
 	t := model.FullTableName
 
 	// Subsequent run: recompile with is_incremental()=true
 	_, err := e.Build.Engine.CompileModel(model, &IncrementalContext{IsIncremental: true})
 	if err != nil {
-		return g.Error(err, "could not compile incremental SQL for '%s'", model.Name)
+		return 0, g.Error(err, "could not compile incremental SQL for '%s'", model.Name)
 	}
 
 	// Re-apply table reference rewriting after incremental recompilation
@@ -703,7 +837,7 @@ func (e *Executor) executeLegacyIncremental(model *Model) error {
 	// Re-split after recompilation since CompiledSQL changed
 	result, splitErr := MakeModelSQL(model.CompiledSQL, e.DbConn.GetType())
 	if splitErr != nil {
-		return g.Error(splitErr, "could not parse incremental SQL for '%s'", model.Name)
+		return 0, g.Error(splitErr, "could not parse incremental SQL for '%s'", model.Name)
 	}
 	model.CompiledSQL = result.ModelQuery
 	incrementalSQL := model.CompiledSQL
@@ -719,18 +853,8 @@ func (e *Executor) executeLegacyIncremental(model *Model) error {
 		}
 	}()
 
-	// ClickHouse temp staging uses Memory engine (model=nil → Memory default in createTableAs)
-	if e.isClickHouse() {
-		quoted, qErr := e.quoteFullTableName(tempTable)
-		if qErr != nil {
-			return qErr
-		}
-		_, err = e.DbConn.Exec(g.F("CREATE TABLE %s ENGINE = Memory AS (%s)", quoted, incrementalSQL))
-	} else {
-		err = e.createTableAs(tempTable, incrementalSQL, nil)
-	}
-	if err != nil {
-		return g.Error(err, "could not create temp table for incremental merge on '%s'", model.Name)
+	if _, err = e.createTempTable(tempTable, incrementalSQL); err != nil {
+		return 0, g.Error(err, "could not create temp table for incremental merge on '%s'", model.Name)
 	}
 
 	// Generate and execute merge SQL using sling's merge infrastructure
@@ -738,37 +862,70 @@ func (e *Executor) executeLegacyIncremental(model *Model) error {
 	// Quote target/temp for merge; GenerateMergeSQL expects usable identifiers
 	tgtQuoted, err := e.quoteFullTableName(t)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	tmpQuoted, err := e.quoteFullTableName(tempTable)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	mergeSQL, err := e.DbConn.GenerateMergeSQLWithStrategy(tmpQuoted, tgtQuoted, uniqueKeys, &strategy)
 	if err != nil {
-		return g.Error(err, "could not generate merge SQL for '%s'", model.Name)
+		return 0, g.Error(err, "could not generate merge SQL for '%s'", model.Name)
 	}
 
-	_, err = e.DbConn.ExecMulti(mergeSQL)
+	rows, err := rowsFromExec(e.DbConn.ExecMulti(mergeSQL))
 	if err != nil {
-		return g.Error(err, "could not execute incremental merge for '%s'", model.Name)
+		return 0, g.Error(err, "could not execute incremental merge for '%s'", model.Name)
 	}
-
-	return nil
+	return e.countIfColumnStore(tempTable, rows), nil
 }
 
 // executeAppend handles append-only mode (formerly "snapshot").
-// First run: CTAS. Subsequent: INSERT.
-func (e *Executor) executeAppend(model *Model) error {
+// First run: CTAS. Subsequent: INSERT. Column stores stage into a temp table
+// and COUNT(*) that table, because INSERT RowsAffected is often 0.
+func (e *Executor) executeAppend(model *Model) (uint64, error) {
 	sql := model.CompiledSQL
 
 	exists, err := e.tableExists(model)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	if !exists {
-		return e.createTableAs(model.FullTableName, sql, model)
+		rows, err := e.createTableAs(model.FullTableName, sql, model)
+		if err != nil {
+			return 0, err
+		}
+		return e.countIfColumnStore(model.FullTableName, rows), nil
+	}
+
+	if e.DbConn != nil && e.DbConn.GetType().IsColumnStore() {
+		tempTable := e.getTempTableName(model)
+		defer func() {
+			if dropErr := e.dropTable(tempTable, false); dropErr != nil {
+				g.Debug("could not drop temp table %s: %s", tempTable, dropErr)
+			}
+		}()
+
+		rows, err := e.createTempTable(tempTable, sql)
+		if err != nil {
+			return 0, g.Error(err, "could not create temp table for append of '%s'", model.Name)
+		}
+		rows = e.countIfColumnStore(tempTable, rows)
+
+		tgtQuoted, err := e.quoteFullTableName(model.FullTableName)
+		if err != nil {
+			return rows, err
+		}
+		tmpQuoted, err := e.quoteFullTableName(tempTable)
+		if err != nil {
+			return rows, err
+		}
+		// No wrapping parens: ClickHouse rejects INSERT INTO t (SELECT * FROM tmp)
+		if _, err = e.DbConn.Exec(g.F("INSERT INTO %s SELECT * FROM %s", tgtQuoted, tmpQuoted)); err != nil {
+			return rows, g.Error(err, "could not append from temp table into '%s'", model.Name)
+		}
+		return rows, nil
 	}
 
 	return e.insertSelect(model.FullTableName, sql)
@@ -880,6 +1037,19 @@ func (e *Executor) getTempTableName(model *Model) string {
 	return getTempTableName(model, e.RunID)
 }
 
+// createTempTable stages SQL into a temp table. ClickHouse uses Memory engine
+// (no ORDER BY). Other dialects use CREATE TABLE AS.
+func (e *Executor) createTempTable(tempTable, sql string) (uint64, error) {
+	if e.isClickHouse() {
+		quoted, err := e.quoteFullTableName(tempTable)
+		if err != nil {
+			return 0, err
+		}
+		return rowsFromExec(e.DbConn.Exec(g.F("CREATE TABLE %s ENGINE = Memory AS (%s)", quoted, sql)))
+	}
+	return e.createTableAs(tempTable, sql, nil)
+}
+
 // getTempTableName is the package-level implementation.
 // Uses a schema-qualified name so that GetColumns() can find the table for merge SQL generation.
 func getTempTableName(model *Model, runID string) string {
@@ -895,6 +1065,225 @@ func getTempTableName(model *Model, runID string) string {
 	}, model.Name)
 	tempName := g.F("_sling_build_tmp_%s_%s", safeName, runID)
 	return g.F("%s.%s", model.Schema, tempName)
+}
+
+func (e *Executor) attachLogSink() {
+	prev := env.LogSink
+	e.prevLogSink = prev
+	env.LogSink = func(ll *g.LogLine) {
+		if prev != nil {
+			prev(ll)
+		}
+		if e.OutputLines == nil {
+			return
+		}
+		select {
+		case e.OutputLines <- ll:
+		default:
+		}
+	}
+}
+
+func (e *Executor) detachLogSink() {
+	env.LogSink = e.prevLogSink
+}
+
+func (e *Executor) drainLogs() g.LogLines {
+	lines := g.LogLines{}
+	if e.OutputLines == nil {
+		return lines
+	}
+	for {
+		select {
+		case ol := <-e.OutputLines:
+			lines = append(lines, *ol)
+		default:
+			return lines
+		}
+	}
+}
+
+func (e *Executor) fileName() *string {
+	if v := os.Getenv("SLING_FILE_NAME"); v != "" && IsConfigFileName(filepath.Base(v)) {
+		return g.Ptr(v)
+	}
+	if e.Build != nil && e.Build.Project != nil {
+		if p, ok := FindConfigFile(e.Build.Project.Dir); ok {
+			if rel, err := filepath.Rel(e.Build.Project.Dir, p); err == nil {
+				return g.Ptr(rel)
+			}
+			return g.Ptr(p)
+		}
+	}
+	return nil
+}
+
+func (e *Executor) selectedOrder(name string) int {
+	if e.Build == nil {
+		return 0
+	}
+	for i, n := range e.Build.Selected {
+		if n == name {
+			return i + 1
+		}
+	}
+	return 0
+}
+
+func (e *Executor) tryNumber() int {
+	n := cast.ToInt(os.Getenv("SLING_TRY_NUMBER"))
+	return lo.Ternary(n == 0, 1, n)
+}
+
+func (e *Executor) syncModelStatus(modelName string, result ExecutionResult, status sling.ExecStatus) {
+	ms := e.makeModelStatus(modelName, result, status)
+	_ = sling.StoreSet(ms)
+}
+
+func (e *Executor) makeModelStatus(modelName string, result ExecutionResult, status sling.ExecStatus) *store.BuildModelStatus {
+	ms := &store.BuildModelStatus{
+		ProjectID:  g.String(os.Getenv("SLING_PROJECT_ID")),
+		JobID:      os.Getenv("SLING_JOB_ID"),
+		ExecID:     os.Getenv("SLING_EXEC_ID"),
+		FileName:   e.fileName(),
+		Target:     e.ConnName,
+		ModelName:  modelName,
+		NodeType:   result.NodeType,
+		ObjectName: result.Name,
+		Mode:       result.Mode,
+		Status:     status,
+		Rows:       result.Rows,
+		Bytes:      result.Bytes,
+		Order:      e.selectedOrder(modelName),
+		Tries:      e.tryNumber(),
+		TryNumber:  e.tryNumber(),
+		NewLines:   e.drainLogs(),
+		TimeNs:     time.Now().UnixNano(),
+		AgentID:    g.Getenv("SLING_RUNNER_ID", os.Getenv("SLING_AGENT_ID")),
+	}
+	ms.Hostname, _ = os.Hostname()
+	if result.Err != nil {
+		ms.Error = g.Ptr(cast.ToString(result.Err))
+	}
+	if result.StartTime != nil {
+		ms.StartTimeNs = g.Int64(result.StartTime.UnixNano())
+	}
+	if status != sling.ExecStatusRunning {
+		ms.EndTimeNs = g.Int64(time.Now().UnixNano())
+	}
+	return ms
+}
+
+func (e *Executor) startModelHeartbeat(modelName string, result *ExecutionResult) func() {
+	ticker := time.NewTicker(5 * time.Second)
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	var once sync.Once
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				e.ctx.Lock()
+				snap := *result
+				e.ctx.Unlock()
+				e.syncModelStatus(modelName, snap, sling.ExecStatusRunning)
+			case <-done:
+				return
+			}
+		}
+	}()
+	return func() {
+		once.Do(func() {
+			close(done)
+			wg.Wait()
+		})
+	}
+}
+
+func (e *Executor) startBuildHeartbeat() func() {
+	ticker := time.NewTicker(5 * time.Second)
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	var once sync.Once
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				e.syncBuildStatus(sling.ExecStatusRunning, nil)
+			case <-done:
+				return
+			}
+		}
+	}()
+	return func() {
+		once.Do(func() {
+			close(done)
+			wg.Wait()
+		})
+	}
+}
+
+func (e *Executor) syncBuildStatus(status sling.ExecStatus, runErr error) {
+	_ = sling.StoreSet(e.makeBuildStatus(status, runErr))
+}
+
+func (e *Executor) makeBuildStatus(status sling.ExecStatus, runErr error) *store.BuildStatus {
+	e.ctx.Lock()
+	results := append([]ExecutionResult(nil), e.Results...)
+	e.ctx.Unlock()
+
+	bs := &store.BuildStatus{
+		ProjectID:  g.String(os.Getenv("SLING_PROJECT_ID")),
+		JobID:      os.Getenv("SLING_JOB_ID"),
+		ExecID:     os.Getenv("SLING_EXEC_ID"),
+		FileName:   e.fileName(),
+		Target:     e.ConnName,
+		Status:     status,
+		ModelCount: 0,
+		Tries:      e.tryNumber(),
+		TryNumber:  e.tryNumber(),
+		NewLines:   e.drainLogs(),
+		TimeNs:     time.Now().UnixNano(),
+		AgentID:    g.Getenv("SLING_RUNNER_ID", os.Getenv("SLING_AGENT_ID")),
+	}
+	if e.Build != nil {
+		bs.Select = e.Build.Options.Select
+		bs.Exclude = e.Build.Options.Exclude
+		bs.FullRefresh = e.Build.Options.FullRefresh
+		bs.ModelCount = len(e.Build.Selected)
+	}
+	bs.Hostname, _ = os.Hostname()
+	if e.startTime != nil {
+		bs.StartTimeNs = g.Int64(e.startTime.UnixNano())
+	}
+	if status != sling.ExecStatusRunning {
+		bs.EndTimeNs = g.Int64(time.Now().UnixNano())
+		if status == sling.ExecStatusError {
+			bs.ExitCode = 1
+		}
+	}
+	if runErr != nil {
+		bs.Error = g.Ptr(cast.ToString(runErr))
+	}
+	for _, r := range results {
+		bs.Rows += r.Rows
+		bs.Bytes += r.Bytes
+		switch {
+		case r.Skipped:
+			bs.SkippedCount++
+		case r.Err != nil:
+			bs.FailedCount++
+		default:
+			bs.OkCount++
+		}
+	}
+	return bs
 }
 
 // printProgress prints a single line of execution progress.
@@ -1362,17 +1751,18 @@ func (e *Executor) queryTargetMax(model *Model, updateKey string) (string, iop.C
 // executeRange iterates over the chunks in r and runs a merge for each one.
 // On any chunk failure it calls handleChunkError and returns.
 // On all-success it conditionally advances SLING_STATE.
-func (e *Executor) executeRange(model *Model, r *Range) error {
+func (e *Executor) executeRange(model *Model, r *Range) (uint64, error) {
 	if len(r.Chunks) == 0 {
 		g.Debug("build[%s]: range resolved to 0 chunks; skipping", model.Name)
-		return nil
+		return 0, nil
 	}
 
 	updateKey := model.Config.UpdateKey
 	if updateKey == "" {
-		return g.Error("model '%s': sling-style incremental requires update_key in config()", model.Name)
+		return 0, g.Error("model '%s': sling-style incremental requires update_key in config()", model.Name)
 	}
 
+	var rows uint64
 	multi := len(r.Chunks) > 1
 	for i, chunk := range r.Chunks {
 		whereCond := chunk.WhereCond(updateKey, e.DbConn.Quote)
@@ -1388,8 +1778,9 @@ func (e *Executor) executeRange(model *Model, r *Range) error {
 		}
 
 		chunkStart := time.Now()
-		chunkErr := e.runMergeForChunk(model, incCtx)
+		chunkRows, chunkErr := e.runMergeForChunk(model, incCtx)
 		chunkDur := time.Since(chunkStart)
+		rows += chunkRows
 
 		if multi {
 			g.Debug("%s", formatChunkProgressLine(i+1, len(r.Chunks), chunk, updateKey, chunkDur, chunkErr != nil))
@@ -1399,7 +1790,7 @@ func (e *Executor) executeRange(model *Model, r *Range) error {
 		}
 
 		if chunkErr != nil {
-			return e.handleChunkError(model, r, i, chunkErr)
+			return rows, e.handleChunkError(model, r, i, chunkErr)
 		}
 	}
 
@@ -1410,18 +1801,18 @@ func (e *Executor) executeRange(model *Model, r *Range) error {
 		}
 	}
 
-	return nil
+	return rows, nil
 }
 
 // runMergeForChunk compiles the model with incCtx, rewrites refs, and executes
 // the temp-table + merge strategy. This is factored from executeLegacyIncremental.
-func (e *Executor) runMergeForChunk(model *Model, incCtx *IncrementalContext) error {
+func (e *Executor) runMergeForChunk(model *Model, incCtx *IncrementalContext) (uint64, error) {
 	t := model.FullTableName
 	uniqueKeys := getUniqueKeys(model)
 
 	_, err := e.Build.Engine.CompileModel(model, incCtx)
 	if err != nil {
-		return g.Error(err, "could not compile incremental SQL for '%s'", model.Name)
+		return 0, g.Error(err, "could not compile incremental SQL for '%s'", model.Name)
 	}
 
 	// Honor rewrite: false
@@ -1432,7 +1823,7 @@ func (e *Executor) runMergeForChunk(model *Model, incCtx *IncrementalContext) er
 
 	result, splitErr := MakeModelSQL(model.CompiledSQL, e.DbConn.GetType())
 	if splitErr != nil {
-		return g.Error(splitErr, "could not parse incremental SQL for '%s'", model.Name)
+		return 0, g.Error(splitErr, "could not parse incremental SQL for '%s'", model.Name)
 	}
 	model.CompiledSQL = result.ModelQuery
 	incrementalSQL := model.CompiledSQL
@@ -1445,38 +1836,28 @@ func (e *Executor) runMergeForChunk(model *Model, incCtx *IncrementalContext) er
 		}
 	}()
 
-	if e.isClickHouse() {
-		quoted, qErr := e.quoteFullTableName(tempTable)
-		if qErr != nil {
-			return qErr
-		}
-		_, err = e.DbConn.Exec(g.F("CREATE TABLE %s ENGINE = Memory AS (%s)", quoted, incrementalSQL))
-	} else {
-		err = e.createTableAs(tempTable, incrementalSQL, nil)
-	}
-	if err != nil {
-		return g.Error(err, "could not create temp table for incremental merge on '%s'", model.Name)
+	if _, err = e.createTempTable(tempTable, incrementalSQL); err != nil {
+		return 0, g.Error(err, "could not create temp table for incremental merge on '%s'", model.Name)
 	}
 
 	tgtQuoted, err := e.quoteFullTableName(t)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	tmpQuoted, err := e.quoteFullTableName(tempTable)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	mergeSQL, err := e.DbConn.GenerateMergeSQLWithStrategy(tmpQuoted, tgtQuoted, uniqueKeys, &strategy)
 	if err != nil {
-		return g.Error(err, "could not generate merge SQL for '%s'", model.Name)
+		return 0, g.Error(err, "could not generate merge SQL for '%s'", model.Name)
 	}
 
-	_, err = e.DbConn.ExecMulti(mergeSQL)
+	rows, err := rowsFromExec(e.DbConn.ExecMulti(mergeSQL))
 	if err != nil {
-		return g.Error(err, "could not execute incremental merge for '%s'", model.Name)
+		return 0, g.Error(err, "could not execute incremental merge for '%s'", model.Name)
 	}
-
-	return nil
+	return e.countIfColumnStore(tempTable, rows), nil
 }
 
 // handleChunkError formats an error from a failed chunk and optionally prints

--- a/core/sling/build/executor_test.go
+++ b/core/sling/build/executor_test.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"errors"
 	"regexp"
 	"strings"
 	"testing"
@@ -12,6 +13,35 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type mockSQLResult struct {
+	n   int64
+	err error
+}
+
+func (m mockSQLResult) LastInsertId() (int64, error) { return 0, nil }
+func (m mockSQLResult) RowsAffected() (int64, error) { return m.n, m.err }
+
+func TestExecutionResultRowsClamp(t *testing.T) {
+	assert.Equal(t, uint64(0), rowsFromResult(nil))
+	assert.Equal(t, uint64(0), rowsFromResult(mockSQLResult{n: -1}))
+	assert.Equal(t, uint64(0), rowsFromResult(mockSQLResult{n: 5, err: errors.New("unsupported")}))
+	assert.Equal(t, uint64(0), rowsFromResult(mockSQLResult{n: 0}))
+	assert.Equal(t, uint64(42), rowsFromResult(mockSQLResult{n: 42}))
+
+	rows, err := rowsFromExec(nil, errors.New("boom"))
+	assert.Equal(t, uint64(0), rows)
+	assert.Error(t, err)
+
+	rows, err = rowsFromExec(mockSQLResult{n: -1}, nil)
+	assert.Equal(t, uint64(0), rows)
+	assert.NoError(t, err)
+}
+
+func TestCountIfColumnStoreSkipped(t *testing.T) {
+	e := &Executor{}
+	assert.Equal(t, uint64(7), e.countIfColumnStore("analytics.t", 7))
+}
 
 func TestNewExecutor(t *testing.T) {
 	dir := getTestFixturePath("sample_project")
@@ -302,7 +332,7 @@ func TestIncrementalRequiresUniqueKey(t *testing.T) {
 	exec, err := NewExecutor(b)
 	require.NoError(t, err)
 
-	err = exec.executeIncremental(model)
+	_, err = exec.executeIncremental(model)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no unique_key defined")
 }

--- a/core/sling/build/executor_test.go
+++ b/core/sling/build/executor_test.go
@@ -4,12 +4,15 @@ import (
 	"errors"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/flarco/g"
 	"github.com/slingdata-io/sling-cli/core/dbio"
 	"github.com/slingdata-io/sling-cli/core/dbio/database"
 	"github.com/slingdata-io/sling-cli/core/dbio/iop"
+	"github.com/slingdata-io/sling-cli/core/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -556,8 +559,106 @@ func TestFormatResumeCommand_WithStep(t *testing.T) {
 	assert.Equal(t, "2024-02-01,2024-04-01,1mo", formatResumeCommand(failed, last, "1mo"))
 }
 
+func TestProgressPrefixModeParensColored(t *testing.T) {
+	old := env.NoColor
+	env.NoColor = false
+	t.Cleanup(func() { env.NoColor = old })
+
+	prefix := progressPrefix(1, 2, "analytics.gitbook_insights_questions", "full-refresh")
+	assert.Equal(t, "[1/2] analytics.gitbook_insights_questions (full-refresh) ", stripANSI(prefix))
+	// Closing paren must sit inside the dark-gray span, not after the reset.
+	assert.Contains(t, prefix, "\x1b[90m(full-refresh)\x1b[0m")
+}
+
 func TestFormatResumeCommand_WithoutStep(t *testing.T) {
 	failed := RangeChunk{LowerRaw: "2024-02-01"}
 	last := RangeChunk{UpperRaw: "2024-04-01"}
 	assert.Equal(t, "2024-02-01,2024-04-01", formatResumeCommand(failed, last, ""))
+}
+
+func TestModelLogIsolationAcrossThreads(t *testing.T) {
+	e := &Executor{modelLogs: make(map[string]g.LogLines)}
+	e.attachLogSink()
+	defer e.detachLogSink()
+
+	const n = 20
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		unbind := e.bindModel("gitbook_insights_questions")
+		defer unbind()
+		for i := 0; i < n; i++ {
+			env.LogSink(&g.LogLine{Text: "gitbook line %d", Args: []any{i}})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		unbind := e.bindModel("gsc_indexed_questions")
+		defer unbind()
+		for i := 0; i < n; i++ {
+			env.LogSink(&g.LogLine{Text: "gsc line %d", Args: []any{i}})
+		}
+	}()
+	wg.Wait()
+
+	// Unscoped logs must not leak into a model drain.
+	env.LogSink(&g.LogLine{Text: "parent summary"})
+
+	gitbook := e.drainLogs("gitbook_insights_questions")
+	gsc := e.drainLogs("gsc_indexed_questions")
+	parent := e.drainLogs("")
+
+	require.Len(t, gitbook, n)
+	require.Len(t, gsc, n)
+	require.Len(t, parent, 1)
+	assert.Equal(t, "parent summary", parent[0].Text)
+
+	for _, ll := range gitbook {
+		assert.Equal(t, "gitbook line %d", ll.Text)
+		assert.Contains(t, ll.Group, "gitbook_insights_questions")
+	}
+	for _, ll := range gsc {
+		assert.Equal(t, "gsc line %d", ll.Text)
+		assert.Contains(t, ll.Group, "gsc_indexed_questions")
+	}
+
+	// Draining one model must not steal the other's leftover (already drained).
+	assert.Empty(t, e.drainLogs("gitbook_insights_questions"))
+	assert.Empty(t, e.drainLogs("gsc_indexed_questions"))
+}
+
+func TestDrainLogsDoesNotStealOtherModel(t *testing.T) {
+	e := &Executor{modelLogs: make(map[string]g.LogLines)}
+	e.attachLogSink()
+	defer e.detachLogSink()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		unbind := e.bindModel("model_a")
+		defer unbind()
+		env.LogSink(&g.LogLine{Text: "a-1"})
+		close(started)
+		<-release
+		env.LogSink(&g.LogLine{Text: "a-2"})
+	}()
+
+	<-started
+	unbindB := e.bindModel("model_b")
+	env.LogSink(&g.LogLine{Text: "b-1"})
+	bLines := e.drainLogs("model_b")
+	unbindB()
+	close(release)
+	wg.Wait()
+
+	aLines := e.drainLogs("model_a")
+	require.Len(t, bLines, 1)
+	assert.Equal(t, "b-1", bLines[0].Text)
+	require.Len(t, aLines, 2)
+	assert.Equal(t, "a-1", aLines[0].Text)
+	assert.Equal(t, "a-2", aLines[1].Text)
 }

--- a/core/sling/build/executor_test.go
+++ b/core/sling/build/executor_test.go
@@ -243,6 +243,13 @@ func TestGetTempTableName(t *testing.T) {
 	assert.NotEqual(t, tempName, tempName2)
 }
 
+func TestGetTempTableNameThreePart(t *testing.T) {
+	model := &Model{Name: "fct_orders", Schema: "marts", Database: "ANALYTICS_DB"}
+
+	tempName := getTempTableName(model, "abc123")
+	assert.Equal(t, "ANALYTICS_DB.marts._sling_build_tmp_fct_orders_abc123", tempName)
+}
+
 func TestNormalizeMode(t *testing.T) {
 	m, warn := normalizeMode("snapshot")
 	assert.Equal(t, "append", m)

--- a/core/sling/build/hook_runner.go
+++ b/core/sling/build/hook_runner.go
@@ -83,6 +83,7 @@ func RunForHook(path string, opts sling.HookBuildRunOptions) (map[string]any, er
 func resultsToState(path, target string, results []ExecutionResult) map[string]any {
 	rows := make([]map[string]any, 0, len(results))
 	ok, failed, skipped := 0, 0, 0
+	var totalRows, totalBytes uint64
 	for _, r := range results {
 		status := "success"
 		errMsg := ""
@@ -97,6 +98,8 @@ func resultsToState(path, target string, results []ExecutionResult) map[string]a
 		default:
 			ok++
 		}
+		totalRows += r.Rows
+		totalBytes += r.Bytes
 		rows = append(rows, g.M(
 			"name", r.Name,
 			"type", r.NodeType,
@@ -104,6 +107,8 @@ func resultsToState(path, target string, results []ExecutionResult) map[string]a
 			"duration", r.Duration.Seconds(),
 			"status", status,
 			"error", errMsg,
+			"rows", r.Rows,
+			"bytes", r.Bytes,
 		))
 	}
 
@@ -118,6 +123,8 @@ func resultsToState(path, target string, results []ExecutionResult) map[string]a
 		"ok", ok,
 		"failed", failed,
 		"skipped", skipped,
+		"rows", totalRows,
+		"bytes", totalBytes,
 		// Convenience: comma-joined names of successful models/seeds
 		"ok_names", joinResultNames(results, "success"),
 	)

--- a/core/sling/build/hook_runner.go
+++ b/core/sling/build/hook_runner.go
@@ -29,6 +29,8 @@ func RunForHook(path string, opts sling.HookBuildRunOptions) (map[string]any, er
 		NoSeeds:     opts.NoSeeds,
 		Recursive:   opts.Recursive,
 		Test:        opts.Test,
+		Compile:     opts.Compile,
+		List:        opts.List,
 	}
 	if buildOpts.Threads < 1 {
 		buildOpts.Threads = DefaultThreads
@@ -44,6 +46,13 @@ func RunForHook(path string, opts sling.HookBuildRunOptions) (map[string]any, er
 
 	if err := b.Compile(); err != nil {
 		return nil, g.Error(err, "could not compile build project")
+	}
+
+	if opts.List {
+		return listToState(path, b), nil
+	}
+	if opts.Compile {
+		return compileToState(path, b), nil
 	}
 
 	// Multi-target / recursive sub-projects use Build.Execute (no per-node results).
@@ -144,4 +153,88 @@ func joinResultNames(results []ExecutionResult, wantStatus string) string {
 		}
 	}
 	return strings.Join(names, ",")
+}
+
+func compileToState(path string, b *Build) map[string]any {
+	if len(b.SubBuilds) > 0 {
+		var all []map[string]any
+		total := 0
+		for _, sub := range b.SubBuilds {
+			p := sub.CompileJSONPayload()
+			all = append(all, p)
+			if order, ok := p["order"].([]string); ok {
+				total += len(order)
+			}
+		}
+		return g.M(
+			"path", path,
+			"command", "compile",
+			"sub_projects", all,
+			"results", []map[string]any{},
+			"total", total,
+			"ok", total,
+			"failed", 0,
+			"skipped", 0,
+		)
+	}
+	payload := b.CompileJSONPayload()
+	order, _ := payload["order"].([]string)
+	nodes, _ := payload["nodes"].([]map[string]any)
+	return g.M(
+		"path", path,
+		"target", b.GetTarget(),
+		"command", "compile",
+		"order", payload["order"],
+		"nodes", payload["nodes"],
+		"results", nodes,
+		"total", len(order),
+		"ok", len(order),
+		"failed", 0,
+		"skipped", 0,
+	)
+}
+
+func listToState(path string, b *Build) map[string]any {
+	showTable := b.GetTarget() != ""
+	var rows []map[string]any
+	if b.DAG != nil {
+		for _, name := range b.Selected {
+			node := b.DAG.Nodes[name]
+			if node == nil {
+				continue
+			}
+			if b.Options.NoSeeds && node.Seed != nil {
+				continue
+			}
+			item := g.M("name", name)
+			if node.Seed != nil {
+				item["type"] = "seed"
+				item["file"] = node.Seed.RelPath
+				if showTable {
+					item["table"] = node.Seed.FullTableName
+				}
+			} else if node.Model != nil {
+				item["type"] = "model"
+				item["mode"] = b.GetModelMode(node.Model)
+				item["file"] = node.Model.RelPath
+				if showTable {
+					item["table"] = node.Model.FullTableName
+				}
+			}
+			rows = append(rows, item)
+		}
+	}
+	if rows == nil {
+		rows = []map[string]any{}
+	}
+	return g.M(
+		"path", path,
+		"target", b.GetTarget(),
+		"command", "list",
+		"results", rows,
+		"total", len(rows),
+		"ok", len(rows),
+		"failed", 0,
+		"skipped", 0,
+	)
 }

--- a/core/sling/build/names.go
+++ b/core/sling/build/names.go
@@ -1,0 +1,205 @@
+package build
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// NameRef is a resolved model or seed.
+type NameRef struct {
+	Name          string
+	RelPath       string
+	FullTableName string
+	Model         *Model
+	Seed          *Seed
+}
+
+// NameNotFoundError is returned when no model or seed matches.
+type NameNotFoundError struct {
+	Query       string
+	Kind        string // "ref" or "selector"
+	Suggestions []NameRef
+}
+
+func (e *NameNotFoundError) Error() string {
+	var b strings.Builder
+	if e.Kind == "selector" {
+		fmt.Fprintf(&b, "selector '%s' not found.", e.Query)
+	} else {
+		fmt.Fprintf(&b, "ref('%s') not found.", e.Query)
+	}
+	if len(e.Suggestions) == 0 {
+		return b.String()
+	}
+	b.WriteString(" Did you mean:\n")
+	for _, c := range e.Suggestions {
+		fmt.Fprintf(&b, "  %-20s %s\n", c.Name, c.RelPath)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func (e *NameNotFoundError) asSelector() *NameNotFoundError {
+	cp := *e
+	cp.Kind = "selector"
+	return &cp
+}
+
+func nameRefFromModel(m *Model) NameRef {
+	return NameRef{
+		Name:          m.Name,
+		RelPath:       m.RelPath,
+		FullTableName: m.FullTableName,
+		Model:         m,
+	}
+}
+
+func nameRefFromSeed(s *Seed) NameRef {
+	return NameRef{
+		Name:          s.Name,
+		RelPath:       s.RelPath,
+		FullTableName: s.FullTableName,
+		Seed:          s,
+	}
+}
+
+// stripDatabase removes the leading database qualifier from a three-part name.
+func stripDatabase(fullName string) string {
+	parts := strings.Split(fullName, ".")
+	if len(parts) == 3 {
+		return parts[1] + "." + parts[2]
+	}
+	return fullName
+}
+
+// ResolveName returns the model or seed for name.
+// name may be the file stem ("dim_customers") or the prod table name
+// ("marts.dim_customers", or "DB.marts.dim_customers" on three-part projects).
+func (p *BuildProject) ResolveName(name string) (*NameRef, error) {
+	if name == "" {
+		return nil, &NameNotFoundError{Query: name}
+	}
+
+	if m, ok := p.Models[name]; ok {
+		ref := nameRefFromModel(m)
+		return &ref, nil
+	}
+	if s, ok := p.Seeds[name]; ok {
+		ref := nameRefFromSeed(s)
+		return &ref, nil
+	}
+
+	lower := strings.ToLower(name)
+	for _, m := range p.Models {
+		if strings.ToLower(m.ProdFullTableName) == lower {
+			ref := nameRefFromModel(m)
+			return &ref, nil
+		}
+	}
+	for _, s := range p.Seeds {
+		if strings.ToLower(s.ProdFullTableName) == lower {
+			ref := nameRefFromSeed(s)
+			return &ref, nil
+		}
+	}
+
+	// schema.name spelling on a three-part project
+	for _, m := range p.Models {
+		if strings.ToLower(stripDatabase(m.ProdFullTableName)) == lower {
+			ref := nameRefFromModel(m)
+			return &ref, nil
+		}
+	}
+	for _, s := range p.Seeds {
+		if strings.ToLower(stripDatabase(s.ProdFullTableName)) == lower {
+			ref := nameRefFromSeed(s)
+			return &ref, nil
+		}
+	}
+
+	return nil, &NameNotFoundError{Query: name, Suggestions: p.suggest(name)}
+}
+
+func (p *BuildProject) suggest(name string) []NameRef {
+	lower := strings.ToLower(name)
+	seen := map[string]bool{}
+	var out []NameRef
+	add := func(r NameRef) {
+		if seen[r.Name] {
+			return
+		}
+		seen[r.Name] = true
+		out = append(out, r)
+	}
+
+	for _, m := range p.Models {
+		if strings.HasSuffix(strings.ToLower(m.Name), "_"+lower) {
+			add(nameRefFromModel(m))
+			continue
+		}
+		if levenshtein(strings.ToLower(m.Name), lower) <= 2 {
+			add(nameRefFromModel(m))
+		}
+	}
+	for _, s := range p.Seeds {
+		if strings.HasSuffix(strings.ToLower(s.Name), "_"+lower) {
+			add(nameRefFromSeed(s))
+			continue
+		}
+		if levenshtein(strings.ToLower(s.Name), lower) <= 2 {
+			add(nameRefFromSeed(s))
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	if len(out) > 5 {
+		out = out[:5]
+	}
+	return out
+}
+
+func levenshtein(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if a == "" {
+		return len(b)
+	}
+	if b == "" {
+		return len(a)
+	}
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for j := 0; j <= len(b); j++ {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			del := prev[j] + 1
+			ins := curr[j-1] + 1
+			sub := prev[j-1] + cost
+			curr[j] = del
+			if ins < curr[j] {
+				curr[j] = ins
+			}
+			if sub < curr[j] {
+				curr[j] = sub
+			}
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
+}
+
+func selectorResolveError(err error) error {
+	switch e := err.(type) {
+	case *NameNotFoundError:
+		return e.asSelector()
+	default:
+		return err
+	}
+}

--- a/core/sling/build/project.go
+++ b/core/sling/build/project.go
@@ -33,13 +33,13 @@ type BuildProject struct {
 
 // Model represents a SQL model file in the project.
 type Model struct {
-	Name              string      // e.g., "dim_customers"
+	Name              string      // file stem, unique across the project, e.g. "events"
 	FilePath          string      // absolute path
 	RelPath           string      // relative path from project root
-	Schema            string      // derived from folder or override
-	Prefix            string      // underscore-joined nested folder names
-	FullTableName     string      // schema.prefix_name (current mode)
-	ProdFullTableName string      // schema.prefix_name (always prod-mode, for SQL matching)
+	Schema            string      // derived from first folder or override
+	Database          string      // optional catalog; three-part dialects only
+	FullTableName     string      // [database.]schema.name (current mode)
+	ProdFullTableName string      // [database.]schema.name (always prod-mode, for SQL matching)
 	RawSQL            string      // raw file content (frontmatter stripped)
 	CompiledSQL       string      // after Jinja rendering
 	PreStatements     []string    // SQL statements before the model query (from multi-statement splitting)
@@ -66,6 +66,7 @@ type ModelConfig struct {
 	PreHook       string        `yaml:"pre_hook,omitempty"`  // deprecated: kept for validation only
 	PostHook      string        `yaml:"post_hook,omitempty"` // deprecated: kept for validation only
 	Schema        string        `yaml:"schema,omitempty"`
+	Database      string        `yaml:"database,omitempty"`
 	Enabled       *bool         `yaml:"enabled,omitempty"`
 	Engine        string        `yaml:"engine,omitempty"`
 	Range         *RangeConfig  `yaml:"range,omitempty"`
@@ -174,13 +175,13 @@ func validateModel(m *Model) error {
 
 // Seed represents a seed file (CSV, JSON, Parquet) in the project.
 type Seed struct {
-	Name              string // e.g., "country_codes"
+	Name              string // file stem, unique across the project
 	FilePath          string // absolute path
 	RelPath           string // relative path from project root
 	Schema            string
-	Prefix            string
-	FullTableName     string // schema.prefix_name (current mode)
-	ProdFullTableName string // schema.prefix_name (always prod-mode, for SQL matching)
+	Database          string // optional catalog; three-part dialects only
+	FullTableName     string // [database.]schema.name (current mode)
+	ProdFullTableName string // [database.]schema.name (always prod-mode, for SQL matching)
 	Format            string // csv, json, parquet
 }
 
@@ -191,13 +192,16 @@ type BuildConfig struct {
 	DbtProject any            `yaml:"dbt_project,omitempty"`
 	Vars       map[string]any `yaml:"vars,omitempty"`
 	Defaults   BuildDefaults  `yaml:"defaults,omitempty"`
+
+	unresolvedVars []string // ${VAR} names that had no value and no fallback
 }
 
 // DevConfig holds dev-mode settings in sling_build.yml.
 // When present, dev mode is the default (override with --prod).
 type DevConfig struct {
-	Target string `yaml:"target,omitempty"` // optional, falls back to top-level target
-	Schema string `yaml:"schema"`           // mandatory for dev mode
+	Target   string `yaml:"target,omitempty"`   // optional, falls back to top-level target
+	Schema   string `yaml:"schema"`             // mandatory for dev mode
+	Database string `yaml:"database,omitempty"` // optional; falls back to defaults.database
 }
 
 // DbtProjectConfig holds dbt project compatibility settings.
@@ -210,7 +214,8 @@ type DbtProjectConfig struct {
 type BuildDefaults struct {
 	Mode          string        `yaml:"mode,omitempty"`
 	Schema        string        `yaml:"schema,omitempty"`
-	Tags          []string      `yaml:"tags,omitempty"` // additive across nesting
+	Database      string        `yaml:"database,omitempty"` // three-part dialects only
+	Tags          []string      `yaml:"tags,omitempty"`     // additive across nesting
 	UniqueKey     any           `yaml:"unique_key,omitempty"`
 	UpdateKey     string        `yaml:"update_key,omitempty"`
 	MergeStrategy string        `yaml:"merge_strategy,omitempty"`
@@ -237,6 +242,9 @@ type BuildOptions struct {
 	Recursive   bool    // CLI --recursive/-R: discover sling_build.yml in immediate subdirectories
 	Test        bool    // CLI --test: run data tests only (no materialization)
 	JSON        bool    // CLI --json: machine-readable compile/list output
+	// SkipUnresolvedCheck skips the ${VAR} error for fields in effect.
+	// sling validate uses this because it does not choose a run mode.
+	SkipUnresolvedCheck bool
 }
 
 // DefaultThreads is the default parallelism for model execution.
@@ -453,6 +461,10 @@ func LoadProject(dir string, opts ...BuildOptions) (*BuildProject, error) {
 		return nil, err
 	}
 
+	if err := project.checkUnresolvedVars(cliOpts); err != nil {
+		return nil, err
+	}
+
 	return project, nil
 }
 
@@ -463,10 +475,13 @@ func loadConfig(path string) (*BuildConfig, error) {
 		return nil, g.Error(err, "could not read config file")
 	}
 
+	expanded, unresolved := expandConfigVars(string(data))
+
 	cfg := &BuildConfig{}
-	if err := yaml.Unmarshal(data, cfg); err != nil {
+	if err := yaml.Unmarshal([]byte(expanded), cfg); err != nil {
 		return nil, g.Error(err, "could not parse config file")
 	}
+	cfg.unresolvedVars = unresolved
 
 	if cfg.Defaults.Mode != "" {
 		canonical, warn := normalizeMode(cfg.Defaults.Mode)
@@ -483,6 +498,127 @@ func loadConfig(path string) (*BuildConfig, error) {
 	}
 
 	return cfg, nil
+}
+
+// configVarRe matches ${VAR} and ${VAR:-fallback}. Bare $VAR is not expanded.
+var configVarRe = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}`)
+
+// ExpandConfigVars expands ${VAR} and ${VAR:-fallback} in sling_build.yml text.
+func ExpandConfigVars(text string) (string, []string) {
+	return expandConfigVars(text)
+}
+
+// ExpandConfigVarsEnv is ExpandConfigVars with extra names checked before the process environment.
+func ExpandConfigVarsEnv(text string, extra map[string]string) (string, []string) {
+	return expandConfigVarsLookup(text, func(name string) (string, bool) {
+		if extra != nil {
+			if v, ok := extra[name]; ok && v != "" {
+				return v, true
+			}
+		}
+		return os.LookupEnv(name)
+	})
+}
+
+// expandConfigVars expands ${VAR} and ${VAR:-fallback} in sling_build.yml text.
+// Unset or empty variables without a fallback stay literal and are listed in unresolved.
+func expandConfigVars(text string) (string, []string) {
+	return expandConfigVarsLookup(text, os.LookupEnv)
+}
+
+func expandConfigVarsLookup(text string, lookup func(string) (string, bool)) (out string, unresolved []string) {
+	seen := map[string]bool{}
+	out = configVarRe.ReplaceAllStringFunc(text, func(m string) string {
+		sub := configVarRe.FindStringSubmatch(m)
+		name := sub[1]
+		rest := m[2+len(name):] // after `${NAME`
+		hasFallback := strings.HasPrefix(rest, ":-")
+
+		val, ok := lookup(name)
+		if ok && val != "" {
+			return val
+		}
+		if hasFallback {
+			return sub[2]
+		}
+		if !seen[name] {
+			seen[name] = true
+			unresolved = append(unresolved, name)
+		}
+		return m
+	})
+	return out, unresolved
+}
+
+// UnresolvedConfigVars returns ${VAR} names that had no value and no fallback.
+func (p *BuildProject) UnresolvedConfigVars() []string {
+	if p == nil || p.Config == nil {
+		return nil
+	}
+	return p.Config.unresolvedVars
+}
+
+// checkUnresolvedVars reports the first unresolved ${VAR} in a field that is
+// in effect for this run. See D3 in the build-dev-ux plan.
+func (p *BuildProject) checkUnresolvedVars(opts BuildOptions) error {
+	if opts.SkipUnresolvedCheck {
+		return nil
+	}
+	if err := p.Config.checkUnresolved(p.Mode, opts); err != nil {
+		return err
+	}
+	for _, cfg := range p.ChildConfigs {
+		if err := cfg.checkUnresolved(p.Mode, opts); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *BuildConfig) checkUnresolved(mode string, opts BuildOptions) error {
+	if c == nil || len(c.unresolvedVars) == 0 {
+		return nil
+	}
+
+	// vars are always in effect
+	for k, v := range c.Vars {
+		s := cast.ToString(v)
+		if name, ok := firstUnresolvedVar(s); ok {
+			return unresolvedVarError("vars."+k, name, "")
+		}
+	}
+
+	// target: only when the resolved value still holds a token
+	if name, ok := firstUnresolvedVar(c.Target); ok {
+		return unresolvedVarError("target", name, ",\nor pass --target <name>.")
+	}
+
+	if mode == "dev" && c.Dev != nil {
+		if opts.Schema == "" {
+			if name, ok := firstUnresolvedVar(c.Dev.Schema); ok {
+				return unresolvedVarError("dev.schema", name, ",\nor pass --schema <name>.")
+			}
+		}
+		if opts.Target == "" {
+			if name, ok := firstUnresolvedVar(c.Dev.Target); ok {
+				return unresolvedVarError("dev.target", name, ",\nor pass --target <name>.")
+			}
+		}
+	}
+
+	return nil
+}
+
+func firstUnresolvedVar(s string) (string, bool) {
+	sub := configVarRe.FindStringSubmatch(s)
+	if sub == nil {
+		return "", false
+	}
+	return sub[1], true
+}
+
+func unresolvedVarError(field, name, extraHint string) error {
+	return g.Error("sling_build.yml: %s uses ${%s} but %s is not set.\nSet it in ~/.sling/env.yaml under `env:`, export it in the shell%s", field, name, name, extraHint)
 }
 
 // mergeHookMaps produces a HookMap whose slices are the ordered concatenation
@@ -522,10 +658,11 @@ func mergeConfigs(parent, child *BuildConfig) *BuildConfig {
 	}
 
 	merged := &BuildConfig{
-		Target:     parent.Target,
-		Dev:        parent.Dev,
-		DbtProject: parent.DbtProject,
-		Defaults:   parent.Defaults,
+		Target:         parent.Target,
+		Dev:            parent.Dev,
+		DbtProject:     parent.DbtProject,
+		Defaults:       parent.Defaults,
+		unresolvedVars: lo.Uniq(append(append([]string{}, parent.unresolvedVars...), child.unresolvedVars...)),
 	}
 
 	// Deep merge vars
@@ -555,6 +692,9 @@ func mergeConfigs(parent, child *BuildConfig) *BuildConfig {
 	}
 	if child.Defaults.Schema != "" {
 		merged.Defaults.Schema = child.Defaults.Schema
+	}
+	if child.Defaults.Database != "" {
+		merged.Defaults.Database = child.Defaults.Database
 	}
 	if child.Defaults.UniqueKey != nil {
 		merged.Defaults.UniqueKey = child.Defaults.UniqueKey
@@ -626,6 +766,10 @@ func loadIndependentBuilds(project *BuildProject, cliOpts BuildOptions) (*BuildP
 		warnMacroShadows(subProject)
 
 		if err := validateUniqueNames(subProject); err != nil {
+			return nil, err
+		}
+
+		if err := subProject.checkUnresolvedVars(cliOpts); err != nil {
 			return nil, err
 		}
 
@@ -1035,8 +1179,9 @@ func addModel(project *BuildProject, absPath, relPath string) error {
 		return g.Error(err, "could not read model file: %s", absPath)
 	}
 
-	schema, prefix, name, fullTableName := resolveTableName(relPath, project.Mode, project.SchemaOverride, project.DefaultSchema)
-	_, _, _, prodFullTableName := resolveTableName(relPath, "prod", "", project.DefaultSchema)
+	identity := identityFromPath(relPath, project.Mode, project.SchemaOverride, project.DefaultSchema)
+	prodIdentity := identityFromPath(relPath, "prod", "", project.DefaultSchema)
+	name := identity.Name
 
 	// Apply merged defaults (root + child sling_build.yml) for this file's location.
 	defaults := effectiveDefaults(project, relPath)
@@ -1083,6 +1228,9 @@ func addModel(project *BuildProject, absPath, relPath string) error {
 		if fmConfig.Schema != "" {
 			modelConfig.Schema = fmConfig.Schema
 		}
+		if fmConfig.Database != "" {
+			modelConfig.Database = fmConfig.Database
+		}
 		if fmConfig.Enabled != nil {
 			modelConfig.Enabled = fmConfig.Enabled
 		}
@@ -1106,18 +1254,17 @@ func addModel(project *BuildProject, absPath, relPath string) error {
 		}
 	}
 
-	// Schema override from defaults or frontmatter — recompute FullTableName.
-	// (Before this change, a frontmatter `schema:` was silently ignored at the
-	// table-name level; only modelConfig.Schema was set.)
-	// ProdFullTableName is intentionally NOT rewritten: it exists specifically
-	// as the prod-mode reference for SQL ref() matching.
+	// Schema and database overrides from defaults or frontmatter.
+	// ProdFullTableName keeps the folder-derived schema: it exists as the
+	// prod-mode reference for SQL ref() matching. Its database follows the
+	// same resolution, since database is never folder-derived.
 	if modelConfig.Schema != "" {
-		schema = modelConfig.Schema
-		qualifiedName := name
-		if prefix != "" {
-			qualifiedName = prefix + "_" + name
-		}
-		fullTableName = schema + "." + qualifiedName
+		identity.Schema = modelConfig.Schema
+	}
+	identity.Database = resolveDatabase(project, modelConfig.Database, defaults.Database)
+	prodIdentity.Database = prodDatabase(project, modelConfig.Database, defaults.Database)
+	if modelConfig.Database == "" {
+		modelConfig.Database = identity.Database
 	}
 
 	// Detect incremental pattern (dbt-style vs sling-native). Errors at load time
@@ -1131,10 +1278,10 @@ func addModel(project *BuildProject, absPath, relPath string) error {
 		Name:              name,
 		FilePath:          absPath,
 		RelPath:           relPath,
-		Schema:            schema,
-		Prefix:            prefix,
-		FullTableName:     fullTableName,
-		ProdFullTableName: prodFullTableName,
+		Schema:            identity.Schema,
+		Database:          identity.Database,
+		FullTableName:     identity.FullName(),
+		ProdFullTableName: prodIdentity.FullName(),
 		RawSQL:            sqlContent,
 		Config:            modelConfig,
 		HasFrontmatter:    hasFrontmatter,
@@ -1155,82 +1302,93 @@ func addModel(project *BuildProject, absPath, relPath string) error {
 
 // addSeed creates a Seed from a file and adds it to the project.
 func addSeed(project *BuildProject, absPath, relPath, format string) error {
-	schema, prefix, name, fullTableName := resolveTableName(relPath, project.Mode, project.SchemaOverride, project.DefaultSchema)
-	_, _, _, prodFullTableName := resolveTableName(relPath, "prod", "", project.DefaultSchema)
+	identity := identityFromPath(relPath, project.Mode, project.SchemaOverride, project.DefaultSchema)
+	prodIdentity := identityFromPath(relPath, "prod", "", project.DefaultSchema)
 
-	// Seeds only honor defaults.schema from the merged config — no tags,
-	// enabled, hooks, or unique_key semantics apply to seeds today.
-	if defaults := effectiveDefaults(project, relPath); defaults.Schema != "" {
-		schema = defaults.Schema
-		qualifiedName := name
-		if prefix != "" {
-			qualifiedName = prefix + "_" + name
-		}
-		fullTableName = schema + "." + qualifiedName
+	// Seeds only honor defaults.schema and defaults.database from the merged
+	// config — no tags, enabled, hooks, or unique_key semantics apply to seeds.
+	defaults := effectiveDefaults(project, relPath)
+	if defaults.Schema != "" {
+		identity.Schema = defaults.Schema
 	}
+	identity.Database = resolveDatabase(project, "", defaults.Database)
+	prodIdentity.Database = prodDatabase(project, "", defaults.Database)
 
 	seed := &Seed{
-		Name:              name,
+		Name:              identity.Name,
 		FilePath:          absPath,
 		RelPath:           relPath,
-		Schema:            schema,
-		Prefix:            prefix,
-		FullTableName:     fullTableName,
-		ProdFullTableName: prodFullTableName,
+		Schema:            identity.Schema,
+		Database:          identity.Database,
+		FullTableName:     identity.FullName(),
+		ProdFullTableName: prodIdentity.FullName(),
 		Format:            format,
 	}
 
-	if existing, ok := project.Seeds[name]; ok {
-		return g.Error("duplicate seed name '%s': found in both '%s' and '%s'", name, existing.RelPath, relPath)
+	if existing, ok := project.Seeds[identity.Name]; ok {
+		return g.Error("duplicate seed name '%s': found in both '%s' and '%s'", identity.Name, existing.RelPath, relPath)
 	}
 
-	project.Seeds[name] = seed
+	project.Seeds[identity.Name] = seed
 	return nil
 }
 
-// resolveTableName determines the schema, prefix, name, and full table name from a relative path.
-func resolveTableName(relPath, mode, schemaOverride, defaultSchema string) (schema, prefix, name, fullTableName string) {
-	// Normalize path separators
-	relPath = filepath.ToSlash(relPath)
+// resolveDatabase returns the database for the current mode. An explicit
+// front-matter value always wins. Otherwise dev mode uses dev.database when
+// set, and both modes fall back to defaults.database.
+func resolveDatabase(project *BuildProject, frontmatter, defaultDatabase string) string {
+	if frontmatter != "" {
+		return frontmatter
+	}
+	if project.Mode == "dev" && project.Config != nil && project.Config.Dev != nil && project.Config.Dev.Database != "" {
+		return project.Config.Dev.Database
+	}
+	return defaultDatabase
+}
 
-	// Split path into parts
-	parts := strings.Split(relPath, "/")
+// prodDatabase returns the database used for the prod-mode reference name.
+func prodDatabase(project *BuildProject, frontmatter, defaultDatabase string) string {
+	if frontmatter != "" {
+		return frontmatter
+	}
+	return defaultDatabase
+}
 
-	// Extract filename and remove extension
+// TableIdentity is the resolved warehouse location of a model or seed.
+type TableIdentity struct {
+	Name     string // file stem
+	Schema   string
+	Database string // optional; three-part dialects only
+}
+
+// FullName returns [database.]schema.name.
+func (t TableIdentity) FullName() string {
+	if t.Database != "" {
+		return t.Database + "." + t.Schema + "." + t.Name
+	}
+	return t.Schema + "." + t.Name
+}
+
+// identityFromPath derives the table identity from a relative file path.
+// The file stem is the table name. In prod mode the first folder is the
+// schema. In dev mode the schema is the override. Deeper folders organize
+// files only; they do not change the name.
+func identityFromPath(relPath, mode, schemaOverride, defaultSchema string) TableIdentity {
+	parts := strings.Split(filepath.ToSlash(relPath), "/")
+
 	fileName := parts[len(parts)-1]
-	ext := filepath.Ext(fileName)
-	name = strings.TrimSuffix(fileName, ext)
-
-	// Get directory parts (excluding filename)
+	name := strings.TrimSuffix(fileName, filepath.Ext(fileName))
 	dirParts := parts[:len(parts)-1]
 
-	if mode == "dev" {
-		// Dev mode: all folder parts become prefix, use override schema
+	schema := defaultSchema
+	switch {
+	case mode == "dev":
 		schema = schemaOverride
-		if len(dirParts) > 0 {
-			prefix = strings.Join(dirParts, "_")
-		}
-	} else {
-		// Prod mode: 1st folder = schema, remaining = prefix
-		if len(dirParts) == 0 {
-			// Root-level file
-			schema = defaultSchema
-		} else {
-			schema = dirParts[0]
-			if len(dirParts) > 1 {
-				prefix = strings.Join(dirParts[1:], "_")
-			}
-		}
+	case len(dirParts) > 0:
+		schema = dirParts[0]
 	}
 
-	// Build full table name
-	qualifiedName := name
-	if prefix != "" {
-		qualifiedName = prefix + "_" + name
-	}
-	fullTableName = schema + "." + qualifiedName
-
-	return
+	return TableIdentity{Name: name, Schema: schema}
 }
 
 // validateUniqueNames checks that there are no duplicate names across models and seeds.
@@ -1299,13 +1457,11 @@ func (p *BuildProject) AllNames() []string {
 
 // LookupFullTableName returns the full table name for a given model or seed name.
 func (p *BuildProject) LookupFullTableName(name string) (string, bool) {
-	if m, ok := p.Models[name]; ok {
-		return m.FullTableName, true
+	ref, err := p.ResolveName(name)
+	if err != nil || ref == nil {
+		return "", false
 	}
-	if s, ok := p.Seeds[name]; ok {
-		return s.FullTableName, true
-	}
-	return "", false
+	return ref.FullTableName, true
 }
 
 // prodNameEntry maps a prod-mode name to its model/seed name and current-mode FullTableName.

--- a/core/sling/build/project.go
+++ b/core/sling/build/project.go
@@ -468,6 +468,12 @@ func LoadProject(dir string, opts ...BuildOptions) (*BuildProject, error) {
 	return project, nil
 }
 
+// LoadBuildConfig parses a sling_build.yml body. It expands ${VAR} references
+// and validates defaults.mode.
+func LoadBuildConfig(content string) (cfg *BuildConfig, err error) {
+	return loadBuildConfig(content, "sling_build.yml")
+}
+
 // loadConfig reads and parses a sling_build.yml file.
 func loadConfig(path string) (*BuildConfig, error) {
 	data, err := os.ReadFile(path)
@@ -475,7 +481,12 @@ func loadConfig(path string) (*BuildConfig, error) {
 		return nil, g.Error(err, "could not read config file")
 	}
 
-	expanded, unresolved := expandConfigVars(string(data))
+	return loadBuildConfig(string(data), path)
+}
+
+// loadBuildConfig parses a sling_build.yml body. name is used for messages only.
+func loadBuildConfig(content, name string) (*BuildConfig, error) {
+	expanded, unresolved := expandConfigVars(content)
 
 	cfg := &BuildConfig{}
 	if err := yaml.Unmarshal([]byte(expanded), cfg); err != nil {
@@ -486,13 +497,13 @@ func loadConfig(path string) (*BuildConfig, error) {
 	if cfg.Defaults.Mode != "" {
 		canonical, warn := normalizeMode(cfg.Defaults.Mode)
 		if warn != "" {
-			g.Warn("%s: defaults.mode: %s", path, warn)
+			g.Warn("%s: defaults.mode: %s", name, warn)
 		}
 		if canonical == "ephemeral" {
-			return nil, g.Error("%s: defaults.mode: ephemeral models are not supported; use view or table", path)
+			return nil, g.Error("%s: defaults.mode: ephemeral models are not supported; use view or table", name)
 		}
 		if !ValidModes[canonical] {
-			return nil, g.Error("%s: unknown defaults.mode '%s'; expected one of: %s", path, cfg.Defaults.Mode, validModeNames())
+			return nil, g.Error("%s: unknown defaults.mode '%s'; expected one of: %s", name, cfg.Defaults.Mode, validModeNames())
 		}
 		cfg.Defaults.Mode = canonical
 	}

--- a/core/sling/build/project.go
+++ b/core/sling/build/project.go
@@ -187,13 +187,44 @@ type Seed struct {
 
 // BuildConfig represents the contents of sling_build.yml.
 type BuildConfig struct {
-	Target     string         `yaml:"target"`
-	Dev        *DevConfig     `yaml:"dev,omitempty"`
-	DbtProject any            `yaml:"dbt_project,omitempty"`
-	Vars       map[string]any `yaml:"vars,omitempty"`
-	Defaults   BuildDefaults  `yaml:"defaults,omitempty"`
+	Target     string         `json:"target,omitempty" yaml:"target"`
+	Dev        *DevConfig     `json:"dev,omitempty" yaml:"dev,omitempty"`
+	DbtProject any            `json:"dbt_project,omitempty" yaml:"dbt_project,omitempty"`
+	Vars       map[string]any `json:"vars,omitempty" yaml:"vars,omitempty"`
+	Defaults   BuildDefaults  `json:"defaults,omitempty" yaml:"defaults,omitempty"`
+
+	// Order and Nodes are the compiled output, set by Build.Compile.
+	// They live on the root config only; mergeConfigs does not carry them.
+	Order    []string `json:"order" yaml:"-"`
+	Nodes    []Node   `json:"nodes" yaml:"-"`
+	Compiled bool     `json:"compiled" yaml:"-"`
 
 	unresolvedVars []string // ${VAR} names that had no value and no fallback
+}
+
+// Node is one selected model or seed of a compiled build project.
+type Node struct {
+	Name         string   `json:"name" yaml:"name"`
+	Type         string   `json:"type,omitempty" yaml:"type,omitempty"` // model or seed
+	Table        string   `json:"table,omitempty" yaml:"table,omitempty"`
+	File         string   `json:"file,omitempty" yaml:"file,omitempty"`
+	Mode         string   `json:"mode,omitempty" yaml:"mode,omitempty"`                 // models only
+	Dependencies []string `json:"dependencies,omitempty" yaml:"dependencies,omitempty"` // models only
+	SQL          string   `json:"sql,omitempty" yaml:"sql,omitempty"`                   // models only
+	Tests        []any    `json:"tests,omitempty" yaml:"tests,omitempty"`               // models only
+}
+
+// ModelNames returns the names of the compiled nodes that are models, in order.
+func (c *BuildConfig) ModelNames() (names []string) {
+	if c == nil {
+		return
+	}
+	for _, node := range c.Nodes {
+		if node.Type == NodeTypeModel {
+			names = append(names, node.Name)
+		}
+	}
+	return
 }
 
 // DevConfig holds dev-mode settings in sling_build.yml.
@@ -1436,6 +1467,17 @@ func effectiveDefaults(project *BuildProject, relPath string) BuildDefaults {
 		return BuildDefaults{}
 	}
 	return cfg.Defaults
+}
+
+// GetConfig returns the project root config, creating it when absent.
+func (p *BuildProject) GetConfig() *BuildConfig {
+	if p == nil {
+		return &BuildConfig{}
+	}
+	if p.Config == nil {
+		p.Config = &BuildConfig{}
+	}
+	return p.Config
 }
 
 // GetEffectiveConfig returns the merged config for the project, applying child overrides.

--- a/core/sling/build/project.go
+++ b/core/sling/build/project.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -165,7 +166,7 @@ func validateModel(m *Model) error {
 
 	// range.* features require owning the WHERE clause (sling style)
 	if (r.Advance != "" || r.Lookback != "") && m.Style == StyleDbt {
-		return g.Error("model '%s': range.* requires {incremental_where_cond} (sling style); is_incremental() is not compatible with range.*", m.Name)
+		return g.Error("model '%s': range.* requires incremental_where_cond() (sling style); is_incremental() is not compatible with range.*", m.Name)
 	}
 
 	return nil
@@ -241,14 +242,31 @@ type BuildOptions struct {
 // DefaultThreads is the default parallelism for model execution.
 const DefaultThreads = 4
 
-// ValidModes are the recognized materialization modes.
+// ValidModes are the recognized materialization modes, post-normalization.
+// Aliases (table, snapshot) are resolved by normalizeMode before this is checked.
 var ValidModes = map[string]bool{
 	"full-refresh": true,
 	"view":         true,
 	"truncate":     true,
 	"incremental":  true,
 	"append":       true,
-	"snapshot":     true, // deprecated alias for append
+}
+
+// validModeNames returns the valid modes sorted, for error messages.
+func validModeNames() string {
+	names := lo.Keys(ValidModes)
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+// validateMode rejects an unrecognized canonical mode. It expects a mode that
+// has already been through normalizeMode, and ignores the empty string since
+// that falls back to the project default.
+func validateMode(mode, modelName string) error {
+	if mode == "" || ValidModes[mode] {
+		return nil
+	}
+	return g.Error("model '%s': unknown mode '%s'; expected one of: %s", modelName, mode, validModeNames())
 }
 
 // normalizeMode maps aliases and deprecated names to canonical modes.
@@ -310,13 +328,57 @@ func applyModeAliases(cfg *ModelConfig, modelName string) error {
 		if canonical == "ephemeral" {
 			return g.Error("model '%s': ephemeral models are not supported; use view or table", modelName)
 		}
+		if err := validateMode(canonical, modelName); err != nil {
+			return err
+		}
 		cfg.Mode = canonical
 	}
 	return nil
 }
 
-// ConfigFileName is the standard config file name.
+// ConfigFileName is the canonical config file name.
 const ConfigFileName = "sling_build.yml"
+
+// ConfigFileNameYAML is the alternate config file name.
+const ConfigFileNameYAML = "sling_build.yaml"
+
+// IsConfigFileName reports whether name is sling_build.yml or sling_build.yaml.
+func IsConfigFileName(name string) bool {
+	n := strings.ToLower(name)
+	return n == ConfigFileName || n == ConfigFileNameYAML
+}
+
+// FindConfigFile returns the path of sling_build.yml or sling_build.yaml in dir.
+// Prefer .yml when both exist. Match is case-insensitive on the file name.
+func FindConfigFile(dir string) (string, bool) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		for _, name := range []string{ConfigFileName, ConfigFileNameYAML} {
+			p := filepath.Join(dir, name)
+			if _, statErr := os.Stat(p); statErr == nil {
+				return p, true
+			}
+		}
+		return "", false
+	}
+	var yamlPath string
+	for _, e := range entries {
+		if e.IsDir() || !IsConfigFileName(e.Name()) {
+			continue
+		}
+		p := filepath.Join(dir, e.Name())
+		if strings.EqualFold(e.Name(), ConfigFileName) {
+			return p, true
+		}
+		if yamlPath == "" {
+			yamlPath = p
+		}
+	}
+	if yamlPath != "" {
+		return yamlPath, true
+	}
+	return "", false
+}
 
 // seedExtensions are recognized seed file extensions.
 var seedExtensions = map[string]string{
@@ -355,8 +417,7 @@ func LoadProject(dir string, opts ...BuildOptions) (*BuildProject, error) {
 	}
 
 	// Load root config if present
-	rootConfigPath := filepath.Join(absDir, ConfigFileName)
-	if _, err := os.Stat(rootConfigPath); err == nil {
+	if rootConfigPath, ok := FindConfigFile(absDir); ok {
 		cfg, err := loadConfig(rootConfigPath)
 		if err != nil {
 			return nil, g.Error(err, "could not load %s", rootConfigPath)
@@ -405,6 +466,20 @@ func loadConfig(path string) (*BuildConfig, error) {
 	cfg := &BuildConfig{}
 	if err := yaml.Unmarshal(data, cfg); err != nil {
 		return nil, g.Error(err, "could not parse config file")
+	}
+
+	if cfg.Defaults.Mode != "" {
+		canonical, warn := normalizeMode(cfg.Defaults.Mode)
+		if warn != "" {
+			g.Warn("%s: defaults.mode: %s", path, warn)
+		}
+		if canonical == "ephemeral" {
+			return nil, g.Error("%s: defaults.mode: ephemeral models are not supported; use view or table", path)
+		}
+		if !ValidModes[canonical] {
+			return nil, g.Error("%s: unknown defaults.mode '%s'; expected one of: %s", path, cfg.Defaults.Mode, validModeNames())
+		}
+		cfg.Defaults.Mode = canonical
 	}
 
 	return cfg, nil
@@ -517,9 +592,7 @@ func discoverNestedConfigs(project *BuildProject) error {
 		}
 
 		childDir := filepath.Join(project.Dir, entry.Name())
-		childConfigPath := filepath.Join(childDir, ConfigFileName)
-
-		if _, err := os.Stat(childConfigPath); err == nil {
+		if childConfigPath, ok := FindConfigFile(childDir); ok {
 			cfg, err := loadConfig(childConfigPath)
 			if err != nil {
 				return g.Error(err, "could not load %s", childConfigPath)
@@ -669,7 +742,7 @@ func skipNestedBuildDir(project *BuildProject, dir string) bool {
 	if project == nil || dir == "" || dir == project.Dir {
 		return false
 	}
-	if _, err := os.Stat(filepath.Join(dir, ConfigFileName)); err != nil {
+	if _, ok := FindConfigFile(dir); !ok {
 		return false
 	}
 	if !project.Recursive {
@@ -709,7 +782,7 @@ func walkFlat(project *BuildProject) error {
 		}
 
 		// Skip config files
-		if info.Name() == ConfigFileName {
+		if IsConfigFileName(info.Name()) {
 			return nil
 		}
 
@@ -757,7 +830,7 @@ func walkForModels(project *BuildProject, walkRoot, baseDir string) error {
 			}
 			return nil
 		}
-		if strings.HasPrefix(info.Name(), ".") || info.Name() == ConfigFileName {
+		if strings.HasPrefix(info.Name(), ".") || IsConfigFileName(info.Name()) {
 			return nil
 		}
 
@@ -802,7 +875,7 @@ func walkForSeeds(project *BuildProject, walkRoot, baseDir string) error {
 			}
 			return nil
 		}
-		if strings.HasPrefix(info.Name(), ".") || info.Name() == ConfigFileName {
+		if strings.HasPrefix(info.Name(), ".") || IsConfigFileName(info.Name()) {
 			return nil
 		}
 
@@ -1276,7 +1349,7 @@ func (p *BuildProject) BuildProdNameIndex() map[string]prodNameEntry {
 // LoadSeed loads a seed file into the target database using the existing
 // sling task infrastructure. This gets CSV/JSON/Parquet parsing, type inference,
 // bulk loading, and all 30+ connectors for free. Seeds always use full-refresh.
-func LoadSeed(seed *Seed, connName string, fullRefresh bool) error {
+func LoadSeed(seed *Seed, connName string, fullRefresh bool) (rows, bytes uint64, err error) {
 	_ = fullRefresh // seeds always full-refresh; kept for call-site clarity
 
 	// Build source connection using file:// prefix for the directory
@@ -1298,14 +1371,15 @@ func LoadSeed(seed *Seed, connName string, fullRefresh bool) error {
 
 	task := sling.NewTask("", cfg)
 	if task.Err != nil {
-		return g.Error(task.Err, "could not create task for seed '%s'", seed.Name)
+		return 0, 0, g.Error(task.Err, "could not create task for seed '%s'", seed.Name)
 	}
 
 	if err := task.Execute(); err != nil {
-		return g.Error(err, "could not load seed '%s' into %s", seed.Name, seed.FullTableName)
+		return 0, 0, g.Error(err, "could not load seed '%s' into %s", seed.Name, seed.FullTableName)
 	}
 
-	return nil
+	inBytes, _ := task.GetBytes()
+	return task.GetCount(), inBytes, nil
 }
 
 // MakeSeedConfig creates a sling.Config for loading a seed file

--- a/core/sling/build/project_test.go
+++ b/core/sling/build/project_test.go
@@ -305,6 +305,36 @@ func TestLoadProjectWithProdOverride(t *testing.T) {
 	assert.Equal(t, "prod", project.Mode)
 }
 
+func TestFindConfigFile(t *testing.T) {
+	dir := t.TempDir()
+	_, ok := FindConfigFile(dir)
+	assert.False(t, ok)
+
+	ymlPath := filepath.Join(dir, "sling_build.yml")
+	require.NoError(t, os.WriteFile(ymlPath, []byte("target: POSTGRES\n"), 0644))
+	found, ok := FindConfigFile(dir)
+	require.True(t, ok)
+	assert.Equal(t, ymlPath, found)
+
+	yamlPath := filepath.Join(dir, "sling_build.yaml")
+	require.NoError(t, os.WriteFile(yamlPath, []byte("target: DUCKDB\n"), 0644))
+	found, ok = FindConfigFile(dir)
+	require.True(t, ok)
+	assert.Equal(t, ymlPath, found, "prefer .yml when both exist")
+}
+
+func TestLoadProjectYAMLConfig(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sling_build.yaml"), []byte("target: DUCKDB\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "stg_ok.sql"), []byte("select 1 as id\n"), 0644))
+
+	project, err := LoadProject(dir)
+	require.NoError(t, err)
+	require.NotNil(t, project.Config)
+	assert.Equal(t, "DUCKDB", project.Config.Target)
+	require.NotNil(t, project.Models["stg_ok"])
+}
+
 func TestNestedProjectIsolation(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "sling_build.yml"), []byte("target: POSTGRES\n"), 0644))
@@ -1030,6 +1060,49 @@ func TestFrontmatterSnapshotRenamedToAppend(t *testing.T) {
 	assert.Equal(t, "append", m.Config.Mode)
 }
 
+func TestFrontmatterUnknownModeRejected(t *testing.T) {
+	_, err := addModelFromFrontmatter(t,
+		"mode: incremenal",
+		"SELECT 1 as id")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown mode 'incremenal'")
+	assert.Contains(t, err.Error(), "full-refresh")
+}
+
+func TestFrontmatterValidModesAccepted(t *testing.T) {
+	for mode := range ValidModes {
+		frontmatter := "mode: " + mode
+		if mode == "incremental" {
+			frontmatter += "\nunique_key: id\nupdate_key: updated_at"
+		}
+		m, err := addModelFromFrontmatter(t, frontmatter, "SELECT 1 as id, 2 as updated_at")
+		require.NoError(t, err, "mode %s should be accepted", mode)
+		assert.Equal(t, mode, m.Config.Mode)
+	}
+}
+
+func TestLoadConfigUnknownDefaultsModeRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ConfigFileName)
+	require.NoError(t, os.WriteFile(path,
+		[]byte("target: MY_PG\ndefaults:\n  mode: bogus\n"), 0644))
+
+	_, err := loadConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown defaults.mode 'bogus'")
+}
+
+func TestLoadConfigDefaultsModeAliasNormalized(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ConfigFileName)
+	require.NoError(t, os.WriteFile(path,
+		[]byte("target: MY_PG\ndefaults:\n  mode: table\n"), 0644))
+
+	cfg, err := loadConfig(path)
+	require.NoError(t, err)
+	assert.Equal(t, "full-refresh", cfg.Defaults.Mode)
+}
+
 func TestFrontmatterDataTests(t *testing.T) {
 	m, err := addModelFromFrontmatter(t,
 		"mode: full-refresh\ntests:\n  - not_null: [id]\n  - unique: id\n  - expr: sum(id) > 0",
@@ -1059,7 +1132,7 @@ func TestFrontmatterDropCascade(t *testing.T) {
 func TestRangeConfig_Valid_AbsentMeansPlainIncremental(t *testing.T) {
 	m, err := addModelFromFrontmatter(t,
 		"mode: incremental\nunique_key: id\nupdate_key: updated_at",
-		"SELECT id, updated_at FROM raw WHERE {incremental_where_cond}")
+		"SELECT id, updated_at FROM raw WHERE {{ incremental_where_cond() }}")
 	require.NoError(t, err)
 	require.NotNil(t, m)
 	assert.Nil(t, m.Config.Range)
@@ -1069,7 +1142,7 @@ func TestRangeConfig_Valid_AbsentMeansPlainIncremental(t *testing.T) {
 func TestRangeConfig_Valid_AdvanceOnly(t *testing.T) {
 	m, err := addModelFromFrontmatter(t,
 		"mode: incremental\nunique_key: id\nupdate_key: updated_at\nrange:\n  advance: 7d",
-		"SELECT id, updated_at FROM raw WHERE {incremental_where_cond}")
+		"SELECT id, updated_at FROM raw WHERE {{ incremental_where_cond() }}")
 	require.NoError(t, err)
 	require.NotNil(t, m.Config.Range)
 	assert.Equal(t, "7d", m.Config.Range.Advance)
@@ -1080,7 +1153,7 @@ func TestRangeConfig_Valid_AdvanceOnly(t *testing.T) {
 func TestRangeConfig_Valid_StartAndAdvance(t *testing.T) {
 	m, err := addModelFromFrontmatter(t,
 		"mode: incremental\nunique_key: id\nupdate_key: updated_at\nrange:\n  start: '2020-01-01'\n  advance: 1mo",
-		"SELECT id, updated_at FROM raw WHERE {incremental_where_cond}")
+		"SELECT id, updated_at FROM raw WHERE {{ incremental_where_cond() }}")
 	require.NoError(t, err)
 	require.NotNil(t, m.Config.Range)
 	assert.Equal(t, "2020-01-01", m.Config.Range.Start)
@@ -1090,7 +1163,7 @@ func TestRangeConfig_Valid_StartAndAdvance(t *testing.T) {
 func TestRangeConfig_Valid_AdvanceAndLookback(t *testing.T) {
 	m, err := addModelFromFrontmatter(t,
 		"mode: incremental\nunique_key: id\nupdate_key: updated_at\nrange:\n  advance: 7d\n  lookback: 2d",
-		"SELECT id, updated_at FROM raw WHERE {incremental_where_cond}")
+		"SELECT id, updated_at FROM raw WHERE {{ incremental_where_cond() }}")
 	require.NoError(t, err)
 	require.NotNil(t, m.Config.Range)
 	assert.Equal(t, "7d", m.Config.Range.Advance)
@@ -1101,7 +1174,7 @@ func TestRangeConfig_Valid_AdvanceAndLookback(t *testing.T) {
 func TestRangeConfig_Valid_LookbackOnly(t *testing.T) {
 	m, err := addModelFromFrontmatter(t,
 		"mode: incremental\nunique_key: id\nupdate_key: updated_at\nrange:\n  lookback: 3h",
-		"SELECT id, updated_at FROM raw WHERE {incremental_where_cond}")
+		"SELECT id, updated_at FROM raw WHERE {{ incremental_where_cond() }}")
 	require.NoError(t, err)
 	require.NotNil(t, m.Config.Range)
 	assert.Equal(t, "", m.Config.Range.Advance)
@@ -1111,7 +1184,7 @@ func TestRangeConfig_Valid_LookbackOnly(t *testing.T) {
 func TestRangeConfig_Invalid_StartWithoutAdvance(t *testing.T) {
 	_, err := addModelFromFrontmatter(t,
 		"mode: incremental\nunique_key: id\nupdate_key: updated_at\nrange:\n  start: '2020-01-01'",
-		"SELECT id, updated_at FROM raw WHERE {incremental_where_cond}")
+		"SELECT id, updated_at FROM raw WHERE {{ incremental_where_cond() }}")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "range.start requires range.advance")
 }
@@ -1119,7 +1192,7 @@ func TestRangeConfig_Invalid_StartWithoutAdvance(t *testing.T) {
 func TestRangeConfig_Invalid_AdvanceWithoutUpdateKey(t *testing.T) {
 	_, err := addModelFromFrontmatter(t,
 		"mode: incremental\nunique_key: id\nrange:\n  advance: 7d",
-		"SELECT id FROM raw WHERE {incremental_where_cond}")
+		"SELECT id FROM raw WHERE {{ incremental_where_cond() }}")
 	require.Error(t, err)
 	// incremental mode without update_key fires first
 	assert.Contains(t, err.Error(), "update_key")
@@ -1136,7 +1209,7 @@ func TestRangeConfig_Invalid_RangeWithoutIncrementalMode(t *testing.T) {
 func TestRangeConfig_Invalid_BadAdvanceDuration(t *testing.T) {
 	_, err := addModelFromFrontmatter(t,
 		"mode: incremental\nunique_key: id\nupdate_key: updated_at\nrange:\n  advance: seven_days",
-		"SELECT id, updated_at FROM raw WHERE {incremental_where_cond}")
+		"SELECT id, updated_at FROM raw WHERE {{ incremental_where_cond() }}")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid range.advance")
 }
@@ -1144,7 +1217,7 @@ func TestRangeConfig_Invalid_BadAdvanceDuration(t *testing.T) {
 func TestRangeConfig_Invalid_BadLookbackDuration(t *testing.T) {
 	_, err := addModelFromFrontmatter(t,
 		"mode: incremental\nunique_key: id\nupdate_key: updated_at\nrange:\n  lookback: later",
-		"SELECT id, updated_at FROM raw WHERE {incremental_where_cond}")
+		"SELECT id, updated_at FROM raw WHERE {{ incremental_where_cond() }}")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid range.lookback")
 }
@@ -1189,17 +1262,17 @@ func TestValidateModel_RangeWithDbtStyleErrors(t *testing.T) {
 		`SELECT id, updated_at FROM raw
 {% if is_incremental() %}WHERE updated_at > (SELECT MAX(updated_at) FROM {{ this }}){% endif %}`)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "range.* requires {incremental_where_cond}")
+	assert.Contains(t, err.Error(), "range.* requires incremental_where_cond()")
 }
 
 func TestValidateModel_MixedStyleErrors(t *testing.T) {
-	// A model containing both is_incremental() AND {incremental_where_cond} errors.
+	// A model containing both is_incremental() AND {{ incremental_where_cond() }} errors.
 	_, err := addModelFromFrontmatter(t,
 		"mode: incremental\nunique_key: id\nupdate_key: updated_at",
-		`SELECT id, updated_at FROM raw WHERE {incremental_where_cond}
+		`SELECT id, updated_at FROM raw WHERE {{ incremental_where_cond() }}
 {% if is_incremental() %}AND updated_at > (SELECT MAX(updated_at) FROM {{ this }}){% endif %}`)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot mix is_incremental() and {incremental_where_cond}")
+	assert.Contains(t, err.Error(), "cannot mix is_incremental() and incremental_where_cond()")
 }
 
 // =============================================================================
@@ -1502,7 +1575,7 @@ defaults:
 `,
 		nil,
 		map[string]string{
-			"staging/orders.sql": "SELECT id, updated_at FROM raw WHERE {incremental_where_cond}",
+			"staging/orders.sql": "SELECT id, updated_at FROM raw WHERE {{ incremental_where_cond() }}",
 		},
 		nil,
 	)

--- a/core/sling/build/project_test.go
+++ b/core/sling/build/project_test.go
@@ -32,7 +32,7 @@ func getTestFixturePath(name string) string {
 	return filepath.Join(dir, "tests/build", name)
 }
 
-func TestResolveTableName(t *testing.T) {
+func TestIdentityFromPath(t *testing.T) {
 	tests := []struct {
 		name           string
 		relPath        string
@@ -40,7 +40,6 @@ func TestResolveTableName(t *testing.T) {
 		schemaOverride string
 		defaultSchema  string
 		wantSchema     string
-		wantPrefix     string
 		wantName       string
 		wantFull       string
 	}{
@@ -50,19 +49,17 @@ func TestResolveTableName(t *testing.T) {
 			mode:          "prod",
 			defaultSchema: "public",
 			wantSchema:    "staging",
-			wantPrefix:    "",
 			wantName:      "stg_orders",
 			wantFull:      "staging.stg_orders",
 		},
 		{
-			name:          "prod mode - nested folder becomes prefix",
+			name:          "prod mode - nested folder does not change the name",
 			relPath:       "marts/core/dim_customers.sql",
 			mode:          "prod",
 			defaultSchema: "public",
 			wantSchema:    "marts",
-			wantPrefix:    "core",
 			wantName:      "dim_customers",
-			wantFull:      "marts.core_dim_customers",
+			wantFull:      "marts.dim_customers",
 		},
 		{
 			name:          "prod mode - deeply nested folders",
@@ -70,9 +67,8 @@ func TestResolveTableName(t *testing.T) {
 			mode:          "prod",
 			defaultSchema: "public",
 			wantSchema:    "marts",
-			wantPrefix:    "core_finance",
 			wantName:      "revenue",
-			wantFull:      "marts.core_finance_revenue",
+			wantFull:      "marts.revenue",
 		},
 		{
 			name:          "prod mode - root level file uses default schema",
@@ -80,31 +76,28 @@ func TestResolveTableName(t *testing.T) {
 			mode:          "prod",
 			defaultSchema: "public",
 			wantSchema:    "public",
-			wantPrefix:    "",
 			wantName:      "raw",
 			wantFull:      "public.raw",
 		},
 		{
-			name:           "dev mode - all folders become prefix",
+			name:           "dev mode - one folder",
 			relPath:        "staging/stg_orders.sql",
 			mode:           "dev",
 			schemaOverride: "dev_fritz",
 			defaultSchema:  "public",
 			wantSchema:     "dev_fritz",
-			wantPrefix:     "staging",
 			wantName:       "stg_orders",
-			wantFull:       "dev_fritz.staging_stg_orders",
+			wantFull:       "dev_fritz.stg_orders",
 		},
 		{
-			name:           "dev mode - nested folders all become prefix",
+			name:           "dev mode - nested folders",
 			relPath:        "marts/core/dim_customers.sql",
 			mode:           "dev",
 			schemaOverride: "dev_fritz",
 			defaultSchema:  "public",
 			wantSchema:     "dev_fritz",
-			wantPrefix:     "marts_core",
 			wantName:       "dim_customers",
-			wantFull:       "dev_fritz.marts_core_dim_customers",
+			wantFull:       "dev_fritz.dim_customers",
 		},
 		{
 			name:           "dev mode - root level file",
@@ -113,7 +106,6 @@ func TestResolveTableName(t *testing.T) {
 			schemaOverride: "dev_fritz",
 			defaultSchema:  "public",
 			wantSchema:     "dev_fritz",
-			wantPrefix:     "",
 			wantName:       "raw",
 			wantFull:       "dev_fritz.raw",
 		},
@@ -123,7 +115,6 @@ func TestResolveTableName(t *testing.T) {
 			mode:          "prod",
 			defaultSchema: "public",
 			wantSchema:    "staging",
-			wantPrefix:    "",
 			wantName:      "country_codes",
 			wantFull:      "staging.country_codes",
 		},
@@ -133,7 +124,6 @@ func TestResolveTableName(t *testing.T) {
 			mode:          "prod",
 			defaultSchema: "public",
 			wantSchema:    "seeds",
-			wantPrefix:    "",
 			wantName:      "status_map",
 			wantFull:      "seeds.status_map",
 		},
@@ -141,13 +131,17 @@ func TestResolveTableName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			schema, prefix, name, fullTableName := resolveTableName(tt.relPath, tt.mode, tt.schemaOverride, tt.defaultSchema)
-			assert.Equal(t, tt.wantSchema, schema, "schema")
-			assert.Equal(t, tt.wantPrefix, prefix, "prefix")
-			assert.Equal(t, tt.wantName, name, "name")
-			assert.Equal(t, tt.wantFull, fullTableName, "fullTableName")
+			identity := identityFromPath(tt.relPath, tt.mode, tt.schemaOverride, tt.defaultSchema)
+			assert.Equal(t, tt.wantSchema, identity.Schema, "schema")
+			assert.Equal(t, tt.wantName, identity.Name, "name")
+			assert.Equal(t, tt.wantFull, identity.FullName(), "fullTableName")
 		})
 	}
+}
+
+func TestTableIdentityFullNameThreePart(t *testing.T) {
+	identity := TableIdentity{Name: "dim_customers", Schema: "marts", Database: "ANALYTICS_DB"}
+	assert.Equal(t, "ANALYTICS_DB.marts.dim_customers", identity.FullName())
 }
 
 func TestDiscoverFilesFlatMode(t *testing.T) {
@@ -183,23 +177,20 @@ func TestDiscoverFilesFlatMode(t *testing.T) {
 	// Check specific model properties
 	stgOrders := project.Models["stg_orders"]
 	assert.Equal(t, "staging", stgOrders.Schema)
-	assert.Equal(t, "", stgOrders.Prefix)
 	assert.Equal(t, "staging.stg_orders", stgOrders.FullTableName)
 	assert.NotEmpty(t, stgOrders.RawSQL)
 
 	dimCustomers := project.Models["dim_customers"]
 	assert.Equal(t, "marts", dimCustomers.Schema)
-	assert.Equal(t, "core", dimCustomers.Prefix)
-	assert.Equal(t, "marts.core_dim_customers", dimCustomers.FullTableName)
+	assert.Equal(t, "dim_customers", dimCustomers.Name)
+	assert.Equal(t, "marts.dim_customers", dimCustomers.FullTableName)
 
 	revenue := project.Models["revenue"]
 	assert.Equal(t, "marts", revenue.Schema)
-	assert.Equal(t, "finance", revenue.Prefix)
-	assert.Equal(t, "marts.finance_revenue", revenue.FullTableName)
+	assert.Equal(t, "marts.revenue", revenue.FullTableName)
 
 	raw := project.Models["raw"]
 	assert.Equal(t, "public", raw.Schema)
-	assert.Equal(t, "", raw.Prefix)
 	assert.Equal(t, "public.raw", raw.FullTableName)
 
 	// Check seed properties
@@ -303,6 +294,283 @@ func TestLoadProjectWithProdOverride(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "prod", project.Mode)
+}
+
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+	t.Setenv(key, "")
+	os.Unsetenv(key)
+}
+
+func TestExpandConfigVars(t *testing.T) {
+	t.Run("set", func(t *testing.T) {
+		t.Setenv("USER", "alice")
+		out, unresolved := expandConfigVars("dev_${USER}")
+		assert.Equal(t, "dev_alice", out)
+		assert.Empty(t, unresolved)
+	})
+	t.Run("unset", func(t *testing.T) {
+		unsetEnv(t, "MISSING_VAR")
+		out, unresolved := expandConfigVars("dev_${MISSING_VAR}")
+		assert.Equal(t, "dev_${MISSING_VAR}", out)
+		assert.Equal(t, []string{"MISSING_VAR"}, unresolved)
+	})
+	t.Run("empty with fallback", func(t *testing.T) {
+		t.Setenv("USER", "")
+		out, unresolved := expandConfigVars("dev_${USER:-scratch}")
+		assert.Equal(t, "dev_scratch", out)
+		assert.Empty(t, unresolved)
+	})
+	t.Run("empty without fallback", func(t *testing.T) {
+		t.Setenv("USER", "")
+		out, unresolved := expandConfigVars("dev_${USER}")
+		assert.Equal(t, "dev_${USER}", out)
+		assert.Equal(t, []string{"USER"}, unresolved)
+	})
+	t.Run("bare $VAR untouched", func(t *testing.T) {
+		t.Setenv("USER", "alice")
+		out, unresolved := expandConfigVars("dev_$USER")
+		assert.Equal(t, "dev_$USER", out)
+		assert.Empty(t, unresolved)
+	})
+	t.Run("${A} inside a longer word", func(t *testing.T) {
+		t.Setenv("A", "xx")
+		out, unresolved := expandConfigVars("foo${A}bar")
+		assert.Equal(t, "fooxxbar", out)
+		assert.Empty(t, unresolved)
+	})
+	t.Run("$USERNAME not prefix-expanded", func(t *testing.T) {
+		t.Setenv("USER", "fritz")
+		out, _ := expandConfigVars("$USERNAME")
+		assert.Equal(t, "$USERNAME", out)
+	})
+	t.Run("unset with fallback", func(t *testing.T) {
+		unsetEnv(t, "USER")
+		out, unresolved := expandConfigVars("dev_${USER:-scratch}")
+		assert.Equal(t, "dev_scratch", out)
+		assert.Empty(t, unresolved)
+	})
+}
+
+func writeDevVarProject(t *testing.T, yml string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sling_build.yml"), []byte(yml), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "staging"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "staging", "stg_orders.sql"), []byte("select 1 as id\n"), 0644))
+	return dir
+}
+
+func TestLoadProjectDevSchemaFromEnv(t *testing.T) {
+	t.Setenv("USER", "alice")
+	dir := writeDevVarProject(t, "target: POSTGRES\ndev:\n  schema: dev_${USER}\n")
+
+	project, err := LoadProject(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "dev", project.Mode)
+	m := project.Models["stg_orders"]
+	require.NotNil(t, m)
+	assert.Equal(t, "dev_alice.stg_orders", m.FullTableName)
+}
+
+func TestLoadProjectDevSchemaUnresolvedErrors(t *testing.T) {
+	unsetEnv(t, "USER")
+	dir := writeDevVarProject(t, "target: POSTGRES\ndev:\n  schema: dev_${USER}\n")
+
+	_, err := LoadProject(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "USER")
+	assert.Contains(t, err.Error(), "dev.schema")
+}
+
+func TestLoadProjectDevSchemaUnresolvedProdOK(t *testing.T) {
+	unsetEnv(t, "USER")
+	dir := writeDevVarProject(t, "target: POSTGRES\ndev:\n  schema: dev_${USER}\n")
+
+	project, err := LoadProject(dir, BuildOptions{Prod: true})
+	require.NoError(t, err)
+	assert.Equal(t, "prod", project.Mode)
+	m := project.Models["stg_orders"]
+	require.NotNil(t, m)
+	assert.Equal(t, "staging.stg_orders", m.FullTableName)
+}
+
+func TestLoadProjectDevSchemaUnresolvedSchemaFlagOK(t *testing.T) {
+	unsetEnv(t, "USER")
+	dir := writeDevVarProject(t, "target: POSTGRES\ndev:\n  schema: dev_${USER}\n")
+
+	project, err := LoadProject(dir, BuildOptions{Schema: "dev_x"})
+	require.NoError(t, err)
+	assert.Equal(t, "dev", project.Mode)
+	m := project.Models["stg_orders"]
+	require.NotNil(t, m)
+	assert.Equal(t, "dev_x.stg_orders", m.FullTableName)
+}
+
+func TestLoadProjectVarsUnresolvedErrors(t *testing.T) {
+	unsetEnv(t, "MISSING")
+	yml := "target: POSTGRES\nvars:\n  d: ${MISSING}\n"
+	dir := writeDevVarProject(t, yml)
+
+	_, err := LoadProject(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MISSING")
+	assert.Contains(t, err.Error(), "vars.d")
+
+	_, err = LoadProject(dir, BuildOptions{Prod: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MISSING")
+}
+
+func TestLoadProjectDuplicateStemsError(t *testing.T) {
+	dir := getTestFixturePath("duplicate_stems_project")
+
+	_, err := LoadProject(dir, BuildOptions{Prod: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate model name 'events'")
+	assert.Contains(t, err.Error(), filepath.Join("a", "events.sql"))
+	assert.Contains(t, err.Error(), filepath.Join("b", "events.sql"))
+}
+
+func TestResolveNameStemAndSchemaTable(t *testing.T) {
+	project := loadMartsEventsProject(t, BuildOptions{Prod: true})
+
+	ref, err := project.ResolveName("events")
+	require.NoError(t, err)
+	assert.Equal(t, "events", ref.Name)
+	assert.Equal(t, "analytics.events", ref.FullTableName)
+
+	ref, err = project.ResolveName("analytics.events")
+	require.NoError(t, err)
+	assert.Equal(t, "events", ref.Name)
+
+	// dev mode: the stem and the prod schema.table spelling both resolve
+	dev := loadMartsEventsProject(t, BuildOptions{Schema: "dev_x"})
+	ref, err = dev.ResolveName("events")
+	require.NoError(t, err)
+	assert.Equal(t, "dev_x.events", ref.FullTableName)
+
+	ref, err = dev.ResolveName("analytics.events")
+	require.NoError(t, err)
+	assert.Equal(t, "dev_x.events", ref.FullTableName)
+}
+
+func TestResolveNameBareUnique(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sling_build.yml"), []byte("target: POSTGRES\n"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "staging"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "staging/stg_events.sql"), []byte("select 1 as id\n"), 0644))
+	project, err := LoadProject(dir, BuildOptions{Prod: true})
+	require.NoError(t, err)
+
+	ref, err := project.ResolveName("stg_events")
+	require.NoError(t, err)
+	assert.Equal(t, "stg_events", ref.Name)
+
+	ref, err = project.ResolveName("events")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Did you mean")
+	assert.Contains(t, err.Error(), "stg_events")
+}
+
+func TestResolveNameNotFoundSuggests(t *testing.T) {
+	project := loadNestedEventsProject(t)
+
+	_, err := project.ResolveName("plausible_event")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+	assert.Contains(t, err.Error(), "Did you mean")
+	assert.Contains(t, err.Error(), "plausible_events")
+
+	// old prefixed names are gone: not found, no suggestion for them
+	_, err = project.ResolveName("dim_customers")
+	require.Error(t, err)
+	var notFound *NameNotFoundError
+	require.ErrorAs(t, err, &notFound)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestDefaultsDatabase(t *testing.T) {
+	project := loadDatabaseProject(t, BuildOptions{Prod: true})
+
+	m := project.Models["dim_customers"]
+	require.NotNil(t, m)
+	assert.Equal(t, "ANALYTICS_DB", m.Database)
+	assert.Equal(t, "ANALYTICS_DB.marts.dim_customers", m.FullTableName)
+	assert.Equal(t, "ANALYTICS_DB.marts.dim_customers", m.ProdFullTableName)
+}
+
+func TestFrontmatterDatabase(t *testing.T) {
+	project := loadDatabaseProject(t, BuildOptions{Prod: true})
+
+	m := project.Models["revenue"]
+	require.NotNil(t, m)
+	assert.Equal(t, "FIN_DB", m.Database)
+	assert.Equal(t, "FIN_DB.marts.revenue", m.FullTableName)
+	assert.Equal(t, "FIN_DB.marts.revenue", m.ProdFullTableName)
+}
+
+func TestDevDatabase(t *testing.T) {
+	project := loadDatabaseProject(t)
+	require.Equal(t, "dev", project.Mode)
+
+	// dev.database applies where no explicit database is set
+	assert.Equal(t, "SCRATCH_DB.dev_test.dim_customers", project.Models["dim_customers"].FullTableName)
+	assert.Equal(t, "ANALYTICS_DB.marts.dim_customers", project.Models["dim_customers"].ProdFullTableName)
+
+	// front-matter database wins in both modes
+	assert.Equal(t, "FIN_DB.dev_test.revenue", project.Models["revenue"].FullTableName)
+}
+
+func TestMergeConfigsDatabase(t *testing.T) {
+	parent := &BuildConfig{Defaults: BuildDefaults{Database: "PARENT_DB", Schema: "parent"}}
+	child := &BuildConfig{Defaults: BuildDefaults{Database: "CHILD_DB"}}
+
+	merged := mergeConfigs(parent, child)
+	assert.Equal(t, "CHILD_DB", merged.Defaults.Database)
+	assert.Equal(t, "parent", merged.Defaults.Schema)
+
+	merged = mergeConfigs(parent, &BuildConfig{})
+	assert.Equal(t, "PARENT_DB", merged.Defaults.Database)
+}
+
+func TestConfigCallDatabase(t *testing.T) {
+	project := loadDatabaseProject(t, BuildOptions{Prod: true})
+	te := NewTemplateEngine(project, nil)
+
+	model := &Model{Name: "cfg", Schema: "marts", RawSQL: "{%- config(database='OTHER_DB') -%}\nselect 1 as id"}
+	_, err := te.CompileModel(model, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "OTHER_DB", model.Config.Database)
+}
+
+func loadDatabaseProject(t *testing.T, opts ...BuildOptions) *BuildProject {
+	t.Helper()
+	project, err := LoadProject(getTestFixturePath("database_project"), opts...)
+	require.NoError(t, err)
+	return project
+}
+
+func loadMartsEventsProject(t *testing.T, opts BuildOptions) *BuildProject {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sling_build.yml"), []byte("target: POSTGRES\n"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "analytics/plausible"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "analytics/plausible/events.sql"), []byte("select 1 as id\n"), 0644))
+	project, err := LoadProject(dir, opts)
+	require.NoError(t, err)
+	return project
+}
+
+func loadNestedEventsProject(t *testing.T) *BuildProject {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sling_build.yml"), []byte("target: POSTGRES\n"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "analytics/plausible"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "analytics/plausible_events.sql"), []byte("select 1 as id\n"), 0644))
+	project, err := LoadProject(dir, BuildOptions{Prod: true})
+	require.NoError(t, err)
+	return project
 }
 
 func TestFindConfigFile(t *testing.T) {

--- a/core/sling/build/readonly.go
+++ b/core/sling/build/readonly.go
@@ -44,7 +44,11 @@ func ValidateReadOnlyQuery(sql string, dbType dbio.Type) error {
 	for k := range obj {
 		typeKey = k
 	}
-	if !readOnlyASTKeys[typeKey] {
+	if typeKey == "command" {
+		if err := validateCommandReadOnly(sql); err != nil {
+			return err
+		}
+	} else if !readOnlyASTKeys[typeKey] {
 		return readOnlyErrorf("%s statement", typeKey)
 	}
 
@@ -86,6 +90,24 @@ var readOnlyASTKeys = map[string]bool{
 	"values":        true,
 	"show":          true,
 	"describe":      true,
+	"explain":       true,
+}
+
+// validateCommandReadOnly allows SHOW/DESCRIBE/DESC/EXPLAIN when golyglot
+// emits a generic command node. SET/USE/PRAGMA stay denied.
+func validateCommandReadOnly(sql string) error {
+	stripped := strings.TrimSpace(stripSQLCommentsAndLiterals(sql))
+	for strings.HasSuffix(stripped, ";") {
+		stripped = strings.TrimSpace(strings.TrimSuffix(stripped, ";"))
+	}
+	tokens := sqlWordTokens(stripped)
+	if len(tokens) == 0 {
+		return readOnlyErrorf("command statement")
+	}
+	if !readOnlyFirstKeywords[tokens[0]] {
+		return readOnlyErrorf("%s statement", strings.ToLower(tokens[0]))
+	}
+	return nil
 }
 
 var mutatingASTKeys = map[string]bool{

--- a/core/sling/build/readonly_test.go
+++ b/core/sling/build/readonly_test.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/slingdata-io/golyglot"
 	"github.com/slingdata-io/sling-cli/core/dbio"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -148,5 +149,41 @@ func TestValidateReadOnlyQueryParallel(t *testing.T) {
 	close(errCh)
 	for err := range errCh {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateReadOnlyQueryParserLoaded(t *testing.T) {
+	if err := golyglot.Init(); err != nil {
+		t.Skipf("golyglot parser not available: %v", err)
+	}
+	if _, err := golyglot.Parse("show tables", mapDialect(dbio.TypeDbPostgres)); err != nil {
+		t.Skipf("golyglot parse failed: %v", err)
+	}
+
+	allowed := []string{
+		"select 1",
+		"explain select 1",
+		"EXPLAIN ANALYZE SELECT 1",
+		"show tables",
+		"describe foo",
+		"desc foo",
+	}
+	for _, q := range allowed {
+		t.Run("allow/"+q, func(t *testing.T) {
+			assert.NoError(t, ValidateReadOnlyQuery(q, dbio.TypeDbPostgres))
+		})
+	}
+
+	denied := []string{
+		"set search_path to public",
+		"use db",
+		"insert into t values (1)",
+	}
+	for _, q := range denied {
+		t.Run("deny/"+q, func(t *testing.T) {
+			err := ValidateReadOnlyQuery(q, dbio.TypeDbPostgres)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), readOnlyErrPrefix)
+		})
 	}
 }

--- a/core/sling/build/selector.go
+++ b/core/sling/build/selector.go
@@ -387,6 +387,7 @@ func (dag *DAG) computeDepths() {
 type Selector struct {
 	Includes []string
 	Excludes []string
+	Project  *BuildProject
 }
 
 // NewSelector creates a new selector from include and exclude patterns.
@@ -409,7 +410,7 @@ func (s *Selector) Apply(dag *DAG) ([]string, error) {
 	} else {
 		// Apply each include pattern
 		for _, pattern := range s.Includes {
-			matched, err := matchPattern(pattern, dag)
+			matched, err := matchPattern(pattern, dag, s.Project)
 			if err != nil {
 				return nil, err
 			}
@@ -421,7 +422,7 @@ func (s *Selector) Apply(dag *DAG) ([]string, error) {
 
 	// Apply excludes
 	for _, pattern := range s.Excludes {
-		matched, err := matchPattern(pattern, dag)
+		matched, err := matchPattern(pattern, dag, s.Project)
 		if err != nil {
 			return nil, err
 		}
@@ -452,7 +453,7 @@ func (s *Selector) Apply(dag *DAG) ([]string, error) {
 //   - modelA-modelB       slice: all nodes between A and B (inclusive)
 //   - tag:xxx             match by tag
 //   - path/pattern        match by file path
-func matchPattern(pattern string, dag *DAG) ([]string, error) {
+func matchPattern(pattern string, dag *DAG, project *BuildProject) ([]string, error) {
 	// Tag selector: tag:xxx (check early, before + parsing)
 	if strings.HasPrefix(pattern, "tag:") {
 		tag := strings.TrimPrefix(pattern, "tag:")
@@ -461,7 +462,7 @@ func matchPattern(pattern string, dag *DAG) ([]string, error) {
 
 	// Graph traversal selectors (contains "+")
 	if strings.Contains(pattern, "+") {
-		return matchGraphSelector(pattern, dag)
+		return matchGraphSelector(pattern, dag, project)
 	}
 
 	// Slice selector: modelA-modelB (all nodes between A and B inclusive)
@@ -469,10 +470,19 @@ func matchPattern(pattern string, dag *DAG) ([]string, error) {
 	if idx := strings.Index(pattern, "-"); idx > 0 && idx < len(pattern)-1 && !strings.Contains(pattern, "/") {
 		left := pattern[:idx]
 		right := pattern[idx+1:]
-		_, leftOk := dag.Nodes[left]
-		_, rightOk := dag.Nodes[right]
+		leftName, rightName := left, right
+		if project != nil {
+			if lr, err := project.ResolveName(left); err == nil {
+				leftName = lr.Name
+			}
+			if rr, err := project.ResolveName(right); err == nil {
+				rightName = rr.Name
+			}
+		}
+		_, leftOk := dag.Nodes[leftName]
+		_, rightOk := dag.Nodes[rightName]
 		if leftOk && rightOk {
-			return matchSlice(left, right, dag)
+			return matchSlice(leftName, rightName, dag)
 		}
 	}
 
@@ -481,8 +491,10 @@ func matchPattern(pattern string, dag *DAG) ([]string, error) {
 		return matchByPath(pattern, dag)
 	}
 
-	// Glob selector: match against node names
-	return matchByGlob(pattern, dag)
+	if isGlob(pattern) {
+		return matchByGlob(pattern, dag)
+	}
+	return resolveNodes(pattern, dag, project, pattern)
 }
 
 // matchGraphSelector handles all "+" based selectors:
@@ -490,7 +502,7 @@ func matchPattern(pattern string, dag *DAG) ([]string, error) {
 //	+model, model+, +model+, N+model, model+N
 //
 // The model portion can be an exact name or a glob pattern (e.g. stg_*, *_orders).
-func matchGraphSelector(pattern string, dag *DAG) ([]string, error) {
+func matchGraphSelector(pattern string, dag *DAG, project *BuildProject) ([]string, error) {
 	hasPrefix := strings.HasPrefix(pattern, "+")
 	hasSuffix := strings.HasSuffix(pattern, "+")
 
@@ -498,7 +510,7 @@ func matchGraphSelector(pattern string, dag *DAG) ([]string, error) {
 	if hasPrefix || hasSuffix {
 		modelPattern := strings.Trim(pattern, "+")
 
-		nodes, err := resolveNodes(modelPattern, dag, pattern)
+		nodes, err := resolveNodes(modelPattern, dag, project, pattern)
 		if err != nil {
 			return nil, err
 		}
@@ -527,7 +539,7 @@ func matchGraphSelector(pattern string, dag *DAG) ([]string, error) {
 
 	// N+model (degree upstream)
 	if n, err := strconv.Atoi(left); err == nil && n >= 0 {
-		nodes, err := resolveNodes(right, dag, pattern)
+		nodes, err := resolveNodes(right, dag, project, pattern)
 		if err != nil {
 			return nil, err
 		}
@@ -543,7 +555,7 @@ func matchGraphSelector(pattern string, dag *DAG) ([]string, error) {
 
 	// model+N (degree downstream)
 	if n, err := strconv.Atoi(right); err == nil && n >= 0 {
-		nodes, err := resolveNodes(left, dag, pattern)
+		nodes, err := resolveNodes(left, dag, project, pattern)
 		if err != nil {
 			return nil, err
 		}
@@ -604,8 +616,18 @@ func isGlob(s string) bool {
 // resolveNodes resolves a name-or-glob to matching DAG node names.
 // For exact names, returns the single name or errors if not found.
 // For glob patterns, returns all matches (empty slice if none match).
-func resolveNodes(nameOrGlob string, dag *DAG, selectorForError string) ([]string, error) {
+func resolveNodes(nameOrGlob string, dag *DAG, project *BuildProject, selectorForError string) ([]string, error) {
 	if !isGlob(nameOrGlob) {
+		if project != nil {
+			ref, err := project.ResolveName(nameOrGlob)
+			if err != nil {
+				return nil, selectorResolveError(err)
+			}
+			if _, ok := dag.Nodes[ref.Name]; !ok {
+				return nil, &NameNotFoundError{Query: nameOrGlob, Kind: "selector"}
+			}
+			return []string{ref.Name}, nil
+		}
 		if _, ok := dag.Nodes[nameOrGlob]; !ok {
 			return nil, g.Error("selector '%s': model '%s' not found", selectorForError, nameOrGlob)
 		}
@@ -614,17 +636,34 @@ func resolveNodes(nameOrGlob string, dag *DAG, selectorForError string) ([]strin
 	return matchByGlob(nameOrGlob, dag)
 }
 
-// matchByGlob matches node names using a glob pattern.
+// matchByGlob matches node names using a glob pattern, also trying ProdFullTableName.
 func matchByGlob(pattern string, dag *DAG) ([]string, error) {
-	g, err := glob.Compile(pattern)
+	compiled, err := glob.Compile(pattern)
 	if err != nil {
 		return nil, err
 	}
 
 	var result []string
+	seen := map[string]bool{}
 	for _, name := range dag.Order {
-		if g.Match(name) {
+		if compiled.Match(name) {
 			result = append(result, name)
+			seen[name] = true
+			continue
+		}
+		node := dag.Nodes[name]
+		var prod string
+		if node.Model != nil {
+			prod = node.Model.ProdFullTableName
+		} else if node.Seed != nil {
+			prod = node.Seed.ProdFullTableName
+		}
+		if prod == "" || seen[name] {
+			continue
+		}
+		if compiled.Match(prod) || compiled.Match(stripDatabase(prod)) {
+			result = append(result, name)
+			seen[name] = true
 		}
 	}
 	return result, nil

--- a/core/sling/build/selector_test.go
+++ b/core/sling/build/selector_test.go
@@ -24,21 +24,21 @@ func newTestDAGProject() *BuildProject {
 			},
 			"dim_customers": {
 				Name:          "dim_customers",
-				FullTableName: "marts.core_dim_customers",
+				FullTableName: "marts.dim_customers",
 				RelPath:       "marts/core/dim_customers.sql",
 				DependsOn:     []string{"stg_customers"},
 				Config:        ModelConfig{Tags: []string{"weekly"}},
 			},
 			"fct_orders": {
 				Name:          "fct_orders",
-				FullTableName: "marts.core_fct_orders",
+				FullTableName: "marts.fct_orders",
 				RelPath:       "marts/core/fct_orders.sql",
 				DependsOn:     []string{"stg_orders"},
 				Config:        ModelConfig{Tags: []string{"daily"}},
 			},
 			"revenue": {
 				Name:          "revenue",
-				FullTableName: "marts.finance_revenue",
+				FullTableName: "marts.revenue",
 				RelPath:       "marts/finance/revenue.sql",
 				DependsOn:     []string{"fct_orders"},
 			},
@@ -575,6 +575,86 @@ func TestSelectorGlobGraphNoMatch(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Empty(t, result)
+}
+
+func TestSelectorStemAndSchemaTable(t *testing.T) {
+	project := loadMartsEventsProject(t, BuildOptions{Prod: true})
+	dag, err := BuildDAG(project)
+	require.NoError(t, err)
+
+	sel := NewSelector([]string{"events"}, nil)
+	sel.Project = project
+	result, err := sel.Apply(dag)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"events"}, result)
+
+	sel = NewSelector([]string{"analytics.events"}, nil)
+	sel.Project = project
+	result, err = sel.Apply(dag)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"events"}, result)
+
+	sel = NewSelector([]string{"analytics/plausible/*"}, nil)
+	sel.Project = project
+	result, err = sel.Apply(dag)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"events"}, result)
+}
+
+func TestSelectorOldPrefixedNameErrors(t *testing.T) {
+	project := loadMartsEventsProject(t, BuildOptions{Prod: true})
+	dag, err := BuildDAG(project)
+	require.NoError(t, err)
+
+	sel := NewSelector([]string{"plausible_events"}, nil)
+	sel.Project = project
+	_, err = sel.Apply(dag)
+	require.Error(t, err)
+
+	var notFound *NameNotFoundError
+	require.ErrorAs(t, err, &notFound)
+	assert.Equal(t, "selector", notFound.Kind)
+	assert.Contains(t, err.Error(), "selector 'plausible_events' not found")
+}
+
+func TestSelectorSubfolderPathGlob(t *testing.T) {
+	project, err := LoadProject(getTestFixturePath("sample_project"), BuildOptions{Prod: true})
+	require.NoError(t, err)
+	dag, err := BuildDAG(project)
+	require.NoError(t, err)
+
+	sel := NewSelector([]string{"marts/core/*"}, nil)
+	sel.Project = project
+	result, err := sel.Apply(dag)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"dim_customers", "fct_orders"}, result)
+}
+
+func TestSelectorGlobThreePart(t *testing.T) {
+	project, err := LoadProject(getTestFixturePath("database_project"), BuildOptions{Prod: true})
+	require.NoError(t, err)
+	dag, err := BuildDAG(project)
+	require.NoError(t, err)
+
+	sel := NewSelector([]string{"marts.*"}, nil)
+	sel.Project = project
+	result, err := sel.Apply(dag)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"dim_customers", "revenue"}, result)
+}
+
+func TestSelectorTypoSuggests(t *testing.T) {
+	project := loadNestedEventsProject(t)
+	dag, err := BuildDAG(project)
+	require.NoError(t, err)
+
+	sel := NewSelector([]string{"plausible_event"}, nil)
+	sel.Project = project
+	_, err = sel.Apply(dag)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+	assert.Contains(t, err.Error(), "Did you mean")
+	assert.Contains(t, err.Error(), "plausible_events")
 }
 
 // =============================================================================

--- a/core/sling/build/template.go
+++ b/core/sling/build/template.go
@@ -568,8 +568,8 @@ const (
 	// to write their own WHERE clauses. This is the zero value and the harmless default
 	// for non-incremental models.
 	StyleDbt Style = iota
-	// StyleSling is the sling-native pattern: models use {incremental_where_cond} and/or
-	// {incremental_value} placeholders, and sling owns the WHERE clause / watermark.
+	// StyleSling is the sling-native pattern: models use incremental_where_cond() and/or
+	// incremental_value() Jinja functions, and sling owns the WHERE clause / watermark.
 	StyleSling
 )
 
@@ -577,12 +577,17 @@ const (
 // incremental pattern the model uses. Returns an error if both patterns appear in
 // the same file — the user must pick one.
 func detectModelStyle(rawSQL string) (Style, error) {
-	hasSling := strings.Contains(rawSQL, "{incremental_where_cond}") ||
-		strings.Contains(rawSQL, "{incremental_value}")
+	hasSling := strings.Contains(rawSQL, "incremental_where_cond(") ||
+		strings.Contains(rawSQL, "incremental_value(")
 	hasDbt := strings.Contains(rawSQL, "is_incremental(")
+	hasLegacy := strings.Contains(rawSQL, "{incremental_where_cond}") ||
+		strings.Contains(rawSQL, "{incremental_value}")
 
+	if hasLegacy && !hasSling {
+		return StyleDbt, g.Error("use {{ incremental_where_cond() }} or {{ incremental_value() }} instead of {incremental_where_cond} / {incremental_value}")
+	}
 	if hasSling && hasDbt {
-		return StyleDbt, g.Error("cannot mix is_incremental() and {incremental_where_cond} in the same model. Choose one pattern: either dbt-compatible (is_incremental() + {{ this }}) or sling-native ({incremental_where_cond})")
+		return StyleDbt, g.Error("cannot mix is_incremental() and incremental_where_cond() in the same model. Choose one pattern: either dbt-compatible (is_incremental() + {{ this }}) or sling-native ({{ incremental_where_cond() }})")
 	}
 	if hasSling {
 		return StyleSling, nil
@@ -597,17 +602,17 @@ func detectModelStyle(rawSQL string) (Style, error) {
 // =============================================================================
 
 // IncrementalContext carries values used by CompileModel to resolve incremental
-// placeholders and flags. One type serves both styles:
+// functions and flags. One type serves both styles:
 //
 //   - Style A (dbt):    CompileModel reads IsIncremental only and passes it to
 //     the is_incremental() Jinja function. WhereCond/Value
-//     are ignored because the SQL does not contain the
-//     {incremental_where_cond}/{incremental_value} placeholders.
+//     are ignored because the SQL does not call
+//     incremental_where_cond() / incremental_value().
 //
-//   - Style B (sling):  CompileModel reads WhereCond/Value and substitutes
-//     them into the rendered SQL via g.R(). is_incremental()
-//     is still registered but returns IsIncremental (which
-//     callers typically leave false for sling-style models).
+//   - Style B (sling):  CompileModel reads WhereCond/Value and exposes them as
+//     the incremental_where_cond() / incremental_value() Jinja
+//     functions. is_incremental() is still registered but
+//     returns IsIncremental (typically false for sling-style).
 //
 // A nil *IncrementalContext is equivalent to DefaultIncrementalContext():
 // first-run semantics (WhereCond=1=1, Value=null, IsIncremental=false).
@@ -617,7 +622,7 @@ type IncrementalContext struct {
 	IsIncremental bool   // drives is_incremental() for dbt-style models
 }
 
-// DefaultIncrementalContext returns a first-run context: placeholders resolve
+// DefaultIncrementalContext returns a first-run context: Jinja functions resolve
 // to "1=1"/"null" and is_incremental() returns false.
 func DefaultIncrementalContext() *IncrementalContext {
 	return &IncrementalContext{
@@ -655,8 +660,8 @@ func NewTemplateEngine(project *BuildProject, vars map[string]any) *TemplateEngi
 // CompileModel compiles a model's SQL template, extracting config and resolving references.
 // The incCtx parameter carries incremental-pattern values:
 //   - Style A (dbt) models read incCtx.IsIncremental via the is_incremental() Jinja function.
-//   - Style B (sling) models read incCtx.WhereCond / incCtx.Value via {incremental_where_cond}
-//     and {incremental_value} placeholders, substituted after Jinja rendering.
+//   - Style B (sling) models read incCtx.WhereCond / incCtx.Value via
+//     incremental_where_cond() and incremental_value() Jinja functions.
 //
 // A nil incCtx is equivalent to DefaultIncrementalContext() — first-run semantics.
 func (te *TemplateEngine) CompileModel(model *Model, incCtx *IncrementalContext) (string, error) {
@@ -731,6 +736,13 @@ func (te *TemplateEngine) CompileModel(model *Model, incCtx *IncrementalContext)
 		return incCtx.IsIncremental
 	})
 
+	envCtx.Set("incremental_where_cond", func(_ *exec.Evaluator, params *exec.VarArgs) (string, error) {
+		return incCtx.WhereCond, nil
+	})
+	envCtx.Set("incremental_value", func(_ *exec.Evaluator, params *exec.VarArgs) (string, error) {
+		return incCtx.Value, nil
+	})
+
 	// Register user vars
 	for k, v := range te.vars {
 		envCtx.Set(k, v)
@@ -773,18 +785,7 @@ func (te *TemplateEngine) CompileModel(model *Model, incCtx *IncrementalContext)
 		return "", g.Error(err, "could not compile template for model '%s'", model.Name)
 	}
 
-	// Trim whitespace
 	compiled := strings.TrimSpace(result)
-
-	// Substitute sling-style placeholders. g.R uses {key} literal-bracket syntax;
-	// gonja preserves single-brace text verbatim, so this runs after Jinja rendering.
-	// g.R is a no-op for placeholders not present in the string, so dbt-style and
-	// view/full-refresh models are unaffected.
-	compiled = g.R(compiled,
-		"incremental_where_cond", incCtx.WhereCond,
-		"incremental_value", incCtx.Value,
-	)
-
 	model.CompiledSQL = compiled
 
 	return compiled, nil
@@ -813,6 +814,9 @@ func (te *TemplateEngine) applyConfig(model *Model, params *exec.VarArgs) error 
 			}
 			if canonical == "ephemeral" {
 				return g.Error("model '%s': ephemeral models are not supported; use view or table", model.Name)
+			}
+			if err := validateMode(canonical, model.Name); err != nil {
+				return err
 			}
 			model.Config.Mode = canonical
 		case "materialized":

--- a/core/sling/build/template.go
+++ b/core/sling/build/template.go
@@ -445,7 +445,8 @@ func restoreLiterals(sql string, placeholders []string) string {
 // RewriteTableReferences scans compiled SQL for table references matching prod-mode names
 // of known models/seeds and rewrites them to current-mode FullTableNames.
 // Returns the rewritten SQL and matched model/seed names (for DependsOn).
-func RewriteTableReferences(sql string, project *BuildProject, selfName string) (string, []string) {
+// An ambiguous bare name is an error.
+func RewriteTableReferences(sql string, project *BuildProject, selfName string) (string, []string, error) {
 	// Protect literals so we don't rewrite inside strings/comments
 	protected, placeholders := protectLiterals(sql)
 
@@ -456,9 +457,6 @@ func RewriteTableReferences(sql string, project *BuildProject, selfName string) 
 			cteNames[strings.ToLower(match[1])] = true
 		}
 	}
-
-	// Build lookup index
-	index := project.BuildProdNameIndex()
 
 	// Find all table reference positions
 	matches := tableRefRegex.FindAllStringSubmatchIndex(protected, -1)
@@ -496,20 +494,22 @@ func RewriteTableReferences(sql string, project *BuildProject, selfName string) 
 			continue
 		}
 
-		// Look up in prod-name index
-		entry, ok := index[normalizedLower]
-		if !ok || entry.Name == selfName {
+		resolved, err := project.ResolveName(normalized)
+		if err != nil {
+			continue
+		}
+		if resolved.Name == selfName {
 			continue
 		}
 
 		// Replace the table ref with current-mode FullTableName,
 		// preserving the original quoting style (double quotes, backticks, or none)
 		result.WriteString(protected[lastEnd:refStart])
-		result.WriteString(requoteTableRef(ref, entry.FullTableName))
+		result.WriteString(requoteTableRef(ref, resolved.FullTableName))
 		lastEnd = refEnd
 
-		if !containsStr(deps, entry.Name) {
-			deps = append(deps, entry.Name)
+		if !containsStr(deps, resolved.Name) {
+			deps = append(deps, resolved.Name)
 		}
 	}
 
@@ -517,7 +517,7 @@ func RewriteTableReferences(sql string, project *BuildProject, selfName string) 
 
 	// Restore protected regions
 	final := restoreLiterals(result.String(), placeholders)
-	return final, deps
+	return final, deps, nil
 }
 
 // =============================================================================
@@ -530,30 +530,25 @@ var atRefRegex = regexp.MustCompile(`(?:^|[^@])@([a-zA-Z_]\w*)`)
 
 // preprocessAtRefs replaces @model_name references with the current-mode FullTableName.
 // Must be called before Jinja rendering. Populates model.DependsOn for each resolved reference.
-func (te *TemplateEngine) preprocessAtRefs(sql string, model *Model) string {
-	return atRefRegex.ReplaceAllStringFunc(sql, func(match string) string {
-		// Find where @ starts in the match (the prefix char may be included)
+func (te *TemplateEngine) preprocessAtRefs(sql string, model *Model) (string, error) {
+	out := atRefRegex.ReplaceAllStringFunc(sql, func(match string) string {
 		atIdx := strings.Index(match, "@")
 		prefix := match[:atIdx]
 		name := match[atIdx+1:]
 
-		// Look up in models and seeds
-		if m, ok := te.project.Models[name]; ok && name != model.Name {
-			if !containsStr(model.DependsOn, name) {
-				model.DependsOn = append(model.DependsOn, name)
-			}
-			return prefix + m.FullTableName
+		ref, err := te.project.ResolveName(name)
+		if err != nil {
+			return match
 		}
-		if s, ok := te.project.Seeds[name]; ok {
-			if !containsStr(model.DependsOn, name) {
-				model.DependsOn = append(model.DependsOn, name)
-			}
-			return prefix + s.FullTableName
+		if ref.Name == model.Name {
+			return match
 		}
-
-		// Not a known model/seed — leave as-is (could be a SQL Server @variable)
-		return match
+		if !containsStr(model.DependsOn, ref.Name) {
+			model.DependsOn = append(model.DependsOn, ref.Name)
+		}
+		return prefix + ref.FullTableName
 	})
+	return out, nil
 }
 
 // =============================================================================
@@ -690,20 +685,20 @@ func (te *TemplateEngine) CompileModel(model *Model, incCtx *IncrementalContext)
 		}
 		name := params.Args[0].String()
 
-		fullName, ok := te.project.LookupFullTableName(name)
-		if !ok {
-			return "", g.Error("ref('%s'): model or seed not found in project", name)
+		ref, err := te.project.ResolveName(name)
+		if err != nil {
+			return "", err
 		}
 
-		// Record dependency
+		// Record dependency. Refs keep the literal; DependsOn uses the identity.
 		if !containsStr(model.Refs, name) {
 			model.Refs = append(model.Refs, name)
 		}
-		if !containsStr(model.DependsOn, name) {
-			model.DependsOn = append(model.DependsOn, name)
+		if !containsStr(model.DependsOn, ref.Name) {
+			model.DependsOn = append(model.DependsOn, ref.Name)
 		}
 
-		return fullName, nil
+		return ref.FullTableName, nil
 	})
 
 	// Register src()/source() functions — passthrough, records as source
@@ -766,7 +761,11 @@ func (te *TemplateEngine) CompileModel(model *Model, incCtx *IncrementalContext)
 	}
 
 	// Resolve @model_name references before Jinja rendering
-	processedSQL = te.preprocessAtRefs(processedSQL, model)
+	var atErr error
+	processedSQL, atErr = te.preprocessAtRefs(processedSQL, model)
+	if atErr != nil {
+		return "", atErr
+	}
 
 	// Create template from model SQL
 	templateID := "/" + model.Name
@@ -845,6 +844,8 @@ func (te *TemplateEngine) applyConfig(model *Model, params *exec.VarArgs) error 
 			return g.Error("pre_hook/post_hook are not supported in sling build config(). Use YAML frontmatter with hooks.start/hooks.end instead.\nSee https://docs.slingdata.io/concepts/sling-build for details")
 		case "schema":
 			model.Config.Schema = strVal
+		case "database":
+			model.Config.Database = strVal
 		case "enabled":
 			enabled := cast.ToBool(strVal)
 			model.Config.Enabled = &enabled

--- a/core/sling/build/template_test.go
+++ b/core/sling/build/template_test.go
@@ -594,16 +594,14 @@ func newTestProjectDev() *BuildProject {
 			"stg_orders": {
 				Name:              "stg_orders",
 				Schema:            "dev_fritz",
-				Prefix:            "staging",
-				FullTableName:     "dev_fritz.staging_stg_orders",
+				FullTableName:     "dev_fritz.stg_orders",
 				ProdFullTableName: "staging.stg_orders",
 				RawSQL:            "SELECT 1 as id, 'order_1' as name",
 			},
 			"stg_customers": {
 				Name:              "stg_customers",
 				Schema:            "dev_fritz",
-				Prefix:            "staging",
-				FullTableName:     "dev_fritz.staging_stg_customers",
+				FullTableName:     "dev_fritz.stg_customers",
 				ProdFullTableName: "staging.stg_customers",
 				RawSQL:            "SELECT 1 as id, 'customer_1' as name",
 			},
@@ -612,8 +610,7 @@ func newTestProjectDev() *BuildProject {
 			"country_codes": {
 				Name:              "country_codes",
 				Schema:            "dev_fritz",
-				Prefix:            "staging",
-				FullTableName:     "dev_fritz.staging_country_codes",
+				FullTableName:     "dev_fritz.country_codes",
 				ProdFullTableName: "staging.country_codes",
 				Format:            "csv",
 			},
@@ -1232,7 +1229,7 @@ func TestRewriteTableReferences_ProdMode(t *testing.T) {
 
 	// In prod mode, prod name == current name, so rewriting is a no-op
 	sql := "SELECT * FROM staging.stg_orders"
-	rewritten, deps := RewriteTableReferences(sql, project, "some_model")
+	rewritten, deps, _ := RewriteTableReferences(sql, project, "some_model")
 
 	assert.Equal(t, "SELECT * FROM staging.stg_orders", rewritten)
 	assert.Contains(t, deps, "stg_orders")
@@ -1242,9 +1239,9 @@ func TestRewriteTableReferences_DevMode(t *testing.T) {
 	project := newTestProjectDev()
 
 	sql := "SELECT * FROM staging.stg_orders"
-	rewritten, deps := RewriteTableReferences(sql, project, "some_model")
+	rewritten, deps, _ := RewriteTableReferences(sql, project, "some_model")
 
-	assert.Equal(t, "SELECT * FROM dev_fritz.staging_stg_orders", rewritten)
+	assert.Equal(t, "SELECT * FROM dev_fritz.stg_orders", rewritten)
 	assert.Contains(t, deps, "stg_orders")
 }
 
@@ -1254,10 +1251,10 @@ func TestRewriteTableReferences_DevModeMultiple(t *testing.T) {
 	sql := `SELECT o.*, c.name
 FROM staging.stg_orders o
 JOIN staging.stg_customers c ON o.id = c.id`
-	rewritten, deps := RewriteTableReferences(sql, project, "some_model")
+	rewritten, deps, _ := RewriteTableReferences(sql, project, "some_model")
 
-	assert.Contains(t, rewritten, "FROM dev_fritz.staging_stg_orders o")
-	assert.Contains(t, rewritten, "JOIN dev_fritz.staging_stg_customers c")
+	assert.Contains(t, rewritten, "FROM dev_fritz.stg_orders o")
+	assert.Contains(t, rewritten, "JOIN dev_fritz.stg_customers c")
 	assert.Contains(t, deps, "stg_orders")
 	assert.Contains(t, deps, "stg_customers")
 }
@@ -1267,7 +1264,7 @@ func TestRewriteTableReferences_NoMatch(t *testing.T) {
 
 	// External table not in project — should not be rewritten
 	sql := "SELECT * FROM external_db.raw_events"
-	rewritten, deps := RewriteTableReferences(sql, project, "some_model")
+	rewritten, deps, _ := RewriteTableReferences(sql, project, "some_model")
 
 	assert.Equal(t, "SELECT * FROM external_db.raw_events", rewritten)
 	assert.Empty(t, deps)
@@ -1278,10 +1275,10 @@ func TestRewriteTableReferences_StringsNotRewritten(t *testing.T) {
 
 	// Table name inside string literal should NOT be rewritten
 	sql := "SELECT 'staging.stg_orders' as table_name FROM staging.stg_orders"
-	rewritten, deps := RewriteTableReferences(sql, project, "some_model")
+	rewritten, deps, _ := RewriteTableReferences(sql, project, "some_model")
 
 	assert.Contains(t, rewritten, "'staging.stg_orders'") // string preserved
-	assert.Contains(t, rewritten, "FROM dev_fritz.staging_stg_orders") // real ref rewritten
+	assert.Contains(t, rewritten, "FROM dev_fritz.stg_orders") // real ref rewritten
 	assert.Contains(t, deps, "stg_orders")
 }
 
@@ -1290,10 +1287,10 @@ func TestRewriteTableReferences_CommentsNotRewritten(t *testing.T) {
 
 	sql := `-- FROM staging.stg_orders
 SELECT * FROM staging.stg_customers`
-	rewritten, deps := RewriteTableReferences(sql, project, "some_model")
+	rewritten, deps, _ := RewriteTableReferences(sql, project, "some_model")
 
 	assert.Contains(t, rewritten, "-- FROM staging.stg_orders") // comment preserved
-	assert.Contains(t, rewritten, "FROM dev_fritz.staging_stg_customers")
+	assert.Contains(t, rewritten, "FROM dev_fritz.stg_customers")
 	assert.Contains(t, deps, "stg_customers")
 }
 
@@ -1305,7 +1302,7 @@ func TestRewriteTableReferences_CTENotRewritten(t *testing.T) {
     SELECT 1 as id
 )
 SELECT * FROM stg_orders`
-	rewritten, deps := RewriteTableReferences(sql, project, "some_model")
+	rewritten, deps, _ := RewriteTableReferences(sql, project, "some_model")
 
 	// The CTE reference should not be rewritten
 	assert.Contains(t, rewritten, "FROM stg_orders")
@@ -1318,9 +1315,9 @@ func TestRewriteTableReferences_UnqualifiedName(t *testing.T) {
 
 	// Bare table name without schema should match by model name
 	sql := "SELECT * FROM stg_orders"
-	rewritten, deps := RewriteTableReferences(sql, project, "some_model")
+	rewritten, deps, _ := RewriteTableReferences(sql, project, "some_model")
 
-	assert.Equal(t, "SELECT * FROM dev_fritz.staging_stg_orders", rewritten)
+	assert.Equal(t, "SELECT * FROM dev_fritz.stg_orders", rewritten)
 	assert.Contains(t, deps, "stg_orders")
 }
 
@@ -1329,7 +1326,7 @@ func TestRewriteTableReferences_SelfNotRewritten(t *testing.T) {
 
 	// Self-references should not be rewritten
 	sql := "SELECT * FROM staging.stg_orders"
-	rewritten, deps := RewriteTableReferences(sql, project, "stg_orders")
+	rewritten, deps, _ := RewriteTableReferences(sql, project, "stg_orders")
 
 	assert.Equal(t, "SELECT * FROM staging.stg_orders", rewritten)
 	assert.Empty(t, deps)
@@ -1339,10 +1336,10 @@ func TestRewriteTableReferences_DoubleQuoted(t *testing.T) {
 	project := newTestProjectDev()
 
 	sql := `SELECT * FROM "staging"."stg_orders"`
-	rewritten, deps := RewriteTableReferences(sql, project, "some_model")
+	rewritten, deps, _ := RewriteTableReferences(sql, project, "some_model")
 
 	// Quotes should be preserved in the replacement
-	assert.Equal(t, `SELECT * FROM "dev_fritz"."staging_stg_orders"`, rewritten)
+	assert.Equal(t, `SELECT * FROM "dev_fritz"."stg_orders"`, rewritten)
 	assert.Contains(t, deps, "stg_orders")
 }
 
@@ -1350,10 +1347,10 @@ func TestRewriteTableReferences_Backticked(t *testing.T) {
 	project := newTestProjectDev()
 
 	sql := "SELECT * FROM `staging`.`stg_orders`"
-	rewritten, deps := RewriteTableReferences(sql, project, "some_model")
+	rewritten, deps, _ := RewriteTableReferences(sql, project, "some_model")
 
 	// Backticks should be preserved in the replacement
-	assert.Equal(t, "SELECT * FROM `dev_fritz`.`staging_stg_orders`", rewritten)
+	assert.Equal(t, "SELECT * FROM `dev_fritz`.`stg_orders`", rewritten)
 	assert.Contains(t, deps, "stg_orders")
 }
 
@@ -1361,10 +1358,10 @@ func TestRewriteTableReferences_UnquotedPreserved(t *testing.T) {
 	project := newTestProjectDev()
 
 	sql := "SELECT * FROM staging.stg_orders"
-	rewritten, deps := RewriteTableReferences(sql, project, "some_model")
+	rewritten, deps, _ := RewriteTableReferences(sql, project, "some_model")
 
 	// No quotes in original, no quotes in replacement
-	assert.Equal(t, "SELECT * FROM dev_fritz.staging_stg_orders", rewritten)
+	assert.Equal(t, "SELECT * FROM dev_fritz.stg_orders", rewritten)
 	assert.Contains(t, deps, "stg_orders")
 }
 
@@ -1372,10 +1369,10 @@ func TestRewriteTableReferences_MixedQuotesAndPlain(t *testing.T) {
 	project := newTestProjectDev()
 
 	sql := `SELECT * FROM "staging"."stg_orders" o JOIN staging.stg_customers c ON o.id = c.id`
-	rewritten, deps := RewriteTableReferences(sql, project, "some_model")
+	rewritten, deps, _ := RewriteTableReferences(sql, project, "some_model")
 
-	assert.Contains(t, rewritten, `"dev_fritz"."staging_stg_orders"`)
-	assert.Contains(t, rewritten, "dev_fritz.staging_stg_customers")
+	assert.Contains(t, rewritten, `"dev_fritz"."stg_orders"`)
+	assert.Contains(t, rewritten, "dev_fritz.stg_customers")
 	assert.Contains(t, deps, "stg_orders")
 	assert.Contains(t, deps, "stg_customers")
 }
@@ -1385,7 +1382,7 @@ func TestRewriteTableReferences_QuotedProdMode(t *testing.T) {
 
 	// In prod mode, quoted identifiers should still be preserved (identity rewrite)
 	sql := `SELECT * FROM "staging"."stg_orders"`
-	rewritten, deps := RewriteTableReferences(sql, project, "some_model")
+	rewritten, deps, _ := RewriteTableReferences(sql, project, "some_model")
 
 	assert.Equal(t, `SELECT * FROM "staging"."stg_orders"`, rewritten)
 	assert.Contains(t, deps, "stg_orders")
@@ -1395,9 +1392,9 @@ func TestRewriteTableReferences_SeedRewritten(t *testing.T) {
 	project := newTestProjectDev()
 
 	sql := "SELECT * FROM staging.country_codes"
-	rewritten, deps := RewriteTableReferences(sql, project, "some_model")
+	rewritten, deps, _ := RewriteTableReferences(sql, project, "some_model")
 
-	assert.Equal(t, "SELECT * FROM dev_fritz.staging_country_codes", rewritten)
+	assert.Equal(t, "SELECT * FROM dev_fritz.country_codes", rewritten)
 	assert.Contains(t, deps, "country_codes")
 }
 
@@ -1406,11 +1403,71 @@ func TestRewriteTableReferences_RefOutputNotDoubleRewritten(t *testing.T) {
 
 	// In dev mode, ref() already returns the dev name.
 	// The rewriter should NOT match it again (dev name is not in the prod-name index).
-	sql := "SELECT * FROM dev_fritz.staging_stg_orders"
-	rewritten, deps := RewriteTableReferences(sql, project, "some_model")
+	sql := "SELECT * FROM dev_fritz.stg_orders"
+	rewritten, deps, _ := RewriteTableReferences(sql, project, "some_model")
 
-	assert.Equal(t, "SELECT * FROM dev_fritz.staging_stg_orders", rewritten)
+	assert.Equal(t, "SELECT * FROM dev_fritz.stg_orders", rewritten)
 	assert.Empty(t, deps) // no match since dev name != prod name
+}
+
+func TestRefStemAndSchemaTable(t *testing.T) {
+	project := loadMartsEventsProject(t, BuildOptions{Prod: true})
+	te := NewTemplateEngine(project, nil)
+	model := &Model{Name: "downstream", RawSQL: `select * from {{ ref("events") }}`}
+	sql, err := te.CompileModel(model, nil)
+	require.NoError(t, err)
+	assert.Contains(t, sql, "analytics.events")
+	assert.Contains(t, model.DependsOn, "events")
+	assert.Contains(t, model.Refs, "events")
+
+	model = &Model{Name: "downstream2", RawSQL: `select * from {{ ref("analytics.events") }}`}
+	sql, err = te.CompileModel(model, nil)
+	require.NoError(t, err)
+	assert.Contains(t, sql, "analytics.events")
+	assert.Contains(t, model.DependsOn, "events")
+}
+
+func TestRefOldPrefixedNameNotFound(t *testing.T) {
+	project := loadMartsEventsProject(t, BuildOptions{Prod: true})
+	te := NewTemplateEngine(project, nil)
+	model := &Model{Name: "downstream", RawSQL: `select * from {{ ref("plausible_events") }}`}
+	_, err := te.CompileModel(model, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestRewriteTableReferencesProdQualified(t *testing.T) {
+	project := loadMartsEventsProject(t, BuildOptions{Prod: true})
+	rewritten, deps, err := RewriteTableReferences("select * from analytics.events", project, "downstream")
+	require.NoError(t, err)
+	assert.Equal(t, "select * from analytics.events", rewritten)
+	assert.Contains(t, deps, "events")
+}
+
+func TestRefThreePart(t *testing.T) {
+	project := loadDatabaseProject(t, BuildOptions{Prod: true})
+	te := NewTemplateEngine(project, nil)
+
+	model := &Model{Name: "downstream", RawSQL: `select * from {{ ref("dim_customers") }}`}
+	sql, err := te.CompileModel(model, nil)
+	require.NoError(t, err)
+	assert.Contains(t, sql, "ANALYTICS_DB.marts.dim_customers")
+
+	// `this` renders the three-part name
+	revenue := project.Models["revenue"]
+	revenue.RawSQL = "select * from {{ this }}"
+	sql, err = te.CompileModel(revenue, nil)
+	require.NoError(t, err)
+	assert.Contains(t, sql, "FIN_DB.marts.revenue")
+}
+
+func TestRewriteTableReferencesThreePart(t *testing.T) {
+	project := loadDatabaseProject(t, BuildOptions{Prod: true})
+
+	rewritten, deps, err := RewriteTableReferences("select * from marts.dim_customers", project, "downstream")
+	require.NoError(t, err)
+	assert.Equal(t, "select * from ANALYTICS_DB.marts.dim_customers", rewritten)
+	assert.Contains(t, deps, "dim_customers")
 }
 
 // =============================================================================
@@ -1455,7 +1512,8 @@ func TestPreprocessAtRefs(t *testing.T) {
 		FullTableName: "staging.test_model",
 	}
 
-	result := te.preprocessAtRefs("SELECT * FROM @stg_orders o JOIN @stg_customers c ON o.id = c.id", model)
+	result, err := te.preprocessAtRefs("SELECT * FROM @stg_orders o JOIN @stg_customers c ON o.id = c.id", model)
+	require.NoError(t, err)
 
 	assert.Contains(t, result, "staging.stg_orders")
 	assert.Contains(t, result, "staging.stg_customers")
@@ -1473,10 +1531,11 @@ func TestPreprocessAtRefsDevMode(t *testing.T) {
 		FullTableName: "dev_fritz.test_model",
 	}
 
-	result := te.preprocessAtRefs("SELECT * FROM @stg_orders", model)
+	result, err := te.preprocessAtRefs("SELECT * FROM @stg_orders", model)
+	require.NoError(t, err)
 
 	// Should resolve to dev-mode FullTableName
-	assert.Contains(t, result, "dev_fritz.staging_stg_orders")
+	assert.Contains(t, result, "dev_fritz.stg_orders")
 	assert.Contains(t, model.DependsOn, "stg_orders")
 }
 

--- a/core/sling/build/template_test.go
+++ b/core/sling/build/template_test.go
@@ -990,6 +990,24 @@ SELECT * FROM {{ ref('stg_customers') }}`,
 	assert.Equal(t, "view", model.Config.Mode)
 }
 
+func TestCompileWithConfigUnknownModeRejected(t *testing.T) {
+	project := newTestProject()
+	te := NewTemplateEngine(project, nil)
+
+	model := &Model{
+		Name:          "bad_mode",
+		Schema:        "marts",
+		FullTableName: "marts.bad_mode",
+		RawSQL: `{%- config(mode='vew') -%}
+SELECT 1`,
+	}
+	project.Models["bad_mode"] = model
+
+	_, err := te.CompileModel(model, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown mode 'vew'")
+}
+
 func TestCompileWithConfigEnabled(t *testing.T) {
 	project := newTestProject()
 	te := NewTemplateEngine(project, nil)
@@ -1474,14 +1492,14 @@ func TestCompileModel_SlingStyle_Placeholder_Default(t *testing.T) {
 		Name:          "stg_orders",
 		Schema:        "staging",
 		FullTableName: "staging.stg_orders",
-		RawSQL:        "SELECT * FROM raw WHERE {incremental_where_cond}",
+		RawSQL:        "SELECT * FROM raw WHERE {{ incremental_where_cond() }}",
 	}
 	project.Models["stg_orders"] = model
 
 	result, err := te.CompileModel(model, nil)
 	require.NoError(t, err)
 	assert.Contains(t, result, "WHERE 1=1")
-	assert.NotContains(t, result, "{incremental_where_cond}")
+	assert.NotContains(t, result, "incremental_where_cond")
 }
 
 func TestCompileModel_SlingStyle_Placeholder_Custom(t *testing.T) {
@@ -1492,7 +1510,7 @@ func TestCompileModel_SlingStyle_Placeholder_Custom(t *testing.T) {
 		Name:          "stg_orders",
 		Schema:        "staging",
 		FullTableName: "staging.stg_orders",
-		RawSQL:        "SELECT * FROM raw WHERE {incremental_where_cond}",
+		RawSQL:        "SELECT * FROM raw WHERE {{ incremental_where_cond() }}",
 	}
 	project.Models["stg_orders"] = model
 
@@ -1500,7 +1518,7 @@ func TestCompileModel_SlingStyle_Placeholder_Custom(t *testing.T) {
 	result, err := te.CompileModel(model, ctx)
 	require.NoError(t, err)
 	assert.Contains(t, result, `"created_at" > '2024-01-01'`)
-	assert.NotContains(t, result, "{incremental_where_cond}")
+	assert.NotContains(t, result, "incremental_where_cond")
 }
 
 func TestCompileModel_SlingStyle_IncrementalValue(t *testing.T) {
@@ -1511,7 +1529,7 @@ func TestCompileModel_SlingStyle_IncrementalValue(t *testing.T) {
 		Name:          "stg_orders",
 		Schema:        "staging",
 		FullTableName: "staging.stg_orders",
-		RawSQL:        "SELECT {incremental_value} AS watermark FROM raw",
+		RawSQL:        "SELECT {{ incremental_value() }} AS watermark FROM raw",
 	}
 	project.Models["stg_orders"] = model
 
@@ -1519,7 +1537,7 @@ func TestCompileModel_SlingStyle_IncrementalValue(t *testing.T) {
 	result, err := te.CompileModel(model, ctx)
 	require.NoError(t, err)
 	assert.Contains(t, result, "'2024-01-01' AS watermark")
-	assert.NotContains(t, result, "{incremental_value}")
+	assert.NotContains(t, result, "incremental_value")
 }
 
 func TestCompileModel_DbtStyle_IsIncrementalTrue(t *testing.T) {
@@ -1570,7 +1588,7 @@ func TestCompileModel_NilContext_UsesDefault(t *testing.T) {
 		Name:          "stg_orders",
 		Schema:        "staging",
 		FullTableName: "staging.stg_orders",
-		RawSQL:        "SELECT * FROM raw WHERE {incremental_where_cond}",
+		RawSQL:        "SELECT * FROM raw WHERE {{ incremental_where_cond() }}",
 	}
 	project.Models["stg_orders"] = model
 
@@ -1578,6 +1596,22 @@ func TestCompileModel_NilContext_UsesDefault(t *testing.T) {
 	require.NoError(t, err)
 	// nil context → DefaultIncrementalContext → WhereCond="1=1"
 	assert.Contains(t, result, "WHERE 1=1")
+}
+
+func TestDetectModelStyle_LegacyPlaceholderErrors(t *testing.T) {
+	_, err := detectModelStyle("SELECT * FROM raw WHERE {incremental_where_cond}")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "{{ incremental_where_cond() }}")
+
+	_, err = detectModelStyle("SELECT {incremental_value} AS watermark FROM raw")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "{{ incremental_value() }}")
+}
+
+func TestDetectModelStyle_SlingJinja(t *testing.T) {
+	style, err := detectModelStyle("SELECT * FROM raw WHERE {{ incremental_where_cond() }}")
+	require.NoError(t, err)
+	assert.Equal(t, StyleSling, style)
 }
 
 func TestCompileModel_ViewModel_NoPlaceholders_NoOp(t *testing.T) {

--- a/core/sling/hooks.go
+++ b/core/sling/hooks.go
@@ -50,6 +50,8 @@ type HookBuildRunOptions struct {
 	Range       string
 	Recursive   bool
 	Test        bool
+	Compile     bool
+	List        bool
 }
 
 type Hook interface {

--- a/core/sling/project/scaffold/models/sling_build.yml.tmpl
+++ b/core/sling/project/scaffold/models/sling_build.yml.tmpl
@@ -4,4 +4,4 @@ defaults:
   mode: full-refresh
 
 dev:
-  schema: dev
+  schema: dev_${USER}

--- a/core/sling/sling.go
+++ b/core/sling/sling.go
@@ -29,3 +29,7 @@ func IsReplicationRunMode() bool {
 func IsPipelineRunMode() bool {
 	return os.Getenv("SLING_RUN_MODE") == "pipeline"
 }
+
+func IsBuildRunMode() bool {
+	return os.Getenv("SLING_RUN_MODE") == "build"
+}

--- a/core/sling/task_state.go
+++ b/core/sling/task_state.go
@@ -40,6 +40,20 @@ type ReplicationState struct {
 	mu *sync.RWMutex `json:"-" yaml:"-"`
 }
 
+func NewReplicationState() *ReplicationState {
+	return &ReplicationState{
+		mu: &sync.RWMutex{},
+	}
+}
+
+func (rs *ReplicationState) Lock() {
+	rs.lock()
+}
+
+func (rs *ReplicationState) Unlock() {
+	rs.unlock()
+}
+
 func (rs *ReplicationState) lock() {
 	if rs.mu == nil {
 		rs.mu = &sync.RWMutex{}

--- a/core/sling/types.go
+++ b/core/sling/types.go
@@ -1,5 +1,13 @@
 package sling
 
+import (
+	"bytes"
+	"strings"
+
+	"github.com/flarco/g"
+	"github.com/slingdata-io/sling-cli/core/dbio/iop"
+)
+
 // JobType is an enum type for jobs
 type JobType string
 
@@ -148,4 +156,69 @@ func (s ExecStatus) IsSuccess() bool {
 		return true
 	}
 	return false
+}
+
+// MarkdownLine is one key/value pair for compact MCP text.
+type MarkdownLine struct {
+	Key   string
+	Value string
+}
+
+// MarkdownLines is a list of MarkdownLine values.
+type MarkdownLines []MarkdownLine
+
+// Text joins lines as "Key: Value" separated by blank lines.
+func (mdl MarkdownLines) Text() string {
+	lines := make([]string, len(mdl))
+	for i, mdLine := range mdl {
+		lines[i] = g.F("%s: %s", mdLine.Key, mdLine.Value)
+	}
+	return strings.Join(lines, "\n\n")
+}
+
+// Line joins lines as "Key: Value  |  Key: Value".
+func (mdl MarkdownLines) Line() string {
+	lines := make([]string, len(mdl))
+	for i, mdLine := range mdl {
+		lines[i] = g.F("%s: %s", mdLine.Key, mdLine.Value)
+	}
+	return strings.Join(lines, "  |  ")
+}
+
+// CodeBlock wraps text in a fenced code block.
+func CodeBlock(text string) string {
+	return "\n```\n" + text + "\n```\n"
+}
+
+// DatasetToCompact turns a dataset into Column Types + pipe-delimited CSV.
+func DatasetToCompact(data iop.Dataset) MarkdownLines {
+	if data.Sp == nil {
+		data.Sp = iop.NewStreamProcessor()
+	}
+	var csvOutput bytes.Buffer
+	data.Sp.Config.Delimiter = "|"
+	_, _ = data.WriteCsv(&csvOutput)
+
+	types := make([]string, len(data.Columns))
+	for i, col := range data.Columns {
+		if col.Type != "" {
+			types[i] = string(col.Type)
+		} else {
+			types[i] = "string"
+		}
+	}
+	return MarkdownLines{
+		{"Column Types", strings.Join(types, ", ")},
+		{"Pipe-Delimited Data", CodeBlock(csvOutput.String())},
+	}
+}
+
+// CompactText joins a user summary line with the compact dataset payload.
+func CompactText(user MarkdownLines, data iop.Dataset) string {
+	assistant := DatasetToCompact(data)
+	userLine := user.Line()
+	if userLine == "" {
+		return assistant.Text()
+	}
+	return userLine + "\n\n" + assistant.Text()
 }

--- a/core/sling/types_test.go
+++ b/core/sling/types_test.go
@@ -1,0 +1,43 @@
+package sling
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/slingdata-io/sling-cli/core/dbio/iop"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarkdownLines(t *testing.T) {
+	lines := MarkdownLines{
+		{"Connection", "MY_PG"},
+		{"Count", "2"},
+	}
+	assert.Equal(t, "Connection: MY_PG  |  Count: 2", lines.Line())
+	assert.Equal(t, "Connection: MY_PG\n\nCount: 2", lines.Text())
+}
+
+func TestDatasetToCompact(t *testing.T) {
+	data := iop.NewDataset(iop.NewColumnsFromFields("database", "schema", "name"))
+	data.Rows = append(data.Rows, []any{"mydb", "public", "users"})
+	data.Rows = append(data.Rows, []any{"mydb", "public", "orders"})
+
+	out := DatasetToCompact(data)
+	require.Len(t, out, 2)
+	assert.Equal(t, "Column Types", out[0].Key)
+	assert.Equal(t, "string, string, string", out[0].Value)
+	assert.Equal(t, "Pipe-Delimited Data", out[1].Key)
+	assert.Contains(t, out[1].Value, "database|schema|name")
+	assert.Contains(t, out[1].Value, "mydb|public|users")
+	assert.True(t, strings.Contains(out[1].Value, "```"))
+}
+
+func TestCompactText(t *testing.T) {
+	data := iop.NewDataset(iop.NewColumnsFromFields("name"))
+	data.Rows = append(data.Rows, []any{"users"})
+	text := CompactText(MarkdownLines{{"Type", "tables"}, {"Count", "1"}}, data)
+	assert.Contains(t, text, "Type: tables  |  Count: 1")
+	assert.Contains(t, text, "Column Types: string")
+	assert.Contains(t, text, "name")
+}

--- a/core/sling/validate/kind.go
+++ b/core/sling/validate/kind.go
@@ -78,7 +78,7 @@ func detectKindFromPath(path string) Kind {
 		return KindBuild
 	}
 	if info, err := os.Stat(path); err == nil && info.IsDir() {
-		if _, err := os.Stat(filepath.Join(path, build.ConfigFileName)); err == nil {
+		if _, ok := build.FindConfigFile(path); ok {
 			return KindBuild
 		}
 	}
@@ -101,7 +101,7 @@ func isManifestName(name string) bool {
 
 // isBuildConfigName reports whether the file name is a sling_build config.
 func isBuildConfigName(name string) bool {
-	return name == build.ConfigFileName || strings.EqualFold(name, "sling_build.yaml")
+	return build.IsConfigFileName(name)
 }
 
 // isEnvFileName reports whether the file name is an env.yaml connections file.

--- a/core/sling/validate/validate.go
+++ b/core/sling/validate/validate.go
@@ -134,11 +134,12 @@ func parseBody(display, abs string, kind Kind, body []byte, opts Options) FileRe
 
 	useCompile := opts.Compile && (kind == KindReplication || kind == KindPipeline || kind == KindBuild)
 	var (
-		parsed any
-		err    error
+		parsed   any
+		err      error
+		warnings []string
 	)
 	if useCompile {
-		parsed, err = parseCompile(kind, abs, body)
+		parsed, warnings, err = parseCompile(kind, abs, body)
 	} else {
 		parsed, err = parseDTO(kind, body)
 	}
@@ -149,6 +150,7 @@ func parseBody(display, abs string, kind Kind, body []byte, opts Options) FileRe
 	res.OK = true
 	res.Compiled = useCompile
 	res.Parsed = parsed
+	res.Warnings = append(res.Warnings, warnings...)
 	if kind == KindPipeline {
 		res.Warnings = append(res.Warnings, pipelineStepPathWarnings(abs, parsed)...)
 	}
@@ -332,41 +334,46 @@ func AnyFailed(results []FileResult) bool {
 	return false
 }
 
-func parseCompile(kind Kind, absPath string, body []byte) (any, error) {
+func parseCompile(kind Kind, absPath string, body []byte) (any, []string, error) {
 	env.LoadDotEnvSlingFrom(filepath.Dir(absPath))
 
 	switch kind {
 	case KindReplication:
 		cfg, err := sling.LoadReplicationConfigFromFile(absPath)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if err = cfg.Compile(nil); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return Redact(compiledReplication(cfg)), nil
+		return Redact(compiledReplication(cfg)), nil, nil
 	case KindPipeline:
 		pipeline, err := sling.LoadPipelineConfigFromFile(absPath)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if err := validatePipelineSteps(pipeline.Steps, ""); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		dto := PipelineDTO{Steps: pipeline.Steps, Env: pipeline.Env}
-		return Redact(dtoToMap(dto)), nil
+		return Redact(dtoToMap(dto)), nil, nil
 	case KindBuild:
 		projDir := absPath
 		if isBuildConfigName(filepath.Base(absPath)) {
 			projDir = filepath.Dir(absPath)
 		}
-		project, err := build.LoadProject(projDir)
+		project, err := build.LoadProject(projDir, build.BuildOptions{SkipUnresolvedCheck: true})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return Redact(compiledBuild(project)), nil
+		var warnings []string
+		for _, name := range project.UnresolvedConfigVars() {
+			warnings = append(warnings, fmt.Sprintf("sling_build.yml uses ${%s} but %s is not set", name, name))
+		}
+		return Redact(compiledBuild(project)), warnings, nil
 	default:
-		return parseDTO(kind, body)
+		parsed, err := parseDTO(kind, body)
+		return parsed, nil, err
 	}
 }
 

--- a/core/sling/validate/validate_test.go
+++ b/core/sling/validate/validate_test.go
@@ -128,6 +128,12 @@ func TestDetectFileKindOrder(t *testing.T) {
 			want: KindBuild,
 		},
 		{
+			name: "sling_build.yaml path rule",
+			body: "target: POSTGRES\ndefaults:\n  mode: full-refresh\n",
+			path: "sling_build.yaml",
+			want: KindBuild,
+		},
+		{
 			name: "unknown yaml stays unknown",
 			body: "services:\n  db:\n    image: postgres\n",
 			path: "docker-compose.yml",
@@ -156,6 +162,19 @@ func TestDetectFileKindBuildDir(t *testing.T) {
 	got := DetectFileKind(nil, dir)
 	if got != KindBuild {
 		t.Fatalf("directory with sling_build.yml: got %q want %q", got, KindBuild)
+	}
+}
+
+func TestDetectFileKindBuildDirYAML(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sling_build.yaml")
+	if err := os.WriteFile(path, []byte("target: POSTGRES\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got := DetectFileKind(nil, dir)
+	if got != KindBuild {
+		t.Fatalf("directory with sling_build.yaml: got %q want %q", got, KindBuild)
 	}
 }
 

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -26,6 +26,10 @@ func init() {
 			StoreSetPipelineExec(v)
 		case *sling.PipelineStepExecution:
 			StoreSetPipelineExec(v.Pipeline)
+		case *BuildStatus:
+			StoreSetBuildExec(v)
+		case *BuildModelStatus:
+			StoreSetBuildModelExec(v)
 		}
 		return nil
 	}
@@ -266,4 +270,12 @@ func StoreSetReplicationExec(t *sling.TaskExecution) {
 
 func StoreSetPipelineExec(pl *sling.Pipeline) {
 	syncStatus(pl)
+}
+
+func StoreSetBuildExec(bs *BuildStatus) {
+	syncStatus(bs)
+}
+
+func StoreSetBuildModelExec(ms *BuildModelStatus) {
+	syncStatus(ms)
 }

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -272,6 +272,65 @@ func StoreSetPipelineExec(pl *sling.Pipeline) {
 	syncStatus(pl)
 }
 
+// BuildStatus is the parent-level build run payload
+type BuildStatus struct {
+	ProjectID    *string          `json:"project_id,omitempty"`
+	JobID        string           `json:"job_id,omitempty"`
+	ExecID       string           `json:"exec_id,omitempty"`
+	FileName     *string          `json:"file_name"`
+	Target       string           `json:"target,omitempty"`
+	Select       []string         `json:"select,omitempty"`
+	Exclude      []string         `json:"exclude,omitempty"`
+	FullRefresh  bool             `json:"full_refresh,omitempty"`
+	Status       sling.ExecStatus `json:"status,omitempty"`
+	Error        *string          `json:"error,omitempty"`
+	ExitCode     int              `json:"exit_code,omitempty"`
+	ModelCount   int              `json:"model_count"`
+	OkCount      int              `json:"ok_count"`
+	FailedCount  int              `json:"failed_count"`
+	SkippedCount int              `json:"skipped_count"`
+	Rows         uint64           `json:"rows,omitempty"`
+	Bytes        uint64           `json:"bytes,omitempty"`
+	Tries        int              `json:"tries,omitempty"`
+	NewLines     g.LogLines       `json:"new_lines,omitempty"`
+
+	TimeNs       int64          `json:"time_ns,omitempty"`
+	StartTimeNs  *int64         `json:"start_time_ns,omitempty"`
+	EndTimeNs    *int64         `json:"end_time_ns,omitempty"`
+	TelemetryMap map[string]any `json:"telemetry_map,omitempty"`
+	Hostname     string         `json:"hostname,omitempty"`
+	AgentID      string         `json:"agent_id,omitempty"`
+	TryNumber    int            `json:"try_number,omitempty"`
+}
+
+// BuildModelStatus is the per-model/seed/test payload.
+type BuildModelStatus struct {
+	ProjectID  *string          `json:"project_id,omitempty"`
+	JobID      string           `json:"job_id,omitempty"`
+	ExecID     string           `json:"exec_id,omitempty"`
+	FileName   *string          `json:"file_name"`
+	Target     string           `json:"target,omitempty"`
+	ModelName  string           `json:"model_name"`
+	NodeType   string           `json:"node_type,omitempty"`
+	ObjectName string           `json:"object_name,omitempty"`
+	Mode       string           `json:"mode,omitempty"`
+	Status     sling.ExecStatus `json:"status,omitempty"`
+	Error      *string          `json:"error,omitempty"`
+	Rows       uint64           `json:"rows,omitempty"`
+	Bytes      uint64           `json:"bytes,omitempty"`
+	Order      int              `json:"order,omitempty"`
+	Tries      int              `json:"tries,omitempty"`
+	NewLines   g.LogLines       `json:"new_lines,omitempty"`
+
+	TimeNs       int64          `json:"time_ns,omitempty"`
+	StartTimeNs  *int64         `json:"start_time_ns,omitempty"`
+	EndTimeNs    *int64         `json:"end_time_ns,omitempty"`
+	TelemetryMap map[string]any `json:"telemetry_map,omitempty"`
+	Hostname     string         `json:"hostname,omitempty"`
+	AgentID      string         `json:"agent_id,omitempty"`
+	TryNumber    int            `json:"try_number,omitempty"`
+}
+
 func StoreSetBuildExec(bs *BuildStatus) {
 	syncStatus(bs)
 }

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -285,6 +285,7 @@ type BuildStatus struct {
 	Status       sling.ExecStatus `json:"status,omitempty"`
 	Error        *string          `json:"error,omitempty"`
 	ExitCode     int              `json:"exit_code,omitempty"`
+	Version      string           `json:"version,omitempty"`
 	ModelCount   int              `json:"model_count"`
 	OkCount      int              `json:"ok_count"`
 	FailedCount  int              `json:"failed_count"`

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/exasol/exasol-driver-go v1.0.14
 	github.com/fatih/color v1.18.0
 	github.com/flarco/bigquery v0.0.9
-	github.com/flarco/g v0.1.178
+	github.com/flarco/g v0.1.179
 	github.com/getsentry/sentry-go v0.27.0
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/gobwas/glob v0.2.3

--- a/tests/build/column_store_modes_project/sling_build.yml
+++ b/tests/build/column_store_modes_project/sling_build.yml
@@ -1,0 +1,7 @@
+target: CLICKHOUSE
+
+defaults:
+  mode: full-refresh
+
+vars:
+  extra: false

--- a/tests/build/column_store_modes_project/staging/events_append.sql
+++ b/tests/build/column_store_modes_project/staging/events_append.sql
@@ -1,0 +1,7 @@
+{%- config(mode='append') -%}
+
+SELECT
+    id,
+    name,
+    created_at
+FROM {{ ref('stg_events') }}

--- a/tests/build/column_store_modes_project/staging/events_inc.sql
+++ b/tests/build/column_store_modes_project/staging/events_inc.sql
@@ -1,0 +1,10 @@
+{%- config(mode='incremental', unique_key='id', merge_strategy='delete+insert', update_key='created_at') -%}
+
+SELECT
+    id,
+    name,
+    created_at
+FROM {{ ref('stg_events') }}
+{% if is_incremental() %}
+WHERE created_at > (SELECT max(created_at) FROM {{ this }})
+{% endif %}

--- a/tests/build/column_store_modes_project/staging/stg_events.sql
+++ b/tests/build/column_store_modes_project/staging/stg_events.sql
@@ -1,0 +1,7 @@
+SELECT 1 AS id, 'a' AS name, CAST('2024-01-01' AS DATE) AS created_at
+UNION ALL
+SELECT 2, 'b', CAST('2024-01-02' AS DATE)
+{% if extra %}
+UNION ALL
+SELECT 3, 'c', CAST('2024-01-03' AS DATE)
+{% endif %}

--- a/tests/build/database_project/marts/core/dim_customers.sql
+++ b/tests/build/database_project/marts/core/dim_customers.sql
@@ -1,0 +1,1 @@
+select order_id as customer_id from staging.stg_orders

--- a/tests/build/database_project/marts/finance/revenue.sql
+++ b/tests/build/database_project/marts/finance/revenue.sql
@@ -1,0 +1,4 @@
+/**
+database: FIN_DB
+**/
+select customer_id from {{ ref('dim_customers') }}

--- a/tests/build/database_project/sling_build.yml
+++ b/tests/build/database_project/sling_build.yml
@@ -1,0 +1,8 @@
+target: SNOWFLAKE
+
+defaults:
+  database: ANALYTICS_DB
+
+dev:
+  schema: dev_test
+  database: SCRATCH_DB

--- a/tests/build/database_project/staging/stg_orders.sql
+++ b/tests/build/database_project/staging/stg_orders.sql
@@ -1,0 +1,1 @@
+select 1 as order_id

--- a/tests/build/defaults_expanded_project/staging/stg_orders.sql
+++ b/tests/build/defaults_expanded_project/staging/stg_orders.sql
@@ -2,4 +2,4 @@ SELECT
     1 AS id,
     'order_a' AS name,
     '2024-01-01'::timestamp AS updated_at
-WHERE {incremental_where_cond}
+WHERE {{ incremental_where_cond() }}

--- a/tests/build/duplicate_stems_project/a/events.sql
+++ b/tests/build/duplicate_stems_project/a/events.sql
@@ -1,0 +1,1 @@
+select 1 as id

--- a/tests/build/duplicate_stems_project/b/events.sql
+++ b/tests/build/duplicate_stems_project/b/events.sql
@@ -1,0 +1,1 @@
+select 2 as id

--- a/tests/build/duplicate_stems_project/sling_build.yml
+++ b/tests/build/duplicate_stems_project/sling_build.yml
@@ -1,0 +1,1 @@
+target: POSTGRES

--- a/tests/build/hooks_project/sling_build.yml
+++ b/tests/build/hooks_project/sling_build.yml
@@ -2,3 +2,4 @@ target: POSTGRES
 
 defaults:
   mode: full-refresh
+  schema: build_hooks # own schema: model stems collide with sample_project

--- a/tests/build/nested_yml_project/sling_build.yml
+++ b/tests/build/nested_yml_project/sling_build.yml
@@ -2,3 +2,4 @@ target: POSTGRES
 
 defaults:
   mode: full-refresh
+  schema: build_nested # own schema: model stems collide with sample_project

--- a/tests/build/pipeline_step_project/sling_build.yml
+++ b/tests/build/pipeline_step_project/sling_build.yml
@@ -2,6 +2,7 @@ target: POSTGRES
 
 defaults:
   mode: full-refresh
+  schema: build_pipeline_step # own schema: model stems collide with sample_project
 
 vars:
   run_label: default

--- a/tests/build/range_bad_mixed_style/staging/bad_model.sql
+++ b/tests/build/range_bad_mixed_style/staging/bad_model.sql
@@ -7,4 +7,4 @@ SELECT 1 AS id, '2024-01-01'::date AS created_at
 {% if is_incremental() %}
 WHERE created_at > (SELECT MAX(created_at) FROM {{ this }})
 {% endif %}
-AND {incremental_where_cond}
+AND {{ incremental_where_cond() }}

--- a/tests/build/range_bad_start_no_advance/staging/bad_model.sql
+++ b/tests/build/range_bad_start_no_advance/staging/bad_model.sql
@@ -6,4 +6,4 @@ range:
   start: '2024-01-01'
 **/
 SELECT 1 AS id, '2024-01-01'::date AS created_at
-WHERE {incremental_where_cond}
+WHERE {{ incremental_where_cond() }}

--- a/tests/build/range_test_project/range_test/fact_orders.sql
+++ b/tests/build/range_test_project/range_test/fact_orders.sql
@@ -6,4 +6,4 @@ merge_strategy: delete+insert
 **/
 SELECT id, name, created_at::date AS created_at
 FROM {{ ref('stg_orders') }}
-WHERE {incremental_where_cond}
+WHERE {{ incremental_where_cond() }}

--- a/tests/build/range_test_project/range_test/fact_orders_lookback.sql
+++ b/tests/build/range_test_project/range_test/fact_orders_lookback.sql
@@ -8,4 +8,4 @@ range:
 **/
 SELECT id, name, created_at::date AS created_at
 FROM {{ ref('stg_orders') }}
-WHERE {incremental_where_cond}
+WHERE {{ incremental_where_cond() }}

--- a/tests/build/range_test_project/range_test/fact_orders_paged.sql
+++ b/tests/build/range_test_project/range_test/fact_orders_paged.sql
@@ -8,4 +8,4 @@ range:
 **/
 SELECT id, name, created_at::date AS created_at
 FROM {{ ref('stg_orders') }}
-WHERE {incremental_where_cond}
+WHERE {{ incremental_where_cond() }}

--- a/tests/build/range_test_project/range_test/fact_orders_paged_start.sql
+++ b/tests/build/range_test_project/range_test/fact_orders_paged_start.sql
@@ -9,4 +9,4 @@ range:
 **/
 SELECT id, name, created_at::date AS created_at
 FROM {{ ref('stg_orders') }}
-WHERE {incremental_where_cond}
+WHERE {{ incremental_where_cond() }}

--- a/tests/evals/cases/e.31.build_range_backfill/seed/marts/fct_orders.sql
+++ b/tests/evals/cases/e.31.build_range_backfill/seed/marts/fct_orders.sql
@@ -13,4 +13,4 @@ select
   o_orderdate::date as order_date,
   o_totalprice as total_price
 from orders
-where {incremental_where_cond}
+where {{ incremental_where_cond() }}

--- a/tests/evals/graders.go
+++ b/tests/evals/graders.go
@@ -261,9 +261,8 @@ func gradeSling(ctx GradeContext, cmd string) GraderResult {
 		if rest := fields[1:]; len(rest) > 0 && rest[0] == "run" && ctx.SkipExecute {
 			return GraderResult{Name: "sling:" + cmd, Pass: true, Skip: true, Detail: "SKIPPED (mock: no execute)"}
 		}
-		fields = rewriteBuildArgs(fields)
 	}
-	// Exec the real sling binary for everything else (build --compile, conns, …).
+	// Exec the real sling binary for everything else (build compile, conns, …).
 	if ctx.SlingBin == "" {
 		return GraderResult{Name: "sling:" + cmd, Pass: false, Detail: "SLING_BIN not set"}
 	}
@@ -278,28 +277,6 @@ func gradeSling(ctx GradeContext, cmd string) GraderResult {
 		return GraderResult{Name: "sling:" + cmd, Pass: false, Detail: strings.TrimSpace(buf.String()) + " " + err.Error()}
 	}
 	return GraderResult{Name: "sling:" + cmd, Pass: true, Detail: strings.TrimSpace(buf.String())}
-}
-
-func rewriteBuildArgs(fields []string) []string {
-	// sling: build compile .  →  sling build --compile --json .
-	// sling: build run . --target X  →  sling build --target X .
-	if len(fields) < 2 {
-		return fields
-	}
-	out := []string{"build"}
-	rest := fields[1:]
-	switch rest[0] {
-	case "compile":
-		out = append(out, "--compile", "--json")
-		if len(rest) > 1 {
-			out = append(out, rest[1:]...)
-		}
-		return out
-	case "run":
-		out = append(out, rest[1:]...)
-		return out
-	}
-	return fields
 }
 
 func gradeAPISpecMap(ctx GradeContext, raw any) GraderResult {
@@ -1313,7 +1290,7 @@ func gradeDAG(ctx GradeContext, raw any) GraderResult {
 	if dir == "" {
 		dir = "."
 	}
-	c := exec.Command(ctx.SlingBin, "build", "--compile", "--json", dir)
+	c := exec.Command(ctx.SlingBin, "build", "compile", "--json", dir)
 	c.Dir = ctx.WorkDir
 	c.Env = ctx.Env
 	var buf bytes.Buffer
@@ -1372,7 +1349,7 @@ func gradeTestsPass(ctx GradeContext, raw any) GraderResult {
 		}
 		target = cast.ToString(m["target"])
 	}
-	args := []string{"build", "--compile", "--json", dir}
+	args := []string{"build", "compile", "--json", dir}
 	c := exec.Command(ctx.SlingBin, args...)
 	c.Dir = ctx.WorkDir
 	c.Env = ctx.Env
@@ -1386,7 +1363,7 @@ func gradeTestsPass(ctx GradeContext, raw any) GraderResult {
 	if nTests == 0 {
 		return GraderResult{Name: "tests_pass", Pass: false, Detail: "no declarative tests defined"}
 	}
-	runArgs := []string{"build", "--test"}
+	runArgs := []string{"build", "test"}
 	if target != "" {
 		runArgs = append(runArgs, "--target", target)
 	}

--- a/tests/pipelines/p.28.platform_cli.yaml
+++ b/tests/pipelines/p.28.platform_cli.yaml
@@ -46,7 +46,7 @@ steps:
   - log: '=== Platform CLI: exec list default ==='
 
   - id: exec_list_table
-    command: sling platform execs list
+    command: sling platform executions list
 
   - check: 'contains(state.exec_list_table.output.stdout, "EXEC ID")'
     failure_message: 'exec list (table) missing header'
@@ -54,7 +54,7 @@ steps:
   - log: '=== Platform CLI: exec list -o json ==='
 
   - id: exec_list_json
-    command: sling platform execs list -o json --limit 5
+    command: sling platform executions list -o json --limit 5
 
   - check: contains(state.exec_list_json.output.stdout, "exec_id")
     failure_message: 'exec list (json) missing exec_id key'
@@ -62,7 +62,7 @@ steps:
   - log: '=== Platform CLI: exec list --job-id filter ==='
 
   - id: exec_list_jobfilter
-    command: sling platform execs list --job-id {env.JOB_ID} --limit 3
+    command: sling platform executions list --job-id {env.JOB_ID} --limit 3
 
   - check: 'contains(state.exec_list_jobfilter.output.stdout, "job_0vnx9sjkjzmd95nh")'
     failure_message: 'exec list --job-id filter missing job id in results'

--- a/tests/pipelines/p.45.build_step.yaml
+++ b/tests/pipelines/p.45.build_step.yaml
@@ -41,12 +41,12 @@ steps:
     query: |
       SELECT count(*) AS cnt,
              max(run_label) AS run_label
-      FROM marts.fct_orders
+      FROM build_pipeline_step.fct_orders
     into: fct
 
   - type: check
     check: store.fct[0].cnt == 2
-    failure_message: 'expected 2 rows in marts.fct_orders'
+    failure_message: 'expected 2 rows in build_pipeline_step.fct_orders'
 
   - type: check
     check: store.fct[0].run_label == "from_pipeline"
@@ -71,7 +71,7 @@ steps:
 
   - type: query
     connection: POSTGRES
-    query: SELECT max(run_label) AS run_label FROM staging.stg_orders
+    query: SELECT max(run_label) AS run_label FROM build_pipeline_step.stg_orders
     into: stg_shortcut
 
   - type: check
@@ -85,5 +85,5 @@ steps:
   - type: query
     connection: POSTGRES
     query: |
-      DROP TABLE IF EXISTS marts.fct_orders;
-      DROP TABLE IF EXISTS staging.stg_orders;
+      DROP TABLE IF EXISTS build_pipeline_step.fct_orders;
+      DROP TABLE IF EXISTS build_pipeline_step.stg_orders;

--- a/tests/pipelines/p.45.build_step.yaml
+++ b/tests/pipelines/p.45.build_step.yaml
@@ -32,6 +32,10 @@ steps:
     check: state.build.ok >= 2
     failure_message: 'expected ok >= 2, got {state.build.ok}'
 
+  - type: check
+    check: state.build.rows == 4
+    failure_message: 'expected 4 rows from stg_orders+fct_orders, got {state.build.rows}'
+
   - type: query
     connection: POSTGRES
     query: |
@@ -61,6 +65,10 @@ steps:
     check: state.build_shortcut.ok >= 1
     failure_message: 'shortcut build: form did not run'
 
+  - type: check
+    check: state.build_shortcut.rows == 2
+    failure_message: 'expected 2 rows from stg_orders shortcut, got {state.build_shortcut.rows}'
+
   - type: query
     connection: POSTGRES
     query: SELECT max(run_label) AS run_label FROM staging.stg_orders
@@ -71,7 +79,7 @@ steps:
     failure_message: 'shortcut build vars not applied'
 
   - type: log
-    message: 'SUCCESS: pipeline type:build step completed (rows={store.fct[0].cnt}, label={store.fct[0].run_label})'
+    message: 'SUCCESS: pipeline type:build step completed (rows={store.fct[0].cnt}, build_rows={state.build.rows}, label={store.fct[0].run_label})'
 
   # Cleanup
   - type: query

--- a/tests/pipelines/p.46.build_step_replication_hook.yaml
+++ b/tests/pipelines/p.46.build_step_replication_hook.yaml
@@ -29,7 +29,7 @@ hooks:
 
     - type: query
       connection: '{target.name}'
-      query: SELECT count(*) AS cnt, max(run_label) AS run_label FROM staging.stg_orders
+      query: SELECT count(*) AS cnt, max(run_label) AS run_label FROM build_pipeline_step.stg_orders
       into: stg
 
     - type: check
@@ -50,8 +50,8 @@ hooks:
     - type: query
       connection: '{target.name}'
       query: |
-        DROP TABLE IF EXISTS staging.stg_orders;
-        DROP TABLE IF EXISTS marts.fct_orders;
+        DROP TABLE IF EXISTS build_pipeline_step.stg_orders;
+        DROP TABLE IF EXISTS build_pipeline_step.fct_orders;
         DROP TABLE IF EXISTS build_hook.raw_src;
 
 streams:

--- a/tests/pipelines/p.46.build_step_replication_hook.yaml
+++ b/tests/pipelines/p.46.build_step_replication_hook.yaml
@@ -40,8 +40,12 @@ hooks:
       check: state.transform.ok >= 1
       failure_message: 'transform step state missing ok count'
 
+    - type: check
+      check: state.transform.rows == 2
+      failure_message: 'expected 2 rows from stg_orders, got {state.transform.rows}'
+
     - type: log
-      message: 'SUCCESS: replication end-hook type:build ok (rows={store.stg[0].cnt}, label={store.stg[0].run_label})'
+      message: 'SUCCESS: replication end-hook type:build ok (rows={store.stg[0].cnt}, build_rows={state.transform.rows}, label={store.stg[0].run_label})'
 
     - type: query
       connection: '{target.name}'

--- a/tests/pipelines/p.47.build_step_command.yaml
+++ b/tests/pipelines/p.47.build_step_command.yaml
@@ -1,0 +1,33 @@
+# Pipeline type: build with command: compile | list (no materialization).
+steps:
+  - type: build
+    id: compile
+    build: tests/build/pipeline_step_project
+    target: POSTGRES
+    command: compile
+    select: stg_orders
+
+  - type: check
+    check: state.compile.total >= 1
+    failure_message: 'compile command did not select models, total={state.compile.total}'
+
+  - type: check
+    check: state.compile.command == "compile"
+    failure_message: 'expected command=compile, got {state.compile.command}'
+
+  - type: build
+    id: listed
+    build: tests/build/pipeline_step_project
+    command: list
+    select: stg_orders
+
+  - type: check
+    check: state.listed.total >= 1
+    failure_message: 'list command did not select models, total={state.listed.total}'
+
+  - type: check
+    check: state.listed.command == "list"
+    failure_message: 'expected command=list, got {state.listed.command}'
+
+  - type: log
+    message: 'SUCCESS: pipeline build command compile+list ok total={state.compile.total}'

--- a/tests/pipelines/p.48.build_step_bad_command.yaml
+++ b/tests/pipelines/p.48.build_step_bad_command.yaml
@@ -1,0 +1,6 @@
+# command: test rejects run-only keys (full_refresh).
+steps:
+  - type: build
+    build: tests/build/pipeline_step_project
+    command: test
+    full_refresh: true

--- a/tests/pipelines/p.49.build_clickhouse_incremental_rows.yaml
+++ b/tests/pipelines/p.49.build_clickhouse_incremental_rows.yaml
@@ -1,0 +1,104 @@
+# ClickHouse incremental must count the staging temp table before the merge.
+#
+# The merge consumes that table, and on ClickHouse it is ENGINE = Memory.
+# Counting it after the merge reads back empty, so the model reports 0 rows even
+# though the data landed. A row total alone does not catch this: with a small
+# fixture the merge finishes before the table empties, and the count comes back
+# right by luck. So assert the operation order from system.query_log as well.
+steps:
+  - type: query
+    connection: CLICKHOUSE
+    query: |
+      CREATE DATABASE IF NOT EXISTS staging;
+      DROP TABLE IF EXISTS staging.stg_events;
+      DROP TABLE IF EXISTS staging.events_inc;
+
+  # Seed: 2 source rows, materialized full-refresh.
+  - type: build
+    id: seed
+    build: tests/build/column_store_modes_project
+    target: CLICKHOUSE
+    full_refresh: true
+    select: '+events_inc'
+
+  - type: check
+    check: state.seed.failed == 0
+    failure_message: 'seed build failed: {state.seed.failed}'
+
+  # Mark the boundary so only the incremental run below is inspected. The seed
+  # build issues the same statements and would otherwise be counted.
+  - type: query
+    connection: CLICKHOUSE
+    query: SELECT toString(now64(3)) AS marker
+    into: mark
+
+  # Incremental: extra=true adds 1 new row, merged with delete+insert.
+  - type: build
+    id: incremental
+    build: tests/build/column_store_modes_project
+    target: CLICKHOUSE
+    select: '+events_inc'
+    vars:
+      extra: true
+
+  - type: check
+    check: state.incremental.failed == 0
+    failure_message: 'incremental build failed: {state.incremental.failed}'
+
+  # stg_events full-refresh 3 + events_inc temp table 1 = 4.
+  # Counting after the merge gives 3 + 0 = 3.
+  - type: check
+    check: state.incremental.rows == 4
+    failure_message: 'expected 4 rows (3 stg + 1 staged), got {state.incremental.rows}'
+
+  # system.query_log flushes on its own (7.5s by default). SYSTEM FLUSH LOGS
+  # drops the connection through this driver, so wait it out instead.
+  - type: command
+    command: [sleep, "10"]
+
+  # COUNT_FIRST when the temp table is counted before the merge consumes it.
+  - type: query
+    connection: CLICKHOUSE
+    query: |
+      SELECT multiIf(
+               countIf(kind = 'merge') = 0, 'NO_MERGE',
+               countIf(kind = 'cnt') = 0, 'MERGE_FIRST',
+               minIf(t, kind = 'cnt') < minIf(t, kind = 'merge'), 'COUNT_FIRST',
+               'MERGE_FIRST') AS verdict
+      FROM (
+        SELECT event_time_microseconds AS t,
+               multiIf(query ILIKE '%count(%_sling_build_tmp_events_inc%', 'cnt',
+                       query ILIKE '%ALTER TABLE%events_inc%DELETE%', 'merge',
+                       'other') AS kind
+        FROM system.query_log
+        WHERE type = 'QueryStart'
+          AND event_time_microseconds >= toDateTime64('{store.mark[0].marker}', 3)
+          AND (query ILIKE '%count(%_sling_build_tmp_events_inc%'
+               OR query ILIKE '%ALTER TABLE%events_inc%DELETE%')
+      )
+      WHERE kind != 'other'
+    into: order_check
+
+  - type: check
+    check: store.order_check[0].verdict == "COUNT_FIRST"
+    failure_message: 'temp table was counted after the merge consumed it ({store.order_check[0].verdict})'
+
+  # The data must actually be in the target, so a wrong count cannot be
+  # mistaken for a genuinely empty merge.
+  - type: query
+    connection: CLICKHOUSE
+    query: SELECT toInt32(count(*)) AS cnt FROM staging.events_inc
+    into: tgt
+
+  - type: check
+    check: int_parse(store.tgt[0].cnt) == 3
+    failure_message: 'expected 3 rows in staging.events_inc, got {store.tgt[0].cnt}'
+
+  - type: log
+    message: 'SUCCESS: clickhouse incremental reported rows={state.incremental.rows} target={store.tgt[0].cnt} order={store.order_check[0].verdict}'
+
+  - type: query
+    connection: CLICKHOUSE
+    query: |
+      DROP TABLE IF EXISTS staging.stg_events;
+      DROP TABLE IF EXISTS staging.events_inc;

--- a/tests/suite.cli.build.yaml
+++ b/tests/suite.cli.build.yaml
@@ -164,7 +164,7 @@
     sling build run tests/build/range_test_project --target POSTGRES -s fact_orders --debug
   output_contains:
     - 'incremental'
-    - 'tier B'
+    - 'target MAX'
     - 'SELECT MAX('
     - 'Build Completed'
 

--- a/tests/suite.cli.build.yaml
+++ b/tests/suite.cli.build.yaml
@@ -495,6 +495,7 @@
     - 'Build Completed'
     - 'SUCCESS: pipeline type:build step completed'
     - 'rows=2'
+    - 'build_rows=4'
     - 'label=from_pipeline'
     - 'build total='
 
@@ -507,6 +508,7 @@
     - 'Build Completed'
     - 'SUCCESS: replication end-hook type:build ok'
     - 'rows=2'
+    - 'build_rows=2'
     - 'label=from_repl_hook'
 
 - id: 439
@@ -518,11 +520,92 @@
     rm -f temp/duckdb_parallel/test.duckdb
     sling build tests/build/duckdb_parallel_project --target DUCK_PARALLEL --full-refresh --threads 4
   group: build
+  rows: 5
   output_contains:
     - 'OK'
     - 'Build Completed'
   output_does_not_contain:
     - 'Conflicting lock'
     - 'Could not set lock'
+
+- id: 440
+  name: 'sling build execute clickhouse_project full-refresh row count'
+  group: build
+  run: |
+    SLING_ROW_CNT= sling conns exec CLICKHOUSE "CREATE DATABASE IF NOT EXISTS staging"
+    SLING_ROW_CNT= sling conns exec CLICKHOUSE "CREATE DATABASE IF NOT EXISTS marts"
+    sling build tests/build/clickhouse_project --target CLICKHOUSE --full-refresh
+  rows: 4
+  output_contains:
+    - 'stg_orders'
+    - 'fct_orders'
+    - 'OK'
+    - 'Build Completed'
+
+# Column-store incremental/append: COUNT(*) the staging temp table.
+# Incremental with extra=true: stg full-refresh 3 + temp 1 new row = 4
+# (target-after-merge would be 3+3=6; no count would be 3+0=3).
+# Append second run: stg full-refresh 2 + temp 2 = 4
+# (target-after-insert would be 2+4=6; no count would be 2+0=2).
+
+- id: 441
+  name: 'sling build duckdb incremental counts temp table rows'
+  group: build
+  env:
+    DUCK_MODES: '{type: duckdb, instance: "temp/duckdb_modes/inc.duckdb"}'
+  run: |
+    mkdir -p temp/duckdb_modes
+    rm -f temp/duckdb_modes/inc.duckdb
+    SLING_ROW_CNT= sling build tests/build/column_store_modes_project --target DUCK_MODES --full-refresh -s "+events_inc"
+    sling build tests/build/column_store_modes_project --target DUCK_MODES --vars 'extra: true' -s "+events_inc"
+  rows: 4
+  output_contains:
+    - 'OK'
+    - 'Build Completed'
+
+- id: 442
+  name: 'sling build duckdb append counts temp table rows'
+  group: build
+  env:
+    DUCK_MODES: '{type: duckdb, instance: "temp/duckdb_modes/append.duckdb"}'
+  run: |
+    mkdir -p temp/duckdb_modes
+    rm -f temp/duckdb_modes/append.duckdb
+    SLING_ROW_CNT= sling build tests/build/column_store_modes_project --target DUCK_MODES --full-refresh -s "+events_append"
+    sling build tests/build/column_store_modes_project --target DUCK_MODES -s "+events_append"
+  rows: 4
+  output_contains:
+    - 'OK'
+    - 'Build Completed'
+
+- id: 443
+  name: 'sling build clickhouse incremental counts temp table rows'
+  group: build
+  after: [440]
+  run: |
+    SLING_ROW_CNT= sling conns exec CLICKHOUSE "CREATE DATABASE IF NOT EXISTS staging"
+    SLING_ROW_CNT= sling conns exec CLICKHOUSE "DROP TABLE IF EXISTS staging.stg_events"
+    SLING_ROW_CNT= sling conns exec CLICKHOUSE "DROP TABLE IF EXISTS staging.events_inc"
+    SLING_ROW_CNT= sling build tests/build/column_store_modes_project --target CLICKHOUSE --full-refresh -s "+events_inc"
+    sling build tests/build/column_store_modes_project --target CLICKHOUSE --vars 'extra: true' -s "+events_inc"
+  rows: 4
+  output_contains:
+    - 'OK'
+    - 'Build Completed'
+
+- id: 444
+  name: 'sling build clickhouse append counts temp table rows'
+  group: build
+  after: [440]
+  run: |
+    SLING_ROW_CNT= sling conns exec CLICKHOUSE "CREATE DATABASE IF NOT EXISTS staging"
+    SLING_ROW_CNT= sling conns exec CLICKHOUSE "DROP TABLE IF EXISTS staging.stg_events"
+    SLING_ROW_CNT= sling conns exec CLICKHOUSE "DROP TABLE IF EXISTS staging.events_append"
+    SLING_ROW_CNT= sling build tests/build/column_store_modes_project --target CLICKHOUSE --full-refresh -s "+events_append"
+    sling build tests/build/column_store_modes_project --target CLICKHOUSE -s "+events_append"
+  rows: 4
+  output_contains:
+    - 'OK'
+    - 'Build Completed'
 
 

--- a/tests/suite.cli.build.yaml
+++ b/tests/suite.cli.build.yaml
@@ -593,6 +593,16 @@
     - 'OK'
     - 'Build Completed'
 
+- id: 462
+  name: 'sling build clickhouse incremental counts temp table before merge'
+  group: build
+  after: [440]
+  run: 'sling run -p tests/pipelines/p.49.build_clickhouse_incremental_rows.yaml'
+  output_contains:
+    - 'SUCCESS: clickhouse incremental reported'
+    - 'rows=4'
+    - 'target=3'
+
 - id: 444
   name: 'sling build clickhouse append counts temp table rows'
   group: build

--- a/tests/suite.cli.build.yaml
+++ b/tests/suite.cli.build.yaml
@@ -2,7 +2,7 @@
 
 - id: 400
   name: 'sling build execute nested_yml_project with config inheritance'
-  run: 'sling build tests/build/nested_yml_project --target POSTGRES --full-refresh'
+  run: 'sling build run tests/build/nested_yml_project --target POSTGRES --full-refresh'
   group: build
   output_contains:
     - 'OK'
@@ -11,7 +11,7 @@
 
 - id: 401
   name: 'sling build execute dbt_compat_project'
-  run: 'sling build tests/build/dbt_compat_project --target POSTGRES --full-refresh'
+  run: 'sling build run tests/build/dbt_compat_project --target POSTGRES --full-refresh'
   group: build
   after: [400]
   output_contains:
@@ -22,7 +22,7 @@
 
 - id: 402
   name: 'sling build execute -R multi_target_project'
-  run: 'sling build tests/build/multi_target_project -R --full-refresh'
+  run: 'sling build run tests/build/multi_target_project -R --full-refresh'
   group: build
   after: [401]
   output_contains:
@@ -35,7 +35,7 @@
 
 - id: 403
   name: 'sling build --compile multi_statement_project shows pre/post'
-  run: 'sling build tests/build/multi_statement_project --compile --target POSTGRES'
+  run: 'sling build compile tests/build/multi_statement_project --target POSTGRES'
   output_contains:
     - 'stg_multi'
     - 'mode: full-refresh'
@@ -48,7 +48,7 @@
 
 - id: 404
   name: 'sling build execute multi_statement_project'
-  run: 'sling build tests/build/multi_statement_project --target POSTGRES --full-refresh'
+  run: 'sling build run tests/build/multi_statement_project --target POSTGRES --full-refresh'
   group: build
   after: [402]
   output_contains:
@@ -60,7 +60,7 @@
 
 - id: 405
   name: 'sling build --compile macro_project shows expanded macros'
-  run: 'sling build tests/build/macro_project --compile --target POSTGRES'
+  run: 'sling build compile tests/build/macro_project --target POSTGRES'
   output_contains:
     - 'stg_products'
     - 'product_margins'
@@ -74,7 +74,7 @@
 
 - id: 406
   name: 'sling build execute macro_project'
-  run: 'sling build tests/build/macro_project --target POSTGRES --full-refresh'
+  run: 'sling build run tests/build/macro_project --target POSTGRES --full-refresh'
   output_contains:
     - 'stg_products'
     - 'product_margins'
@@ -85,7 +85,7 @@
 
 - id: 407
   name: 'sling build --compile hooks_project shows hooks'
-  run: 'sling build tests/build/hooks_project --compile --target POSTGRES'
+  run: 'sling build compile tests/build/hooks_project --target POSTGRES'
   output_contains:
     - 'stg_orders'
     - 'fct_orders'
@@ -100,7 +100,7 @@
 
 - id: 408
   name: 'sling build execute hooks_project'
-  run: 'sling build tests/build/hooks_project --target POSTGRES --full-refresh'
+  run: 'sling build run tests/build/hooks_project --target POSTGRES --full-refresh'
   group: build
   output_contains:
     - 'building stg_orders model'
@@ -114,7 +114,7 @@
 
 - id: 409
   name: 'sling build --compile range_test_project validates all models'
-  run: 'sling build tests/build/range_test_project --compile --target POSTGRES'
+  run: 'sling build compile tests/build/range_test_project --target POSTGRES'
   group: build
   output_contains:
     - 'range_test.stg_orders'
@@ -132,7 +132,7 @@
   run: |
     sling conns exec POSTGRES "DROP SCHEMA IF EXISTS range_test CASCADE; CREATE SCHEMA range_test"
     rm -rf tests/build/range_test_project/.sling_state/261
-    sling build tests/build/range_test_project --target POSTGRES --full-refresh
+    sling build run tests/build/range_test_project --target POSTGRES --full-refresh
   output_contains:
     - 'range_test.stg_orders'
     - 'range_test.fact_orders'
@@ -147,8 +147,8 @@
     SLING_STATE: LOCAL/tests/build/range_test_project/.sling_state/262
   run: |
     rm -rf tests/build/range_test_project/.sling_state/262
-    sling build tests/build/range_test_project --target POSTGRES --full-refresh -s fact_orders
-    sling build tests/build/range_test_project --target POSTGRES -s fact_orders --debug
+    sling build run tests/build/range_test_project --target POSTGRES --full-refresh -s fact_orders
+    sling build run tests/build/range_test_project --target POSTGRES -s fact_orders --debug
   output_contains:
     - 'incremental'
     - 'created_at" >'
@@ -160,8 +160,8 @@
   name: 'sling build plain incremental without SLING_STATE queries target MAX (tier B)'
   after: [411]
   run: |
-    sling build tests/build/range_test_project --target POSTGRES --full-refresh -s fact_orders
-    sling build tests/build/range_test_project --target POSTGRES -s fact_orders --debug
+    sling build run tests/build/range_test_project --target POSTGRES --full-refresh -s fact_orders
+    sling build run tests/build/range_test_project --target POSTGRES -s fact_orders --debug
   output_contains:
     - 'incremental'
     - 'tier B'
@@ -173,8 +173,8 @@
   name: 'sling build lookback-only uses inclusive bound with 2d offset'
   after: [412]
   run: |
-    sling build tests/build/range_test_project --target POSTGRES --full-refresh -s fact_orders_lookback
-    sling build tests/build/range_test_project --target POSTGRES -s fact_orders_lookback --debug
+    sling build run tests/build/range_test_project --target POSTGRES --full-refresh -s fact_orders_lookback
+    sling build run tests/build/range_test_project --target POSTGRES -s fact_orders_lookback --debug
   output_contains:
     - 'fact_orders_lookback'
     - 'created_at" >='
@@ -188,8 +188,8 @@
     SLING_STATE: LOCAL/tests/build/range_test_project/.sling_state/265
   run: |
     rm -rf tests/build/range_test_project/.sling_state/265
-    sling build tests/build/range_test_project --target POSTGRES --full-refresh -s fact_orders_paged_start
-    sling build tests/build/range_test_project --target POSTGRES -s fact_orders_paged_start --debug
+    sling build run tests/build/range_test_project --target POSTGRES --full-refresh -s fact_orders_paged_start
+    sling build run tests/build/range_test_project --target POSTGRES -s fact_orders_paged_start --debug
   output_contains:
     - 'fact_orders_paged_start'
     - '2024-01-01'
@@ -204,8 +204,8 @@
     SLING_STATE: LOCAL/tests/build/range_test_project/.sling_state/266
   run: |
     rm -rf tests/build/range_test_project/.sling_state/266
-    sling build tests/build/range_test_project --target POSTGRES --full-refresh -s fact_orders_paged
-    sling build tests/build/range_test_project --target POSTGRES -s fact_orders_paged --debug
+    sling build run tests/build/range_test_project --target POSTGRES --full-refresh -s fact_orders_paged
+    sling build run tests/build/range_test_project --target POSTGRES -s fact_orders_paged --debug
   output_contains:
     - 'fact_orders_paged'
     - 'SELECT MIN('
@@ -219,9 +219,9 @@
     SLING_STATE: LOCAL/tests/build/range_test_project/.sling_state/267
   run: |
     rm -rf tests/build/range_test_project/.sling_state/267
-    sling build tests/build/range_test_project --target POSTGRES --full-refresh -s fact_orders_paged_start
-    sling build tests/build/range_test_project --target POSTGRES -s fact_orders_paged_start
-    sling build tests/build/range_test_project --target POSTGRES -s fact_orders_paged_start --debug
+    sling build run tests/build/range_test_project --target POSTGRES --full-refresh -s fact_orders_paged_start
+    sling build run tests/build/range_test_project --target POSTGRES -s fact_orders_paged_start
+    sling build run tests/build/range_test_project --target POSTGRES -s fact_orders_paged_start --debug
   output_contains:
     - 'fact_orders_paged_start'
     - 'Build Completed'
@@ -232,7 +232,7 @@
   after: [416]
   run: |
     unset SLING_STATE
-    sling build tests/build/range_test_project --target POSTGRES -s fact_orders_paged_start
+    sling build run tests/build/range_test_project --target POSTGRES -s fact_orders_paged_start
   err: true
   output_contains:
     - 'range.advance requires SLING_STATE'
@@ -242,8 +242,8 @@
   name: 'sling build --range single chunk runs once'
   after: [417]
   run: |
-    sling build tests/build/range_test_project --target POSTGRES --full-refresh -s fact_orders
-    sling build tests/build/range_test_project --target POSTGRES \
+    sling build run tests/build/range_test_project --target POSTGRES --full-refresh -s fact_orders
+    sling build run tests/build/range_test_project --target POSTGRES \
       --range '2024-01-01,2024-02-01' -s fact_orders --debug
   output_contains:
     - 'fact_orders'
@@ -256,8 +256,8 @@
   name: 'sling build --range multi-chunk backfill shows per-chunk progress'
   after: [418]
   run: |
-    sling build tests/build/range_test_project --target POSTGRES --full-refresh -s fact_orders
-    sling build tests/build/range_test_project --target POSTGRES \
+    sling build run tests/build/range_test_project --target POSTGRES --full-refresh -s fact_orders
+    sling build run tests/build/range_test_project --target POSTGRES \
       --range '2024-01-01,2024-04-01,1mo' -s fact_orders --debug
   output_contains:
     - 'chunk 1/4'
@@ -274,10 +274,10 @@
     SLING_STATE: LOCAL/tests/build/range_test_project/.sling_state/271
   run: |
     rm -rf tests/build/range_test_project/.sling_state/271
-    sling build tests/build/range_test_project --target POSTGRES --full-refresh -s fact_orders_paged_start
-    sling build tests/build/range_test_project --target POSTGRES -s fact_orders_paged_start
+    sling build run tests/build/range_test_project --target POSTGRES --full-refresh -s fact_orders_paged_start
+    sling build run tests/build/range_test_project --target POSTGRES -s fact_orders_paged_start
     cp tests/build/range_test_project/.sling_state/271/*.json /tmp/sling_state_before_271.json
-    sling build tests/build/range_test_project --target POSTGRES \
+    sling build run tests/build/range_test_project --target POSTGRES \
       --range '2024-01-01,2024-01-08,7d' -s fact_orders_paged_start
     diff /tmp/sling_state_before_271.json tests/build/range_test_project/.sling_state/271/*.json
   output_contains:
@@ -287,7 +287,7 @@
 - id: 421
   name: 'sling build range.start requires range.advance validation error'
   group: build
-  run: 'sling build tests/build/range_bad_start_no_advance --compile --target POSTGRES'
+  run: 'sling build compile tests/build/range_bad_start_no_advance --target POSTGRES'
   err: true
   output_contains:
     - 'range.start requires range.advance'
@@ -296,7 +296,7 @@
 - id: 422
   name: 'sling build dbt-style + range.* validation error'
   group: build
-  run: 'sling build tests/build/range_bad_dbt_with_range --compile --target POSTGRES'
+  run: 'sling build compile tests/build/range_bad_dbt_with_range --target POSTGRES'
   err: true
   output_contains:
     - 'range.* requires incremental_where_cond()'
@@ -305,7 +305,7 @@
 - id: 423
   name: 'sling build mixed is_incremental + where_cond validation error'
   group: build
-  run: 'sling build tests/build/range_bad_mixed_style --compile --target POSTGRES'
+  run: 'sling build compile tests/build/range_bad_mixed_style --target POSTGRES'
   err: true
   output_contains:
     - 'cannot mix is_incremental() and incremental_where_cond()'
@@ -316,7 +316,7 @@
 - id: 424
   name: 'sling build --compile defaults_expanded_project layers defaults'
   group: build
-  run: 'sling build tests/build/defaults_expanded_project --compile --target POSTGRES --recursive'
+  run: 'sling build compile tests/build/defaults_expanded_project --target POSTGRES --recursive'
   output_contains:
     # stg_orders inherits root defaults.schema=raw (overrides folder schema)
     - 'table: raw.stg_orders'
@@ -347,17 +347,16 @@
   run: 'sling build --help'
   output_contains:
     - 'Build and execute SQL models'
-    - '--compile'
-    - '--target'
-    - '--select'
-    - '--full-refresh'
-    - '--schema'
+    - 'run'
+    - 'list'
+    - 'test'
+    - 'compile'
   output_does_not_contain:
     - '--init'
 
 - id: 426
   name: 'sling build --compile sample_project with target'
-  run: 'sling build tests/build/sample_project --compile --target POSTGRES'
+  run: 'sling build compile tests/build/sample_project --target POSTGRES'
   group: build
   output_contains:
     - 'DAG Execution Order:'
@@ -376,7 +375,7 @@
 
 - id: 427
   name: 'sling build --compile with selector stg_*'
-  run: 'sling build tests/build/sample_project --compile --target POSTGRES -s "stg_*"'
+  run: 'sling build compile tests/build/sample_project --target POSTGRES -s "stg_*"'
   group: build
   output_contains:
     - 'stg_customers (full-refresh)'
@@ -390,22 +389,22 @@
 
 - id: 428
   name: 'sling build --compile dev mode with --schema override'
-  run: 'sling build tests/build/sample_project --compile --target POSTGRES --schema dev_test'
+  run: 'sling build compile tests/build/sample_project --target POSTGRES --schema dev_test'
   group: build
   output_contains:
-    - 'dev_test.staging_stg_orders'
-    - 'dev_test.staging_stg_customers'
-    - 'dev_test.marts_core_dim_customers'
-    - 'dev_test.marts_core_fct_orders'
-    - 'dev_test.marts_finance_revenue'
+    - 'dev_test.stg_orders'
+    - 'dev_test.stg_customers'
+    - 'dev_test.dim_customers'
+    - 'dev_test.fct_orders'
+    - 'dev_test.revenue'
     - 'dev_test.raw'
-    - 'dev_test.staging_country_codes'
-    - 'dev_test.seeds_status_map'
+    - 'dev_test.country_codes'
+    - 'dev_test.status_map'
 
 
 - id: 429
   name: 'sling build --compile with upstream selector +revenue'
-  run: 'sling build tests/build/sample_project --compile --target POSTGRES -s "+revenue"'
+  run: 'sling build compile tests/build/sample_project --target POSTGRES -s "+revenue"'
   group: build
   output_contains:
     - 'stg_orders'
@@ -419,7 +418,7 @@
 
 - id: 430
   name: 'sling build --compile dbt_compat_project'
-  run: 'sling build tests/build/dbt_compat_project --compile --target POSTGRES'
+  run: 'sling build compile tests/build/dbt_compat_project --target POSTGRES'
   group: build
   output_contains:
     - 'stg_orders'
@@ -428,7 +427,7 @@
 
 - id: 431
   name: 'sling build --compile nested_yml_project inherits config'
-  run: 'sling build tests/build/nested_yml_project --compile --target POSTGRES --recursive'
+  run: 'sling build compile tests/build/nested_yml_project --target POSTGRES --recursive'
   group: build
   output_contains:
     - 'stg_orders (truncate)'
@@ -436,16 +435,18 @@
 
 
 - id: 432
-  name: 'sling build with no config and no target shows help'
-  run: 'sling build /tmp --compile'
+  name: 'sling build with no verb prints help'
+  run: 'sling build'
   output_contains:
     - 'Build and execute SQL models'
-    - '--recursive'
+    - 'run'
+    - 'list'
+    - 'compile'
 
 
 - id: 433
   name: 'sling build execute with selector'
-  run: 'sling build tests/build/sample_project --target POSTGRES --full-refresh -s "stg_*"'
+  run: 'sling build run tests/build/sample_project --target POSTGRES --full-refresh -s "stg_*"'
   group: build
   output_contains:
     - 'stg_orders'
@@ -457,7 +458,7 @@
 
 - id: 434
   name: 'sling build execute sample_project full-refresh'
-  run: 'sling build tests/build/sample_project --target POSTGRES --full-refresh'
+  run: 'sling build run tests/build/sample_project --target POSTGRES --full-refresh'
   group: build
   output_contains:
     - 'OK'
@@ -465,7 +466,7 @@
 
 - id: 435
   name: 'sling build second run (view and incremental modes)'
-  run: 'sling build tests/build/sample_project --target POSTGRES'
+  run: 'sling build run tests/build/sample_project --target POSTGRES'
   group: build
   after: [434]
   output_contains:
@@ -475,14 +476,13 @@
     - 'Build Completed'
 
 - id: 436
-  name: 'sling build --help shows range without short -r'
-  run: 'sling build --help'
+  name: 'sling build run --help shows range without short -r'
+  run: 'sling build run --help'
   output_contains:
-    - 'Build and execute SQL models'
+    - 'Materialize models'
     - '--range'
     - '--threads'
-    - '--test'
-    - '--json'
+    - '--full-refresh'
   output_does_not_contain:
     - '-r, --range'
 
@@ -518,7 +518,7 @@
   run: |
     mkdir -p temp/duckdb_parallel
     rm -f temp/duckdb_parallel/test.duckdb
-    sling build tests/build/duckdb_parallel_project --target DUCK_PARALLEL --full-refresh --threads 4
+    sling build run tests/build/duckdb_parallel_project --target DUCK_PARALLEL --full-refresh --threads 4
   group: build
   rows: 5
   output_contains:
@@ -534,7 +534,7 @@
   run: |
     SLING_ROW_CNT= sling conns exec CLICKHOUSE "CREATE DATABASE IF NOT EXISTS staging"
     SLING_ROW_CNT= sling conns exec CLICKHOUSE "CREATE DATABASE IF NOT EXISTS marts"
-    sling build tests/build/clickhouse_project --target CLICKHOUSE --full-refresh
+    sling build run tests/build/clickhouse_project --target CLICKHOUSE --full-refresh
   rows: 4
   output_contains:
     - 'stg_orders'
@@ -556,8 +556,8 @@
   run: |
     mkdir -p temp/duckdb_modes
     rm -f temp/duckdb_modes/inc.duckdb
-    SLING_ROW_CNT= sling build tests/build/column_store_modes_project --target DUCK_MODES --full-refresh -s "+events_inc"
-    sling build tests/build/column_store_modes_project --target DUCK_MODES --vars 'extra: true' -s "+events_inc"
+    SLING_ROW_CNT= sling build run tests/build/column_store_modes_project --target DUCK_MODES --full-refresh -s "+events_inc"
+    sling build run tests/build/column_store_modes_project --target DUCK_MODES --vars 'extra: true' -s "+events_inc"
   rows: 4
   output_contains:
     - 'OK'
@@ -571,8 +571,8 @@
   run: |
     mkdir -p temp/duckdb_modes
     rm -f temp/duckdb_modes/append.duckdb
-    SLING_ROW_CNT= sling build tests/build/column_store_modes_project --target DUCK_MODES --full-refresh -s "+events_append"
-    sling build tests/build/column_store_modes_project --target DUCK_MODES -s "+events_append"
+    SLING_ROW_CNT= sling build run tests/build/column_store_modes_project --target DUCK_MODES --full-refresh -s "+events_append"
+    sling build run tests/build/column_store_modes_project --target DUCK_MODES -s "+events_append"
   rows: 4
   output_contains:
     - 'OK'
@@ -586,8 +586,8 @@
     SLING_ROW_CNT= sling conns exec CLICKHOUSE "CREATE DATABASE IF NOT EXISTS staging"
     SLING_ROW_CNT= sling conns exec CLICKHOUSE "DROP TABLE IF EXISTS staging.stg_events"
     SLING_ROW_CNT= sling conns exec CLICKHOUSE "DROP TABLE IF EXISTS staging.events_inc"
-    SLING_ROW_CNT= sling build tests/build/column_store_modes_project --target CLICKHOUSE --full-refresh -s "+events_inc"
-    sling build tests/build/column_store_modes_project --target CLICKHOUSE --vars 'extra: true' -s "+events_inc"
+    SLING_ROW_CNT= sling build run tests/build/column_store_modes_project --target CLICKHOUSE --full-refresh -s "+events_inc"
+    sling build run tests/build/column_store_modes_project --target CLICKHOUSE --vars 'extra: true' -s "+events_inc"
   rows: 4
   output_contains:
     - 'OK'
@@ -601,11 +601,148 @@
     SLING_ROW_CNT= sling conns exec CLICKHOUSE "CREATE DATABASE IF NOT EXISTS staging"
     SLING_ROW_CNT= sling conns exec CLICKHOUSE "DROP TABLE IF EXISTS staging.stg_events"
     SLING_ROW_CNT= sling conns exec CLICKHOUSE "DROP TABLE IF EXISTS staging.events_append"
-    SLING_ROW_CNT= sling build tests/build/column_store_modes_project --target CLICKHOUSE --full-refresh -s "+events_append"
-    sling build tests/build/column_store_modes_project --target CLICKHOUSE -s "+events_append"
+    SLING_ROW_CNT= sling build run tests/build/column_store_modes_project --target CLICKHOUSE --full-refresh -s "+events_append"
+    sling build run tests/build/column_store_modes_project --target CLICKHOUSE -s "+events_append"
   rows: 4
   output_contains:
     - 'OK'
     - 'Build Completed'
 
+- id: 445
+  name: 'sling build run with no config and no target shows help'
+  run: 'sling build run /tmp'
+  output_contains:
+    - 'Materialize models'
+    - '--target'
+    - '--recursive'
 
+- id: 446
+  name: 'sling build list sample_project prints names'
+  run: 'sling build list tests/build/sample_project --target POSTGRES'
+  output_contains:
+    - 'stg_orders'
+    - 'stg_customers'
+    - 'dim_customers'
+
+- id: 447
+  name: 'sling build list --json sample_project'
+  run: 'sling build list tests/build/sample_project --target POSTGRES --json'
+  output_contains:
+    - '"name":"stg_orders"'
+    - '"name":"dim_customers"'
+
+- id: 448
+  name: 'sling build test sample_project'
+  run: 'sling build test tests/build/sample_project --target POSTGRES'
+  group: build
+  output_contains:
+    - 'Build Completed'
+
+- id: 449
+  name: 'sling build unknown verb exits non-zero'
+  run: 'sling build foo'
+  err: true
+  output_contains:
+    - 'unknown build command'
+
+- id: 450
+  name: 'sling build compile --help'
+  run: 'sling build compile --help'
+  output_contains:
+    - 'Render SQL'
+    - '--json'
+    - '--select'
+  output_does_not_contain:
+    - '--full-refresh'
+    - '--range'
+
+- id: 451
+  name: 'sling build list --help'
+  run: 'sling build list --help'
+  output_contains:
+    - 'List selected models'
+    - '--json'
+  output_does_not_contain:
+    - '--full-refresh'
+    - '--range'
+
+- id: 452
+  name: 'sling build test --help'
+  run: 'sling build test --help'
+  output_contains:
+    - 'declarative data tests'
+    - '--json'
+    - '--threads'
+  output_does_not_contain:
+    - '--full-refresh'
+    - '--range'
+
+- id: 453
+  name: 'sling build list without --target uses yml target'
+  run: 'sling build list tests/build/sample_project'
+  output_contains:
+    - 'stg_orders'
+    - 'staging.stg_orders'
+    - 'dim_customers'
+    - 'marts.dim_customers'
+
+- id: 454
+  name: 'pipeline type:build command compile and list'
+  run: 'sling run -d -p tests/pipelines/p.47.build_step_command.yaml'
+  output_contains:
+    - 'SUCCESS: pipeline build command compile+list ok'
+
+- id: 455
+  name: 'pipeline type:build command test rejects full_refresh'
+  run: 'sling run -p tests/pipelines/p.48.build_step_bad_command.yaml'
+  err: true
+  output_contains:
+    - 'full_refresh'
+    - 'command: run'
+
+- id: 456
+  name: 'sling build list duplicate stems errors'
+  run: 'sling build list tests/build/duplicate_stems_project'
+  err: true
+  output_contains:
+    - "duplicate model name 'events'"
+    - 'a/events.sql'
+    - 'b/events.sql'
+
+- id: 457
+  name: 'sling build compile old prefixed selector not found'
+  run: 'sling build compile tests/build/sample_project --target POSTGRES -s core_dim_customers'
+  err: true
+  output_contains:
+    - "selector 'core_dim_customers' not found"
+
+- id: 458
+  name: 'sling build compile database_project prod uses three-part names'
+  run: 'sling build compile tests/build/database_project --target SNOWFLAKE --prod'
+  output_contains:
+    - 'ANALYTICS_DB.marts.dim_customers'
+    - 'FIN_DB.marts.revenue'
+
+- id: 459
+  name: 'sling build compile database_project dev uses dev database and schema'
+  run: 'sling build compile tests/build/database_project --target SNOWFLAKE'
+  output_contains:
+    - 'SCRATCH_DB.dev_test.dim_customers'
+    - 'FIN_DB.dev_test.revenue'
+
+- id: 460
+  name: 'sling build compile database_project on postgres rejects three-part names'
+  run: 'sling build compile tests/build/database_project --target POSTGRES --prod'
+  err: true
+  output_contains:
+    - 'does not support database.schema.table'
+
+- id: 461
+  name: 'sling build run with subfolder path glob'
+  run: 'sling build run tests/build/sample_project --target POSTGRES -s "marts/core/*"'
+  group: build
+  output_contains:
+    - 'dim_customers'
+    - 'fct_orders'
+  output_does_not_contain:
+    - 'revenue'

--- a/tests/suite.cli.build.yaml
+++ b/tests/suite.cli.build.yaml
@@ -299,7 +299,7 @@
   run: 'sling build tests/build/range_bad_dbt_with_range --compile --target POSTGRES'
   err: true
   output_contains:
-    - 'range.* requires {incremental_where_cond}'
+    - 'range.* requires incremental_where_cond()'
 
 
 - id: 423
@@ -308,7 +308,7 @@
   run: 'sling build tests/build/range_bad_mixed_style --compile --target POSTGRES'
   err: true
   output_contains:
-    - 'cannot mix is_incremental() and {incremental_where_cond}'
+    - 'cannot mix is_incremental() and incremental_where_cond()'
 
 # expanded BuildDefaults — layered schema, additive tags/hooks,
 # enabled:false skip, defaults unique_key/update_key/merge_strategy.


### PR DESCRIPTION
### New Features

- **Build pipeline / hook `command:` and `env:`**: `build:` steps support `command: run|test|compile|list` (with `test: true` as an alias) and an `env:` overlay applied for the step.

- **Build execution status sync**: Platform status reporting for build runs and per-model progress (`BuildStatus` / `BuildModelStatus`), including model log fetch via `ExecBuildModels`.

- **UUID column typing**: `column_typing.uuid.as_text` maps UUID columns to `varchar(36)` instead of unbounded text.

- **Databricks `merge_update`**: Uses `MERGE INTO ... WHEN MATCHED THEN UPDATE` instead of `UPDATE ... FROM`.

- **Assist report composition**: Compose redacted issue reports from collected parts without a local log snapshot; guard contact-form URL size under Cloudflare limits.

- **MCP compact dataset output**: Shared pipe-delimited compact helpers for discover / query / file-list assistant payloads.

- **`sling build` subcommands**: Split into `run`, `compile`, and `list` (replacing flag-based `--compile` / `--list`). Adds `--path` and `--recursive` for discovering `sling_build.yml` in subdirectories.

### Bug Fixes

- **MSSQL `uniqueidentifier` transforms**: Auto `parse_ms_uuid` no longer drops or corrupts user-defined staged transforms.

- **DuckDB process death**: Clearer mid-query death errors (including OOM-killer hint) and reconnect after the process exits.

- **Unsupported API auth types**: Return an explicit error for unknown authentication types instead of failing unclearly.

- **Incremental where parentheses**: `incremental_where_cond` syntax wraps conditions in parentheses.

- **Parallel build logs**: Per-model log buffers so parallel worker output is attributed to the correct model.

- **Replication state locking**: `NewReplicationState` owns the mutex so concurrent stream state updates are safe.
